### PR TITLE
Fix keys command

### DIFF
--- a/redis/src/main/scala/zio/redis/Interpreter.scala
+++ b/redis/src/main/scala/zio/redis/Interpreter.scala
@@ -16,6 +16,9 @@ trait Interpreter {
   type RedisExecutor = Has[RedisExecutor.Service]
 
   object RedisExecutor {
+
+    val ResponseBufferSize = 1024
+
     trait Service {
       def execute(command: Chunk[String]): IO[RedisError, String]
     }
@@ -45,7 +48,7 @@ trait Interpreter {
           channel         <- Managed.fromAutoCloseable(makeChannel)
           pendingRequests <- Queue.unbounded[Request].toManaged_
           readinessFlag    = new AtomicBoolean(true)
-          response         = ByteBuffer.allocate(1024)
+          response         = ByteBuffer.allocate(ResponseBufferSize)
         } yield new Connection(channel, pendingRequests, readinessFlag, response)
 
       connection.refineToOrDie[IOException]

--- a/redis/src/main/scala/zio/redis/Interpreter.scala
+++ b/redis/src/main/scala/zio/redis/Interpreter.scala
@@ -87,7 +87,7 @@ trait Interpreter {
         var responseSize = 0
 
         // TODO: handle -1
-        while (readBytes == 0) {
+        while (readBytes == 0 || readBytes == ResponseBufferSize) {
           channel.read(response)
           response.flip()
 

--- a/redis/src/test/scala/zio/redis/ApiSpec.scala
+++ b/redis/src/test/scala/zio/redis/ApiSpec.scala
@@ -99,7 +99,7 @@ object ApiSpec extends BaseSpec {
             allKeys   <- keys("*")
             randomKey <- randomKey()
           } yield assert(allKeys)(contains(randomKey.get))
-        } @@ ignore,
+        },
         testM("dump followed by restore") {
           for {
             key      <- uuid


### PR DESCRIPTION
This is a fix for:
https://github.com/zio/zio-redis/issues/79

The symptom of the issue was index out of bounds when reading responses from Redis.

```
java.lang.StringIndexOutOfBoundsException: String index out of range: 8
```

The test was failing randomly due to random "cut-off" when the data was read back from the Redis and was misinterpreted because of being incomplete. 

We need to continue reading the data once a full buffer was read.