### PR TITLE
Test sets API

### DIFF
--- a/redis/src/main/scala/zio/redis/api/Sets.scala
+++ b/redis/src/main/scala/zio/redis/api/Sets.scala
@@ -24,7 +24,7 @@ trait Sets {
 
   final val sScan = RedisCommand(
     "SSCAN",
-    Tuple4(LongInput, OptionalInput(RegexInput), OptionalInput(LongInput), OptionalInput(StringInput)),
+    Tuple4(StringInput, LongInput, OptionalInput(RegexInput), OptionalInput(LongInput)),
     ScanOutput
   )
 

--- a/redis/src/main/scala/zio/redis/api/Sets.scala
+++ b/redis/src/main/scala/zio/redis/api/Sets.scala
@@ -17,8 +17,8 @@ trait Sets {
   final val sPop        =
     RedisCommand("SPOP", Tuple2(StringInput, OptionalInput(LongInput)), MultiStringChunkOutput)
 
-  // TODO: can have 2 different outputs depending on whether or not count is provided
-  final val sRandMember = RedisCommand("SRANDMEMBER", Tuple2(StringInput, OptionalInput(LongInput)), MultiStringChunkOutput)
+  final val sRandMember =
+    RedisCommand("SRANDMEMBER", Tuple2(StringInput, OptionalInput(LongInput)), MultiStringChunkOutput)
 
   final val sRem = RedisCommand("SREM", Tuple2(StringInput, NonEmptyList(StringInput)), LongOutput)
 

--- a/redis/src/main/scala/zio/redis/api/Sets.scala
+++ b/redis/src/main/scala/zio/redis/api/Sets.scala
@@ -15,10 +15,10 @@ trait Sets {
   final val sMembers    = RedisCommand("SMEMBERS", StringInput, ChunkOutput)
   final val sMove       = RedisCommand("SMOVE", Tuple3(StringInput, StringInput, StringInput), BoolOutput)
   final val sPop        =
-    RedisCommand("SPOP", Tuple2(StringInput, OptionalInput(LongInput)), OptionalOutput(MultiStringOutput))
+    RedisCommand("SPOP", Tuple2(StringInput, OptionalInput(LongInput)), MultiStringChunkOutput)
 
   // TODO: can have 2 different outputs depending on whether or not count is provided
-  final val sRandMember = RedisCommand("SRANDMEMBER", Tuple2(StringInput, OptionalInput(LongInput)), ChunkOutput)
+  final val sRandMember = RedisCommand("SRANDMEMBER", Tuple2(StringInput, OptionalInput(LongInput)), MultiStringChunkOutput)
 
   final val sRem = RedisCommand("SREM", Tuple2(StringInput, NonEmptyList(StringInput)), LongOutput)
 

--- a/redis/src/main/scala/zio/redis/api/Sets.scala
+++ b/redis/src/main/scala/zio/redis/api/Sets.scala
@@ -24,7 +24,7 @@ trait Sets {
 
   final val sScan = RedisCommand(
     "SSCAN",
-    Tuple4(StringInput, LongInput, OptionalInput(RegexInput), OptionalInput(LongInput)),
+    Tuple4(StringInput, LongInput, OptionalInput(RegexInput), OptionalInput(CountInput)),
     ScanOutput
   )
 

--- a/redis/src/test/scala/zio/redis/ApiSpec.scala
+++ b/redis/src/test/scala/zio/redis/ApiSpec.scala
@@ -3,12 +3,13 @@ package zio.redis
 import zio.test._
 import zio.clock.Clock
 
-object ApiSpec extends KeysSpec with ListSpec with GeoSpec with HyperLogLogSpec {
+object ApiSpec extends KeysSpec with ListSpec with SetsSpec with GeoSpec with HyperLogLogSpec {
 
   def spec =
     suite("Redis commands")(
       keysSuite,
       listSuite,
+      setsSuite,
       geoSuite,
       hyperLogLogSuite
     ).provideCustomLayerShared(Executor ++ Clock.live)

--- a/redis/src/test/scala/zio/redis/KeysSpec.scala
+++ b/redis/src/test/scala/zio/redis/KeysSpec.scala
@@ -146,10 +146,10 @@ trait KeysSpec extends BaseSpec {
             _         <- set(key, value, None, None, None)
             exp       <- pExpire(key, 2000.millis)
             response1 <- exists(key, Nil)
-            _         <- ZIO.sleep(2010.millis)
+            _         <- ZIO.sleep(2050.millis)
             response2 <- exists(key, Nil)
           } yield assert(exp)(isTrue) && assert(response1)(isTrue) && assert(response2)(isFalse)
-        },
+        } @@ eventually,
         testM("set key expiration with pExpireAt command") {
           for {
             key       <- uuid
@@ -158,10 +158,10 @@ trait KeysSpec extends BaseSpec {
             _         <- set(key, value, None, None, None)
             exp       <- pExpireAt(key, expiresAt)
             response1 <- exists(key, Nil)
-            _         <- ZIO.sleep(2010.millis)
+            _         <- ZIO.sleep(2050.millis)
             response2 <- exists(key, Nil)
           } yield assert(exp)(isTrue) && assert(response1)(isTrue) && assert(response2)(isFalse)
-        },
+        } @@ eventually,
         testM("expire followed by persist") {
           for {
             key       <- uuid
@@ -179,7 +179,7 @@ trait KeysSpec extends BaseSpec {
             _         <- set(key, value, None, None, None)
             exp       <- expireAt(key, expiresAt)
             response1 <- exists(key, Nil)
-            _         <- ZIO.sleep(2010.millis)
+            _         <- ZIO.sleep(2050.millis)
             response2 <- exists(key, Nil)
           } yield assert(exp)(isTrue) && assert(response1)(isTrue) && assert(response2)(isFalse)
         } @@ eventually

--- a/redis/src/test/scala/zio/redis/SetsSpec.scala
+++ b/redis/src/test/scala/zio/redis/SetsSpec.scala
@@ -383,6 +383,29 @@ trait SetsSpec extends BaseSpec {
             isMember <- sIsMember(key, "a").either
           } yield assert(isMember)(isLeft(isSubtype[WrongType](anything)))
         }
+      ),
+      suite("members")(
+        testM("sMembers non-empty set") {
+          for {
+            key <- uuid
+            _ <- sAdd(key)("a", "b", "c")
+            members <- sMembers(key)
+          } yield assert(members)(hasSameElements(Chunk("a", "b", "c")))
+        },
+        testM("sMembers empty set") {
+          for {
+            key <- uuid
+            members <- sMembers(key)
+          } yield assert(members)(isEmpty)
+        },
+        testM("sMembers when not set") {
+          for {
+            key <- uuid
+            value <- uuid
+            _ <- set(key, value, None, None, None)
+            members <- sMembers(key).either
+          } yield assert(members)(isLeft(isSubtype[WrongType](anything)))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/SetsSpec.scala
+++ b/redis/src/test/scala/zio/redis/SetsSpec.scala
@@ -8,8 +8,8 @@ import zio.test.Assertion._
 trait SetsSpec extends BaseSpec {
   val setsSuite =
     suite("sets")(
-      suite("add")(
-        testM("sAdd to the empty set") {
+      suite("sAdd")(
+        testM("to empty set") {
           for {
             key     <- uuid
             added   <- sAdd(key)("hello")
@@ -17,7 +17,7 @@ trait SetsSpec extends BaseSpec {
           } yield assert(added)(equalTo(1L)) &&
             assert(members)(hasSameElements(Chunk("hello")))
         },
-        testM("sAdd to the non-empty set") {
+        testM("to the non-empty set") {
           for {
             key     <- uuid
             _       <- sAdd(key)("hello")
@@ -26,7 +26,7 @@ trait SetsSpec extends BaseSpec {
           } yield assert(added)(equalTo(1L)) &&
             assert(members)(hasSameElements(Chunk("hello", "world")))
         },
-        testM("sAdd existing element to the set") {
+        testM("existing element to set") {
           for {
             key     <- uuid
             _       <- sAdd(key)("hello")
@@ -35,7 +35,7 @@ trait SetsSpec extends BaseSpec {
           } yield assert(added)(equalTo(0L)) &&
             assert(members)(hasSameElements(Chunk("hello")))
         },
-        testM("sAdd error when not set") {
+        testM("error when not set") {
           for {
             key   <- uuid
             value <- uuid
@@ -44,18 +44,18 @@ trait SetsSpec extends BaseSpec {
           } yield assert(added)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
-      suite("cardinality")(
-        testM("sCard non-empty set") {
+      suite("sCard")(
+        testM("non-empty set") {
           for {
             key  <- uuid
             _    <- sAdd(key)("hello")
             card <- sCard(key)
           } yield assert(card)(equalTo(1L))
         },
-        testM("sCard 0 when key doesn't exist") {
+        testM("0 when key doesn't exist") {
           assertM(sCard("unknown"))(equalTo(0L))
         },
-        testM("sCard error when not set") {
+        testM("error when not set") {
           for {
             key   <- uuid
             value <- uuid
@@ -64,8 +64,8 @@ trait SetsSpec extends BaseSpec {
           } yield assert(card)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
-      suite("difference")(
-        testM("sDiff two non-empty sets") {
+      suite("sDiff")(
+        testM("two non-empty sets") {
           for {
             first  <- uuid
             second <- uuid
@@ -74,7 +74,7 @@ trait SetsSpec extends BaseSpec {
             diff   <- sDiff(first, List(second))
           } yield assert(diff)(hasSameElements(Chunk("b", "d")))
         },
-        testM("sDiff non-empty set and empty set") {
+        testM("non-empty set and empty set") {
           for {
             first  <- uuid
             second <- uuid
@@ -82,7 +82,7 @@ trait SetsSpec extends BaseSpec {
             diff   <- sDiff(first, List(second))
           } yield assert(diff)(hasSameElements(Chunk("a", "b")))
         },
-        testM("sDiff empty set and non-empty set") {
+        testM("empty set and non-empty set") {
           for {
             first  <- uuid
             second <- uuid
@@ -90,14 +90,14 @@ trait SetsSpec extends BaseSpec {
             diff   <- sDiff(first, List(second))
           } yield assert(diff)(isEmpty)
         },
-        testM("sDiff empty when both sets are empty") {
+        testM("empty when both sets are empty") {
           for {
             first  <- uuid
             second <- uuid
             diff   <- sDiff(first, List(second))
           } yield assert(diff)(isEmpty)
         },
-        testM("sDiff non-empty set with multiple non-empty sets") {
+        testM("non-empty set with multiple non-empty sets") {
           for {
             first  <- uuid
             second <- uuid
@@ -108,7 +108,7 @@ trait SetsSpec extends BaseSpec {
             diff   <- sDiff(first, List(second, third))
           } yield assert(diff)(hasSameElements(Chunk("a")))
         },
-        testM("sDiff error when first parameter is not set") {
+        testM("error when first parameter is not set") {
           for {
             first  <- uuid
             second <- uuid
@@ -117,7 +117,7 @@ trait SetsSpec extends BaseSpec {
             diff   <- sDiff(first, List(second)).either
           } yield assert(diff)(isLeft(isSubtype[WrongType](anything)))
         },
-        testM("sDiff error when second parameter is not set") {
+        testM("error when second parameter is not set") {
           for {
             first  <- uuid
             second <- uuid
@@ -127,8 +127,8 @@ trait SetsSpec extends BaseSpec {
           } yield assert(diff)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
-      suite("store difference")(
-        testM("sDiffStore two non-empty sets") {
+      suite("sDiffStore")(
+        testM("two non-empty sets") {
           for {
             key    <- uuid
             first  <- uuid
@@ -140,7 +140,7 @@ trait SetsSpec extends BaseSpec {
           } yield assert(card)(equalTo(2L)) &&
             assert(diff)(hasSameElements(Chunk("b", "d")))
         },
-        testM("sDiffStore non-empty set and empty set") {
+        testM("non-empty set and empty set") {
           for {
             key    <- uuid
             first  <- uuid
@@ -151,7 +151,7 @@ trait SetsSpec extends BaseSpec {
           } yield assert(card)(equalTo(2L)) &&
             assert(diff)(hasSameElements(Chunk("a", "b")))
         },
-        testM("sDiffStore empty set and non-empty set") {
+        testM("empty set and non-empty set") {
           for {
             key    <- uuid
             first  <- uuid
@@ -162,7 +162,7 @@ trait SetsSpec extends BaseSpec {
           } yield assert(card)(equalTo(0L)) &&
             assert(diff)(isEmpty)
         },
-        testM("sDiffStore empty when both sets are empty") {
+        testM("empty when both sets are empty") {
           for {
             key    <- uuid
             first  <- uuid
@@ -172,7 +172,7 @@ trait SetsSpec extends BaseSpec {
           } yield assert(card)(equalTo(0L)) &&
             assert(diff)(isEmpty)
         },
-        testM("sDiffStore non-empty set with multiple non-empty sets") {
+        testM("non-empty set with multiple non-empty sets") {
           for {
             key    <- uuid
             first  <- uuid
@@ -186,7 +186,7 @@ trait SetsSpec extends BaseSpec {
           } yield assert(card)(equalTo(1L)) &&
             assert(diff)(hasSameElements(Chunk("a")))
         },
-        testM("sDiffStore error when first parameter is not set") {
+        testM("error when first parameter is not set") {
           for {
             key    <- uuid
             first  <- uuid
@@ -196,7 +196,7 @@ trait SetsSpec extends BaseSpec {
             card   <- sDiffStore(key)(first, second).either
           } yield assert(card)(isLeft(isSubtype[WrongType](anything)))
         },
-        testM("sDiffStore error when second parameter is not set") {
+        testM("error when second parameter is not set") {
           for {
             key    <- uuid
             first  <- uuid
@@ -207,8 +207,8 @@ trait SetsSpec extends BaseSpec {
           } yield assert(card)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
-      suite("intersection")(
-        testM("sInter two non-empty sets") {
+      suite("sInter")(
+        testM("two non-empty sets") {
           for {
             first  <- uuid
             second <- uuid
@@ -217,7 +217,7 @@ trait SetsSpec extends BaseSpec {
             inter  <- sInter(first, List(second))
           } yield assert(inter)(hasSameElements(Chunk("a", "c")))
         },
-        testM("sInter empty when one of the sets is empty") {
+        testM("empty when one of the sets is empty") {
           for {
             first  <- uuid
             second <- uuid
@@ -225,14 +225,14 @@ trait SetsSpec extends BaseSpec {
             inter  <- sInter(first, List(second))
           } yield assert(inter)(isEmpty)
         },
-        testM("sInter empty when both sets are empty") {
+        testM("empty when both sets are empty") {
           for {
             first  <- uuid
             second <- uuid
             inter  <- sInter(first, List(second))
           } yield assert(inter)(isEmpty)
         },
-        testM("sInter non-empty set with multiple non-empty sets") {
+        testM("non-empty set with multiple non-empty sets") {
           for {
             first  <- uuid
             second <- uuid
@@ -243,7 +243,7 @@ trait SetsSpec extends BaseSpec {
             inter  <- sInter(first, List(second, third))
           } yield assert(inter)(hasSameElements(Chunk("b")))
         },
-        testM("sInter error when first parameter is not set") {
+        testM("error when first parameter is not set") {
           for {
             first  <- uuid
             second <- uuid
@@ -252,7 +252,7 @@ trait SetsSpec extends BaseSpec {
             inter  <- sInter(first, List(second)).either
           } yield assert(inter)(isLeft(isSubtype[WrongType](anything)))
         },
-        testM("sInter empty with empty first set and second parameter is not set") {
+        testM("empty with empty first set and second parameter is not set") {
           for {
             first  <- uuid
             second <- uuid
@@ -261,7 +261,7 @@ trait SetsSpec extends BaseSpec {
             inter  <- sInter(first, List(second))
           } yield assert(inter)(isEmpty)
         },
-        testM("sInter error with non-empty first set and second parameter is not set") {
+        testM("error with non-empty first set and second parameter is not set") {
           for {
             first  <- uuid
             second <- uuid
@@ -272,8 +272,8 @@ trait SetsSpec extends BaseSpec {
           } yield assert(inter)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
-      suite("store intersection")(
-        testM("sInterStore two non-empty sets") {
+      suite("sInterStore")(
+        testM("two non-empty sets") {
           for {
             key    <- uuid
             first  <- uuid
@@ -285,7 +285,7 @@ trait SetsSpec extends BaseSpec {
           } yield assert(card)(equalTo(2L)) &&
             assert(inter)(hasSameElements(Chunk("a", "c")))
         },
-        testM("sInterStore empty when one of the sets is empty") {
+        testM("empty when one of the sets is empty") {
           for {
             key    <- uuid
             first  <- uuid
@@ -296,7 +296,7 @@ trait SetsSpec extends BaseSpec {
           } yield assert(card)(equalTo(0L)) &&
             assert(inter)(isEmpty)
         },
-        testM("sInterStore empty when both sets are empty") {
+        testM("empty when both sets are empty") {
           for {
             key    <- uuid
             first  <- uuid
@@ -306,7 +306,7 @@ trait SetsSpec extends BaseSpec {
           } yield assert(card)(equalTo(0L)) &&
             assert(inter)(isEmpty)
         },
-        testM("sInterStore non-empty set with multiple non-empty sets") {
+        testM("non-empty set with multiple non-empty sets") {
           for {
             key    <- uuid
             first  <- uuid
@@ -320,7 +320,7 @@ trait SetsSpec extends BaseSpec {
           } yield assert(card)(equalTo(1L)) &&
             assert(inter)(hasSameElements(Chunk("b")))
         },
-        testM("sInterStore error when first parameter is not set") {
+        testM("error when first parameter is not set") {
           for {
             key    <- uuid
             first  <- uuid
@@ -330,7 +330,7 @@ trait SetsSpec extends BaseSpec {
             card   <- sInterStore(key)(first, second).either
           } yield assert(card)(isLeft(isSubtype[WrongType](anything)))
         },
-        testM("sInterStore empty with empty first set and second parameter is not set") {
+        testM("empty with empty first set and second parameter is not set") {
           for {
             key    <- uuid
             first  <- uuid
@@ -342,7 +342,7 @@ trait SetsSpec extends BaseSpec {
           } yield assert(card)(equalTo(0L)) &&
             assert(inter)(isEmpty)
         },
-        testM("sInterStore error with non-empty first set and second parameter is not set") {
+        testM("error with non-empty first set and second parameter is not set") {
           for {
             key    <- uuid
             first  <- uuid
@@ -354,28 +354,28 @@ trait SetsSpec extends BaseSpec {
           } yield assert(card)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
-      suite("is member")(
-        testM("sIsMember actual element of the non-empty set") {
+      suite("sIsMember")(
+        testM("actual element of the non-empty set") {
           for {
             key      <- uuid
             _        <- sAdd(key)("a", "b", "c")
             isMember <- sIsMember(key, "b")
           } yield assert(isMember)(isTrue)
         },
-        testM("sIsMember element that is not present in the set") {
+        testM("element that is not present in the set") {
           for {
             key      <- uuid
             _        <- sAdd(key)("a", "b", "c")
             isMember <- sIsMember(key, "unknown")
           } yield assert(isMember)(isFalse)
         },
-        testM("sIsMember of an empty set") {
+        testM("of an empty set") {
           for {
             key      <- uuid
             isMember <- sIsMember(key, "a")
           } yield assert(isMember)(isFalse)
         },
-        testM("sIsMember when not set") {
+        testM("when not set") {
           for {
             key      <- uuid
             value    <- uuid
@@ -384,21 +384,21 @@ trait SetsSpec extends BaseSpec {
           } yield assert(isMember)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
-      suite("members")(
-        testM("sMembers non-empty set") {
+      suite("sMembers")(
+        testM("non-empty set") {
           for {
             key     <- uuid
             _       <- sAdd(key)("a", "b", "c")
             members <- sMembers(key)
           } yield assert(members)(hasSameElements(Chunk("a", "b", "c")))
         },
-        testM("sMembers empty set") {
+        testM("empty set") {
           for {
             key     <- uuid
             members <- sMembers(key)
           } yield assert(members)(isEmpty)
         },
-        testM("sMembers when not set") {
+        testM("when not set") {
           for {
             key     <- uuid
             value   <- uuid
@@ -407,8 +407,8 @@ trait SetsSpec extends BaseSpec {
           } yield assert(members)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
-      suite("move")(
-        testM("sMove from non-empty source to non-empty destination") {
+      suite("sMove")(
+        testM("from non-empty source to non-empty destination") {
           for {
             src         <- uuid
             dest        <- uuid
@@ -421,7 +421,7 @@ trait SetsSpec extends BaseSpec {
             assert(srcMembers)(hasSameElements(Chunk("b", "c"))) &&
             assert(destMembers)(hasSameElements(Chunk("a", "d", "e", "f")))
         },
-        testM("sMove from non-empty source to empty destination") {
+        testM("from non-empty source to empty destination") {
           for {
             src         <- uuid
             dest        <- uuid
@@ -433,7 +433,7 @@ trait SetsSpec extends BaseSpec {
             assert(srcMembers)(hasSameElements(Chunk("b", "c"))) &&
             assert(destMembers)(hasSameElements(Chunk("a")))
         },
-        testM("sMove element already present in the destination") {
+        testM("element already present in the destination") {
           for {
             src         <- uuid
             dest        <- uuid
@@ -446,7 +446,7 @@ trait SetsSpec extends BaseSpec {
             assert(srcMembers)(hasSameElements(Chunk("b", "c"))) &&
             assert(destMembers)(hasSameElements(Chunk("a", "d", "e")))
         },
-        testM("sMove from empty source to non-empty destination") {
+        testM("from empty source to non-empty destination") {
           for {
             src         <- uuid
             dest        <- uuid
@@ -458,7 +458,7 @@ trait SetsSpec extends BaseSpec {
             assert(srcMembers)(isEmpty) &&
             assert(destMembers)(hasSameElements(Chunk("b", "c")))
         },
-        testM("sMove non-existent element") {
+        testM("non-existent element") {
           for {
             src         <- uuid
             dest        <- uuid
@@ -471,7 +471,7 @@ trait SetsSpec extends BaseSpec {
             assert(srcMembers)(hasSameElements(Chunk("a", "b"))) &&
             assert(destMembers)(hasSameElements(Chunk("c", "d")))
         },
-        testM("sMove from empty source to not set destination") {
+        testM("from empty source to not set destination") {
           for {
             src   <- uuid
             dest  <- uuid
@@ -480,7 +480,7 @@ trait SetsSpec extends BaseSpec {
             moved <- sMove(src, dest, "unknown")
           } yield assert(moved)(isFalse)
         },
-        testM("sMove error when non-empty source and not set destination") {
+        testM("error when non-empty source and not set destination") {
           for {
             src   <- uuid
             dest  <- uuid
@@ -490,7 +490,7 @@ trait SetsSpec extends BaseSpec {
             moved <- sMove(src, dest, "a").either
           } yield assert(moved)(isLeft(isSubtype[WrongType](anything)))
         },
-        testM("sMove error when not set source to non-empty destination") {
+        testM("error when not set source to non-empty destination") {
           for {
             src   <- uuid
             dest  <- uuid
@@ -501,8 +501,8 @@ trait SetsSpec extends BaseSpec {
           } yield assert(moved)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
-      suite("pop")(
-        testM("sPop one element from non-empty set") {
+      suite("sPop")(
+        testM("one element from non-empty set") {
           for {
             key     <- uuid
             _       <- sAdd(key)("a", "b", "c")
@@ -511,13 +511,13 @@ trait SetsSpec extends BaseSpec {
           } yield assert(poped)(isSome) &&
             assert(members)(hasSize(equalTo(2)))
         },
-        testM("sPop one element from an empty set") {
+        testM("one element from an empty set") {
           for {
             key   <- uuid
             poped <- sPop(key, None)
           } yield assert(poped)(isNone)
         },
-        testM("sPop error when poping one element from not set") {
+        testM("error when poping one element from not set") {
           for {
             key   <- uuid
             value <- uuid
@@ -525,7 +525,7 @@ trait SetsSpec extends BaseSpec {
             poped <- sPop(key, None).either
           } yield assert(poped)(isLeft(isSubtype[WrongType](anything)))
         },
-        testM("sPop multiple elements from non-empty set") {
+        testM("multiple elements from non-empty set") {
           for {
             key     <- uuid
             _       <- sAdd(key)("a", "b", "c")
@@ -534,7 +534,7 @@ trait SetsSpec extends BaseSpec {
           } yield assert(poped)(isRight(isSome)) &&
             assert(members)(hasSize(equalTo(1)))
         },
-        testM("sPop more elements then there is in non-empty set") {
+        testM("more elements then there is in non-empty set") {
           for {
             key     <- uuid
             _       <- sAdd(key)("a", "b", "c")
@@ -543,7 +543,7 @@ trait SetsSpec extends BaseSpec {
           } yield assert(poped)(isRight(isSome)) &&
             assert(members)(isEmpty)
         },
-        testM("sPop multiple elements from empty set") {
+        testM("multiple elements from empty set") {
           for {
             key     <- uuid
             poped   <- sPop(key, Some(3)).either
@@ -551,7 +551,7 @@ trait SetsSpec extends BaseSpec {
           } yield assert(poped)(isRight(isNone)) &&
             assert(members)(isEmpty)
         },
-        testM("sPop error when poping multiple elements from not set") {
+        testM("error when poping multiple elements from not set") {
           for {
             key   <- uuid
             value <- uuid
@@ -560,21 +560,21 @@ trait SetsSpec extends BaseSpec {
           } yield assert(poped)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
-      suite("random member")(
-        testM("sRandMember one element from non-empty set") {
+      suite("sRandMember")(
+        testM("one element from non-empty set") {
           for {
             key    <- uuid
             _      <- sAdd(key)("a", "b", "c")
             member <- sRandMember(key, None).either
           } yield assert(member)(isRight(hasSize(equalTo(1))))
         },
-        testM("sRandMember one element from an empty set") {
+        testM("one element from an empty set") {
           for {
             key    <- uuid
             member <- sRandMember(key, None).either
           } yield assert(member)(isRight(isEmpty))
         },
-        testM("sRandMember one element from not set") {
+        testM("one element from not set") {
           for {
             key    <- uuid
             value  <- uuid
@@ -582,40 +582,40 @@ trait SetsSpec extends BaseSpec {
             member <- sRandMember(key, None).either
           } yield assert(member)(isLeft(isSubtype[WrongType](anything)))
         },
-        testM("sRandMember multiple elements from non-empty set") {
+        testM("multiple elements from non-empty set") {
           for {
             key     <- uuid
             _       <- sAdd(key)("a", "b", "c")
             members <- sRandMember(key, Some(2L))
           } yield assert(members)(hasSize(equalTo(2)))
         },
-        testM("sRandMember more elements than there is present in the non-empty set") {
+        testM("more elements than there is present in the non-empty set") {
           for {
             key     <- uuid
             _       <- sAdd(key)("a", "b", "c")
             members <- sRandMember(key, Some(5L))
           } yield assert(members)(hasSize(equalTo(3)))
         },
-        testM("sRandMember multiple elements from an empty set") {
+        testM("multiple elements from an empty set") {
           for {
             key     <- uuid
             members <- sRandMember(key, Some(3L))
           } yield assert(members)(isEmpty)
         },
-        testM("sRandMember repeated elements from non-empty set") {
+        testM("repeated elements from non-empty set") {
           for {
             key     <- uuid
             _       <- sAdd(key)("a", "b", "c")
             members <- sRandMember(key, Some(-5L))
           } yield assert(members)(hasSize(equalTo(5)))
         },
-        testM("sRandMember repeated elements from an empty set") {
+        testM("repeated elements from an empty set") {
           for {
             key     <- uuid
             members <- sRandMember(key, Some(-3L))
           } yield assert(members)(isEmpty)
         },
-        testM("sRandMember error multiple elements from not set") {
+        testM("error multiple elements from not set") {
           for {
             key     <- uuid
             value   <- uuid
@@ -624,8 +624,8 @@ trait SetsSpec extends BaseSpec {
           } yield assert(members)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
-      suite("remove")(
-        testM("sRem existing elements from non-empty set") {
+      suite("sRem")(
+        testM("existing elements from non-empty set") {
           for {
             key     <- uuid
             _       <- sAdd(key)("a", "b", "c")
@@ -634,7 +634,7 @@ trait SetsSpec extends BaseSpec {
           } yield assert(removed)(equalTo(2L)) &&
             assert(members)(hasSameElements(Chunk("a")))
         },
-        testM("sRem when just part of elements are present in the non-empty set") {
+        testM("when just part of elements are present in the non-empty set") {
           for {
             key     <- uuid
             _       <- sAdd(key)("a", "b", "c")
@@ -643,7 +643,7 @@ trait SetsSpec extends BaseSpec {
           } yield assert(removed)(equalTo(1L)) &&
             assert(members)(hasSameElements(Chunk("a", "c")))
         },
-        testM("sRem when none of the elements are present in the non-empty set") {
+        testM("when none of the elements are present in the non-empty set") {
           for {
             key     <- uuid
             _       <- sAdd(key)("a", "b", "c")
@@ -652,13 +652,13 @@ trait SetsSpec extends BaseSpec {
           } yield assert(removed)(equalTo(0L)) &&
             assert(members)(hasSameElements(Chunk("a", "b", "c")))
         },
-        testM("sRem elements from an empty set") {
+        testM("elements from an empty set") {
           for {
             key     <- uuid
             removed <- sRem(key)("a", "b")
           } yield assert(removed)(equalTo(0L))
         },
-        testM("sRem elements from not set") {
+        testM("elements from not set") {
           for {
             key     <- uuid
             value   <- uuid
@@ -667,8 +667,8 @@ trait SetsSpec extends BaseSpec {
           } yield assert(removed)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
-      suite("union")(
-        testM("sUnion two non-empty sets") {
+      suite("sUnion")(
+        testM("two non-empty sets") {
           for {
             first  <- uuid
             second <- uuid
@@ -677,7 +677,7 @@ trait SetsSpec extends BaseSpec {
             union  <- sUnion(first, List(second))
           } yield assert(union)(hasSameElements(Chunk("a", "b", "c", "d", "e")))
         },
-        testM("sUnion equal to the non-empty set when the other one is empty") {
+        testM("equal to the non-empty set when the other one is empty") {
           for {
             first  <- uuid
             second <- uuid
@@ -685,14 +685,14 @@ trait SetsSpec extends BaseSpec {
             union  <- sUnion(first, List(second))
           } yield assert(union)(hasSameElements(Chunk("a", "b")))
         },
-        testM("sUnion empty when both sets are empty") {
+        testM("empty when both sets are empty") {
           for {
             first  <- uuid
             second <- uuid
             union  <- sUnion(first, List(second))
           } yield assert(union)(isEmpty)
         },
-        testM("sUnion non-empty set with multiple non-empty sets") {
+        testM("non-empty set with multiple non-empty sets") {
           for {
             first  <- uuid
             second <- uuid
@@ -703,7 +703,7 @@ trait SetsSpec extends BaseSpec {
             union  <- sUnion(first, List(second, third))
           } yield assert(union)(hasSameElements(Chunk("a", "b", "c", "d", "e")))
         },
-        testM("sUnion error when first parameter is not set") {
+        testM("error when first parameter is not set") {
           for {
             first  <- uuid
             second <- uuid
@@ -712,7 +712,7 @@ trait SetsSpec extends BaseSpec {
             union  <- sUnion(first, List(second)).either
           } yield assert(union)(isLeft(isSubtype[WrongType](anything)))
         },
-        testM("sUnion error when the first parameter is set and the second parameter is not set") {
+        testM("error when the first parameter is set and the second parameter is not set") {
           for {
             first  <- uuid
             second <- uuid
@@ -723,8 +723,8 @@ trait SetsSpec extends BaseSpec {
           } yield assert(union)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
-      suite("store union")(
-        testM("sUnionStore two non-empty sets") {
+      suite("sUnionStore")(
+        testM("two non-empty sets") {
           for {
             first  <- uuid
             second <- uuid
@@ -736,7 +736,7 @@ trait SetsSpec extends BaseSpec {
           } yield assert(card)(equalTo(5L)) &&
             assert(union)(hasSameElements(Chunk("a", "b", "c", "d", "e")))
         },
-        testM("sUnionStore equal to the non-empty set when the other one is empty") {
+        testM("equal to the non-empty set when the other one is empty") {
           for {
             first  <- uuid
             second <- uuid
@@ -747,7 +747,7 @@ trait SetsSpec extends BaseSpec {
           } yield assert(card)(equalTo(2L)) &&
             assert(union)(hasSameElements(Chunk("a", "b")))
         },
-        testM("sUnionStore empty when both sets are empty") {
+        testM("empty when both sets are empty") {
           for {
             first  <- uuid
             second <- uuid
@@ -757,7 +757,7 @@ trait SetsSpec extends BaseSpec {
           } yield assert(card)(equalTo(0L)) &&
             assert(union)(isEmpty)
         },
-        testM("sUnionStore non-empty set with multiple non-empty sets") {
+        testM("non-empty set with multiple non-empty sets") {
           for {
             first  <- uuid
             second <- uuid
@@ -771,7 +771,7 @@ trait SetsSpec extends BaseSpec {
           } yield assert(card)(equalTo(5L)) &&
             assert(union)(hasSameElements(Chunk("a", "b", "c", "d", "e")))
         },
-        testM("sUnionStore error when the first parameter is not set") {
+        testM("error when the first parameter is not set") {
           for {
             first  <- uuid
             second <- uuid
@@ -781,7 +781,7 @@ trait SetsSpec extends BaseSpec {
             card   <- sUnionStore(dest)(first, second).either
           } yield assert(card)(isLeft(isSubtype[WrongType](anything)))
         },
-        testM("sUnionStore error when the first parameter is set and the second parameter is not set") {
+        testM("error when the first parameter is set and the second parameter is not set") {
           for {
             first  <- uuid
             second <- uuid

--- a/redis/src/test/scala/zio/redis/SetsSpec.scala
+++ b/redis/src/test/scala/zio/redis/SetsSpec.scala
@@ -13,27 +13,21 @@ trait SetsSpec extends BaseSpec {
           for {
             key     <- uuid
             added   <- sAdd(key)("hello")
-            members <- sMembers(key)
-          } yield assert(added)(equalTo(1L)) &&
-            assert(members)(hasSameElements(Chunk("hello")))
+          } yield assert(added)(equalTo(1L))
         },
         testM("to the non-empty set") {
           for {
             key     <- uuid
             _       <- sAdd(key)("hello")
             added   <- sAdd(key)("world")
-            members <- sMembers(key)
-          } yield assert(added)(equalTo(1L)) &&
-            assert(members)(hasSameElements(Chunk("hello", "world")))
+          } yield assert(added)(equalTo(1L))
         },
         testM("existing element to set") {
           for {
             key     <- uuid
             _       <- sAdd(key)("hello")
             added   <- sAdd(key)("hello")
-            members <- sMembers(key)
-          } yield assert(added)(equalTo(0L)) &&
-            assert(members)(hasSameElements(Chunk("hello")))
+          } yield assert(added)(equalTo(0L))
         },
         testM("error when not set") {
           for {
@@ -136,9 +130,7 @@ trait SetsSpec extends BaseSpec {
             _      <- sAdd(first)("a", "b", "c", "d")
             _      <- sAdd(second)("a", "c")
             card   <- sDiffStore(key)(first, second)
-            diff   <- sMembers(key)
-          } yield assert(card)(equalTo(2L)) &&
-            assert(diff)(hasSameElements(Chunk("b", "d")))
+          } yield assert(card)(equalTo(2L))
         },
         testM("non-empty set and empty set") {
           for {
@@ -147,9 +139,7 @@ trait SetsSpec extends BaseSpec {
             second <- uuid
             _      <- sAdd(first)("a", "b")
             card   <- sDiffStore(key)(first, second)
-            diff   <- sMembers(key)
-          } yield assert(card)(equalTo(2L)) &&
-            assert(diff)(hasSameElements(Chunk("a", "b")))
+          } yield assert(card)(equalTo(2L))
         },
         testM("empty set and non-empty set") {
           for {
@@ -158,9 +148,7 @@ trait SetsSpec extends BaseSpec {
             second <- uuid
             _      <- sAdd(second)("a", "b")
             card   <- sDiffStore(key)(first, second)
-            diff   <- sMembers(key)
-          } yield assert(card)(equalTo(0L)) &&
-            assert(diff)(isEmpty)
+          } yield assert(card)(equalTo(0L))
         },
         testM("empty when both sets are empty") {
           for {
@@ -168,9 +156,7 @@ trait SetsSpec extends BaseSpec {
             first  <- uuid
             second <- uuid
             card   <- sDiffStore(key)(first, second)
-            diff   <- sMembers(key)
-          } yield assert(card)(equalTo(0L)) &&
-            assert(diff)(isEmpty)
+          } yield assert(card)(equalTo(0L))
         },
         testM("non-empty set with multiple non-empty sets") {
           for {
@@ -182,9 +168,7 @@ trait SetsSpec extends BaseSpec {
             _      <- sAdd(second)("b", "d")
             _      <- sAdd(third)("b", "c")
             card   <- sDiffStore(key)(first, second, third)
-            diff   <- sMembers(key)
-          } yield assert(card)(equalTo(1L)) &&
-            assert(diff)(hasSameElements(Chunk("a")))
+          } yield assert(card)(equalTo(1L))
         },
         testM("error when first parameter is not set") {
           for {
@@ -281,9 +265,7 @@ trait SetsSpec extends BaseSpec {
             _      <- sAdd(first)("a", "b", "c", "d")
             _      <- sAdd(second)("a", "c", "e")
             card   <- sInterStore(key)(first, second)
-            inter  <- sMembers(key)
-          } yield assert(card)(equalTo(2L)) &&
-            assert(inter)(hasSameElements(Chunk("a", "c")))
+          } yield assert(card)(equalTo(2L))
         },
         testM("empty when one of the sets is empty") {
           for {
@@ -292,9 +274,7 @@ trait SetsSpec extends BaseSpec {
             second <- uuid
             _      <- sAdd(first)("a", "b")
             card   <- sInterStore(key)(first, second)
-            inter  <- sMembers(key)
-          } yield assert(card)(equalTo(0L)) &&
-            assert(inter)(isEmpty)
+          } yield assert(card)(equalTo(0L))
         },
         testM("empty when both sets are empty") {
           for {
@@ -302,9 +282,7 @@ trait SetsSpec extends BaseSpec {
             first  <- uuid
             second <- uuid
             card   <- sInterStore(key)(first, second)
-            inter  <- sMembers(key)
-          } yield assert(card)(equalTo(0L)) &&
-            assert(inter)(isEmpty)
+          } yield assert(card)(equalTo(0L))
         },
         testM("non-empty set with multiple non-empty sets") {
           for {
@@ -316,9 +294,7 @@ trait SetsSpec extends BaseSpec {
             _      <- sAdd(second)("b", "d")
             _      <- sAdd(third)("b", "c")
             card   <- sInterStore(key)(first, second, third)
-            inter  <- sMembers(key)
-          } yield assert(card)(equalTo(1L)) &&
-            assert(inter)(hasSameElements(Chunk("b")))
+          } yield assert(card)(equalTo(1L))
         },
         testM("error when first parameter is not set") {
           for {
@@ -338,9 +314,7 @@ trait SetsSpec extends BaseSpec {
             value  <- uuid
             _      <- set(second, value, None, None, None)
             card   <- sInterStore(key)(first, second)
-            inter  <- sMembers(key)
-          } yield assert(card)(equalTo(0L)) &&
-            assert(inter)(isEmpty)
+          } yield assert(card)(equalTo(0L))
         },
         testM("error with non-empty first set and second parameter is not set") {
           for {
@@ -415,11 +389,7 @@ trait SetsSpec extends BaseSpec {
             _           <- sAdd(src)("a", "b", "c")
             _           <- sAdd(dest)("d", "e", "f")
             moved       <- sMove(src, dest, "a")
-            srcMembers  <- sMembers(src)
-            destMembers <- sMembers(dest)
-          } yield assert(moved)(isTrue) &&
-            assert(srcMembers)(hasSameElements(Chunk("b", "c"))) &&
-            assert(destMembers)(hasSameElements(Chunk("a", "d", "e", "f")))
+          } yield assert(moved)(isTrue)
         },
         testM("from non-empty source to empty destination") {
           for {
@@ -427,11 +397,7 @@ trait SetsSpec extends BaseSpec {
             dest        <- uuid
             _           <- sAdd(src)("a", "b", "c")
             moved       <- sMove(src, dest, "a")
-            srcMembers  <- sMembers(src)
-            destMembers <- sMembers(dest)
-          } yield assert(moved)(isTrue) &&
-            assert(srcMembers)(hasSameElements(Chunk("b", "c"))) &&
-            assert(destMembers)(hasSameElements(Chunk("a")))
+          } yield assert(moved)(isTrue)
         },
         testM("element already present in the destination") {
           for {
@@ -440,11 +406,7 @@ trait SetsSpec extends BaseSpec {
             _           <- sAdd(src)("a", "b", "c")
             _           <- sAdd(dest)("a", "d", "e")
             moved       <- sMove(src, dest, "a")
-            srcMembers  <- sMembers(src)
-            destMembers <- sMembers(dest)
-          } yield assert(moved)(isTrue) &&
-            assert(srcMembers)(hasSameElements(Chunk("b", "c"))) &&
-            assert(destMembers)(hasSameElements(Chunk("a", "d", "e")))
+          } yield assert(moved)(isTrue)
         },
         testM("from empty source to non-empty destination") {
           for {
@@ -452,11 +414,7 @@ trait SetsSpec extends BaseSpec {
             dest        <- uuid
             _           <- sAdd(dest)("b", "c")
             moved       <- sMove(src, dest, "a")
-            srcMembers  <- sMembers(src)
-            destMembers <- sMembers(dest)
-          } yield assert(moved)(isFalse) &&
-            assert(srcMembers)(isEmpty) &&
-            assert(destMembers)(hasSameElements(Chunk("b", "c")))
+          } yield assert(moved)(isFalse)
         },
         testM("non-existent element") {
           for {
@@ -465,11 +423,7 @@ trait SetsSpec extends BaseSpec {
             _           <- sAdd(src)("a", "b")
             _           <- sAdd(dest)("c", "d")
             moved       <- sMove(src, dest, "unknown")
-            srcMembers  <- sMembers(src)
-            destMembers <- sMembers(dest)
-          } yield assert(moved)(isFalse) &&
-            assert(srcMembers)(hasSameElements(Chunk("a", "b"))) &&
-            assert(destMembers)(hasSameElements(Chunk("c", "d")))
+          } yield assert(moved)(isFalse)
         },
         testM("from empty source to not set destination") {
           for {
@@ -507,9 +461,7 @@ trait SetsSpec extends BaseSpec {
             key     <- uuid
             _       <- sAdd(key)("a", "b", "c")
             poped   <- sPop(key, None)
-            members <- sMembers(key)
-          } yield assert(poped)(isSome) &&
-            assert(members)(hasSize(equalTo(2)))
+          } yield assert(poped)(isSome)
         },
         testM("one element from an empty set") {
           for {
@@ -530,26 +482,20 @@ trait SetsSpec extends BaseSpec {
             key     <- uuid
             _       <- sAdd(key)("a", "b", "c")
             poped   <- sPop(key, Some(2)).either
-            members <- sMembers(key)
-          } yield assert(poped)(isRight(isSome)) &&
-            assert(members)(hasSize(equalTo(1)))
+          } yield assert(poped)(isRight(isSome))
         },
         testM("more elements then there is in non-empty set") {
           for {
             key     <- uuid
             _       <- sAdd(key)("a", "b", "c")
             poped   <- sPop(key, Some(5)).either
-            members <- sMembers(key)
-          } yield assert(poped)(isRight(isSome)) &&
-            assert(members)(isEmpty)
+          } yield assert(poped)(isRight(isSome))
         },
         testM("multiple elements from empty set") {
           for {
             key     <- uuid
             poped   <- sPop(key, Some(3)).either
-            members <- sMembers(key)
-          } yield assert(poped)(isRight(isNone)) &&
-            assert(members)(isEmpty)
+          } yield assert(poped)(isRight(isNone))
         },
         testM("error when poping multiple elements from not set") {
           for {
@@ -630,27 +576,21 @@ trait SetsSpec extends BaseSpec {
             key     <- uuid
             _       <- sAdd(key)("a", "b", "c")
             removed <- sRem(key)("b", "c")
-            members <- sMembers(key)
-          } yield assert(removed)(equalTo(2L)) &&
-            assert(members)(hasSameElements(Chunk("a")))
+          } yield assert(removed)(equalTo(2L))
         },
         testM("when just part of elements are present in the non-empty set") {
           for {
             key     <- uuid
             _       <- sAdd(key)("a", "b", "c")
             removed <- sRem(key)("b", "d")
-            members <- sMembers(key)
-          } yield assert(removed)(equalTo(1L)) &&
-            assert(members)(hasSameElements(Chunk("a", "c")))
+          } yield assert(removed)(equalTo(1L))
         },
         testM("when none of the elements are present in the non-empty set") {
           for {
             key     <- uuid
             _       <- sAdd(key)("a", "b", "c")
             removed <- sRem(key)("d", "e")
-            members <- sMembers(key)
-          } yield assert(removed)(equalTo(0L)) &&
-            assert(members)(hasSameElements(Chunk("a", "b", "c")))
+          } yield assert(removed)(equalTo(0L))
         },
         testM("elements from an empty set") {
           for {
@@ -732,9 +672,7 @@ trait SetsSpec extends BaseSpec {
             _      <- sAdd(first)("a", "b", "c", "d")
             _      <- sAdd(second)("a", "c", "e")
             card   <- sUnionStore(dest)(first, second)
-            union  <- sMembers(dest)
-          } yield assert(card)(equalTo(5L)) &&
-            assert(union)(hasSameElements(Chunk("a", "b", "c", "d", "e")))
+          } yield assert(card)(equalTo(5L))
         },
         testM("equal to the non-empty set when the other one is empty") {
           for {
@@ -743,9 +681,7 @@ trait SetsSpec extends BaseSpec {
             dest   <- uuid
             _      <- sAdd(first)("a", "b")
             card   <- sUnionStore(dest)(first, second)
-            union  <- sMembers(dest)
-          } yield assert(card)(equalTo(2L)) &&
-            assert(union)(hasSameElements(Chunk("a", "b")))
+          } yield assert(card)(equalTo(2L))
         },
         testM("empty when both sets are empty") {
           for {
@@ -753,9 +689,7 @@ trait SetsSpec extends BaseSpec {
             second <- uuid
             dest   <- uuid
             card   <- sUnionStore(dest)(first, second)
-            union  <- sMembers(dest)
-          } yield assert(card)(equalTo(0L)) &&
-            assert(union)(isEmpty)
+          } yield assert(card)(equalTo(0L))
         },
         testM("non-empty set with multiple non-empty sets") {
           for {
@@ -767,9 +701,7 @@ trait SetsSpec extends BaseSpec {
             _      <- sAdd(second)("b", "d")
             _      <- sAdd(third)("b", "c", "e")
             card   <- sUnionStore(dest)(first, second, third)
-            union  <- sMembers(dest)
-          } yield assert(card)(equalTo(5L)) &&
-            assert(union)(hasSameElements(Chunk("a", "b", "c", "d", "e")))
+          } yield assert(card)(equalTo(5L))
         },
         testM("error when the first parameter is not set") {
           for {

--- a/redis/src/test/scala/zio/redis/SetsSpec.scala
+++ b/redis/src/test/scala/zio/redis/SetsSpec.scala
@@ -43,6 +43,26 @@ trait SetsSpec extends BaseSpec {
             added <- sAdd(key)("hello").either
           } yield assert(added)(isLeft(isSubtype[WrongType](anything)))
         }
+      ),
+      suite("cardinality")(
+        testM("sCard non-empty set") {
+          for {
+            key <- uuid
+            _ <- sAdd(key)("hello")
+            card <- sCard(key)
+          } yield assert(card)(equalTo(1L))
+        },
+        testM("sCard 0 when key doesn't exist") {
+          assertM(sCard("unknown"))(equalTo(0L))
+        },
+        testM("sCard error when not set") {
+          for {
+            key   <- uuid
+            value <- uuid
+            _     <- set(key, value, None, None, None)
+            card <- sCard(key).either
+          } yield assert(card)(isLeft(isSubtype[WrongType](anything)))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/SetsSpec.scala
+++ b/redis/src/test/scala/zio/redis/SetsSpec.scala
@@ -63,6 +63,69 @@ trait SetsSpec extends BaseSpec {
             card <- sCard(key).either
           } yield assert(card)(isLeft(isSubtype[WrongType](anything)))
         }
+      ),
+      suite("difference")(
+        testM("sDiff two non-empty sets") {
+          for {
+            first <- uuid
+            second <- uuid
+            _ <- sAdd(first)("a", "b", "c", "d")
+            _ <- sAdd(second)("a", "c")
+            diff <- sDiff(first, List(second))
+          } yield assert(diff)(hasSameElements(Chunk("b", "d")))
+        },
+        testM("sDiff non-empty set and empty set") {
+          for {
+            first <- uuid
+            second <- uuid
+            _ <- sAdd(first)("a", "b")
+            diff <- sDiff(first, List(second))
+          } yield assert(diff)(hasSameElements(Chunk("a", "b")))
+        },
+        testM("sDiff empty set and non-empty set") {
+          for {
+            first <- uuid
+            second <- uuid
+            _ <- sAdd(second)("a", "b")
+            diff <- sDiff(first, List(second))
+          } yield assert(diff)(isEmpty)
+        },
+        testM("sDiff empty when both sets are empty") {
+          for {
+            first <- uuid
+            second <- uuid
+            diff <- sDiff(first, List(second))
+          } yield assert(diff)(isEmpty)
+        },
+        testM("sDiff non-empty set with multiple non-empty sets") {
+          for {
+            first <- uuid
+            second <- uuid
+            third <- uuid
+            _ <- sAdd(first)("a", "b", "c", "d")
+            _ <- sAdd(second)("b", "d")
+            _ <- sAdd(third)("b", "c")
+            diff <- sDiff(first, List(second, third))
+          } yield assert(diff)(hasSameElements(Chunk("a")))
+        },
+        testM("sDiff error when first parameter is not set") {
+          for {
+            first <- uuid
+            second <- uuid
+            value <- uuid
+            _ <- set(first, value, None, None, None)
+            diff <- sDiff(first, List(second)).either
+          } yield assert(diff)(isLeft(isSubtype[WrongType](anything)))
+        },
+        testM("sDiff error when second parameter is not set") {
+          for {
+            first <- uuid
+            second <- uuid
+            value <- uuid
+            _ <- set(second, value, None, None, None)
+            diff <- sDiff(first, List(second)).either
+          } yield assert(diff)(isLeft(isSubtype[WrongType](anything)))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/SetsSpec.scala
+++ b/redis/src/test/scala/zio/redis/SetsSpec.scala
@@ -11,35 +11,35 @@ trait SetsSpec extends BaseSpec {
       suite("add")(
         testM("sAdd to the empty set") {
           for {
-            key <- uuid
-            added <- sAdd(key)("hello")
+            key     <- uuid
+            added   <- sAdd(key)("hello")
             members <- sMembers(key)
           } yield assert(added)(equalTo(1L)) &&
-              assert(members)(hasSameElements(Chunk("hello")))
+            assert(members)(hasSameElements(Chunk("hello")))
         },
         testM("sAdd to the non-empty set") {
           for {
-            key <- uuid
-            _ <- sAdd(key)("hello")
-            added <- sAdd(key)("world")
+            key     <- uuid
+            _       <- sAdd(key)("hello")
+            added   <- sAdd(key)("world")
             members <- sMembers(key)
           } yield assert(added)(equalTo(1L)) &&
-              assert(members)(hasSameElements(Chunk("hello", "world")))
+            assert(members)(hasSameElements(Chunk("hello", "world")))
         },
         testM("sAdd existing element to the set") {
           for {
-            key <- uuid
-            _ <- sAdd(key)("hello")
-            added <- sAdd(key)("hello")
+            key     <- uuid
+            _       <- sAdd(key)("hello")
+            added   <- sAdd(key)("hello")
             members <- sMembers(key)
           } yield assert(added)(equalTo(0L)) &&
             assert(members)(hasSameElements(Chunk("hello")))
         },
         testM("sAdd error when not set") {
           for {
-            key <- uuid
+            key   <- uuid
             value <- uuid
-            _ <- set(key, value, None, None, None)
+            _     <- set(key, value, None, None, None)
             added <- sAdd(key)("hello").either
           } yield assert(added)(isLeft(isSubtype[WrongType](anything)))
         }
@@ -47,8 +47,8 @@ trait SetsSpec extends BaseSpec {
       suite("cardinality")(
         testM("sCard non-empty set") {
           for {
-            key <- uuid
-            _ <- sAdd(key)("hello")
+            key  <- uuid
+            _    <- sAdd(key)("hello")
             card <- sCard(key)
           } yield assert(card)(equalTo(1L))
         },
@@ -60,326 +60,326 @@ trait SetsSpec extends BaseSpec {
             key   <- uuid
             value <- uuid
             _     <- set(key, value, None, None, None)
-            card <- sCard(key).either
+            card  <- sCard(key).either
           } yield assert(card)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
       suite("difference")(
         testM("sDiff two non-empty sets") {
           for {
-            first <- uuid
+            first  <- uuid
             second <- uuid
-            _ <- sAdd(first)("a", "b", "c", "d")
-            _ <- sAdd(second)("a", "c")
-            diff <- sDiff(first, List(second))
+            _      <- sAdd(first)("a", "b", "c", "d")
+            _      <- sAdd(second)("a", "c")
+            diff   <- sDiff(first, List(second))
           } yield assert(diff)(hasSameElements(Chunk("b", "d")))
         },
         testM("sDiff non-empty set and empty set") {
           for {
-            first <- uuid
+            first  <- uuid
             second <- uuid
-            _ <- sAdd(first)("a", "b")
-            diff <- sDiff(first, List(second))
+            _      <- sAdd(first)("a", "b")
+            diff   <- sDiff(first, List(second))
           } yield assert(diff)(hasSameElements(Chunk("a", "b")))
         },
         testM("sDiff empty set and non-empty set") {
           for {
-            first <- uuid
+            first  <- uuid
             second <- uuid
-            _ <- sAdd(second)("a", "b")
-            diff <- sDiff(first, List(second))
+            _      <- sAdd(second)("a", "b")
+            diff   <- sDiff(first, List(second))
           } yield assert(diff)(isEmpty)
         },
         testM("sDiff empty when both sets are empty") {
           for {
-            first <- uuid
+            first  <- uuid
             second <- uuid
-            diff <- sDiff(first, List(second))
+            diff   <- sDiff(first, List(second))
           } yield assert(diff)(isEmpty)
         },
         testM("sDiff non-empty set with multiple non-empty sets") {
           for {
-            first <- uuid
+            first  <- uuid
             second <- uuid
-            third <- uuid
-            _ <- sAdd(first)("a", "b", "c", "d")
-            _ <- sAdd(second)("b", "d")
-            _ <- sAdd(third)("b", "c")
-            diff <- sDiff(first, List(second, third))
+            third  <- uuid
+            _      <- sAdd(first)("a", "b", "c", "d")
+            _      <- sAdd(second)("b", "d")
+            _      <- sAdd(third)("b", "c")
+            diff   <- sDiff(first, List(second, third))
           } yield assert(diff)(hasSameElements(Chunk("a")))
         },
         testM("sDiff error when first parameter is not set") {
           for {
-            first <- uuid
+            first  <- uuid
             second <- uuid
-            value <- uuid
-            _ <- set(first, value, None, None, None)
-            diff <- sDiff(first, List(second)).either
+            value  <- uuid
+            _      <- set(first, value, None, None, None)
+            diff   <- sDiff(first, List(second)).either
           } yield assert(diff)(isLeft(isSubtype[WrongType](anything)))
         },
         testM("sDiff error when second parameter is not set") {
           for {
-            first <- uuid
+            first  <- uuid
             second <- uuid
-            value <- uuid
-            _ <- set(second, value, None, None, None)
-            diff <- sDiff(first, List(second)).either
+            value  <- uuid
+            _      <- set(second, value, None, None, None)
+            diff   <- sDiff(first, List(second)).either
           } yield assert(diff)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
       suite("store difference")(
         testM("sDiffStore two non-empty sets") {
           for {
-            key <- uuid
-            first <- uuid
+            key    <- uuid
+            first  <- uuid
             second <- uuid
-            _ <- sAdd(first)("a", "b", "c", "d")
-            _ <- sAdd(second)("a", "c")
-            card <- sDiffStore(key)(first, second)
-            diff <- sMembers(key)
+            _      <- sAdd(first)("a", "b", "c", "d")
+            _      <- sAdd(second)("a", "c")
+            card   <- sDiffStore(key)(first, second)
+            diff   <- sMembers(key)
           } yield assert(card)(equalTo(2L)) &&
-              assert(diff)(hasSameElements(Chunk("b", "d")))
+            assert(diff)(hasSameElements(Chunk("b", "d")))
         },
         testM("sDiffStore non-empty set and empty set") {
           for {
-            key <- uuid
-            first <- uuid
+            key    <- uuid
+            first  <- uuid
             second <- uuid
-            _ <- sAdd(first)("a", "b")
-            card <- sDiffStore(key)(first, second)
-            diff <- sMembers(key)
+            _      <- sAdd(first)("a", "b")
+            card   <- sDiffStore(key)(first, second)
+            diff   <- sMembers(key)
           } yield assert(card)(equalTo(2L)) &&
-              assert(diff)(hasSameElements(Chunk("a", "b")))
+            assert(diff)(hasSameElements(Chunk("a", "b")))
         },
         testM("sDiffStore empty set and non-empty set") {
           for {
-            key <- uuid
-            first <- uuid
+            key    <- uuid
+            first  <- uuid
             second <- uuid
-            _ <- sAdd(second)("a", "b")
-            card <- sDiffStore(key)(first, second)
-            diff <- sMembers(key)
+            _      <- sAdd(second)("a", "b")
+            card   <- sDiffStore(key)(first, second)
+            diff   <- sMembers(key)
           } yield assert(card)(equalTo(0L)) &&
-              assert(diff)(isEmpty)
+            assert(diff)(isEmpty)
         },
         testM("sDiffStore empty when both sets are empty") {
           for {
-            key <- uuid
-            first <- uuid
+            key    <- uuid
+            first  <- uuid
             second <- uuid
-            card <- sDiffStore(key)(first, second)
-            diff <- sMembers(key)
+            card   <- sDiffStore(key)(first, second)
+            diff   <- sMembers(key)
           } yield assert(card)(equalTo(0L)) &&
-              assert(diff)(isEmpty)
+            assert(diff)(isEmpty)
         },
         testM("sDiffStore non-empty set with multiple non-empty sets") {
           for {
-            key <- uuid
-            first <- uuid
+            key    <- uuid
+            first  <- uuid
             second <- uuid
-            third <- uuid
-            _ <- sAdd(first)("a", "b", "c", "d")
-            _ <- sAdd(second)("b", "d")
-            _ <- sAdd(third)("b", "c")
-            card <- sDiffStore(key)(first, second, third)
-            diff <- sMembers(key)
+            third  <- uuid
+            _      <- sAdd(first)("a", "b", "c", "d")
+            _      <- sAdd(second)("b", "d")
+            _      <- sAdd(third)("b", "c")
+            card   <- sDiffStore(key)(first, second, third)
+            diff   <- sMembers(key)
           } yield assert(card)(equalTo(1L)) &&
-              assert(diff)(hasSameElements(Chunk("a")))
+            assert(diff)(hasSameElements(Chunk("a")))
         },
         testM("sDiffStore error when first parameter is not set") {
           for {
-            key <- uuid
-            first <- uuid
+            key    <- uuid
+            first  <- uuid
             second <- uuid
-            value <- uuid
-            _ <- set(first, value, None, None, None)
-            card <- sDiffStore(key)(first, second).either
+            value  <- uuid
+            _      <- set(first, value, None, None, None)
+            card   <- sDiffStore(key)(first, second).either
           } yield assert(card)(isLeft(isSubtype[WrongType](anything)))
         },
         testM("sDiffStore error when second parameter is not set") {
           for {
-            key <- uuid
-            first <- uuid
+            key    <- uuid
+            first  <- uuid
             second <- uuid
-            value <- uuid
-            _ <- set(second, value, None, None, None)
-            card <- sDiffStore(key)(first, second).either
+            value  <- uuid
+            _      <- set(second, value, None, None, None)
+            card   <- sDiffStore(key)(first, second).either
           } yield assert(card)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
       suite("intersection")(
         testM("sInter two non-empty sets") {
           for {
-            first <- uuid
+            first  <- uuid
             second <- uuid
-            _ <- sAdd(first)("a", "b", "c", "d")
-            _ <- sAdd(second)("a", "c", "e")
-            inter <- sInter(first, List(second))
+            _      <- sAdd(first)("a", "b", "c", "d")
+            _      <- sAdd(second)("a", "c", "e")
+            inter  <- sInter(first, List(second))
           } yield assert(inter)(hasSameElements(Chunk("a", "c")))
         },
         testM("sInter empty when one of the sets is empty") {
           for {
-            first <- uuid
+            first  <- uuid
             second <- uuid
-            _ <- sAdd(first)("a", "b")
-            inter <- sInter(first, List(second))
+            _      <- sAdd(first)("a", "b")
+            inter  <- sInter(first, List(second))
           } yield assert(inter)(isEmpty)
         },
         testM("sInter empty when both sets are empty") {
           for {
-            first <- uuid
+            first  <- uuid
             second <- uuid
-            inter <- sInter(first, List(second))
+            inter  <- sInter(first, List(second))
           } yield assert(inter)(isEmpty)
         },
         testM("sInter non-empty set with multiple non-empty sets") {
           for {
-            first <- uuid
+            first  <- uuid
             second <- uuid
-            third <- uuid
-            _ <- sAdd(first)("a", "b", "c", "d")
-            _ <- sAdd(second)("b", "d")
-            _ <- sAdd(third)("b", "c")
-            inter <- sInter(first, List(second, third))
+            third  <- uuid
+            _      <- sAdd(first)("a", "b", "c", "d")
+            _      <- sAdd(second)("b", "d")
+            _      <- sAdd(third)("b", "c")
+            inter  <- sInter(first, List(second, third))
           } yield assert(inter)(hasSameElements(Chunk("b")))
         },
         testM("sInter error when first parameter is not set") {
           for {
-            first <- uuid
+            first  <- uuid
             second <- uuid
-            value <- uuid
-            _ <- set(first, value, None, None, None)
-            inter <- sInter(first, List(second)).either
+            value  <- uuid
+            _      <- set(first, value, None, None, None)
+            inter  <- sInter(first, List(second)).either
           } yield assert(inter)(isLeft(isSubtype[WrongType](anything)))
         },
         testM("sInter empty with empty first set and second parameter is not set") {
           for {
-            first <- uuid
+            first  <- uuid
             second <- uuid
-            value <- uuid
-            _ <- set(second, value, None, None, None)
-            inter <- sInter(first, List(second))
+            value  <- uuid
+            _      <- set(second, value, None, None, None)
+            inter  <- sInter(first, List(second))
           } yield assert(inter)(isEmpty)
         },
         testM("sInter error with non-empty first set and second parameter is not set") {
           for {
-            first <- uuid
+            first  <- uuid
             second <- uuid
-            value <- uuid
-            _ <- sAdd(first)("a")
-            _ <- set(second, value, None, None, None)
-            inter <- sInter(first, List(second)).either
+            value  <- uuid
+            _      <- sAdd(first)("a")
+            _      <- set(second, value, None, None, None)
+            inter  <- sInter(first, List(second)).either
           } yield assert(inter)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
       suite("store intersection")(
         testM("sInterStore two non-empty sets") {
           for {
-            key <- uuid
-            first <- uuid
+            key    <- uuid
+            first  <- uuid
             second <- uuid
-            _ <- sAdd(first)("a", "b", "c", "d")
-            _ <- sAdd(second)("a", "c", "e")
-            card <- sInterStore(key)(first, second)
-            inter <- sMembers(key)
+            _      <- sAdd(first)("a", "b", "c", "d")
+            _      <- sAdd(second)("a", "c", "e")
+            card   <- sInterStore(key)(first, second)
+            inter  <- sMembers(key)
           } yield assert(card)(equalTo(2L)) &&
-              assert(inter)(hasSameElements(Chunk("a", "c")))
+            assert(inter)(hasSameElements(Chunk("a", "c")))
         },
         testM("sInterStore empty when one of the sets is empty") {
           for {
-            key <- uuid
-            first <- uuid
+            key    <- uuid
+            first  <- uuid
             second <- uuid
-            _ <- sAdd(first)("a", "b")
-            card <- sInterStore(key)(first, second)
-            inter <- sMembers(key)
+            _      <- sAdd(first)("a", "b")
+            card   <- sInterStore(key)(first, second)
+            inter  <- sMembers(key)
           } yield assert(card)(equalTo(0L)) &&
-              assert(inter)(isEmpty)
+            assert(inter)(isEmpty)
         },
         testM("sInterStore empty when both sets are empty") {
           for {
-            key <- uuid
-            first <- uuid
+            key    <- uuid
+            first  <- uuid
             second <- uuid
-            card <- sInterStore(key)(first, second)
-            inter <- sMembers(key)
+            card   <- sInterStore(key)(first, second)
+            inter  <- sMembers(key)
           } yield assert(card)(equalTo(0L)) &&
-              assert(inter)(isEmpty)
+            assert(inter)(isEmpty)
         },
         testM("sInterStore non-empty set with multiple non-empty sets") {
           for {
-            key <- uuid
-            first <- uuid
+            key    <- uuid
+            first  <- uuid
             second <- uuid
-            third <- uuid
-            _ <- sAdd(first)("a", "b", "c", "d")
-            _ <- sAdd(second)("b", "d")
-            _ <- sAdd(third)("b", "c")
-            card <- sInterStore(key)(first, second, third)
-            inter <- sMembers(key)
+            third  <- uuid
+            _      <- sAdd(first)("a", "b", "c", "d")
+            _      <- sAdd(second)("b", "d")
+            _      <- sAdd(third)("b", "c")
+            card   <- sInterStore(key)(first, second, third)
+            inter  <- sMembers(key)
           } yield assert(card)(equalTo(1L)) &&
-              assert(inter)(hasSameElements(Chunk("b")))
+            assert(inter)(hasSameElements(Chunk("b")))
         },
         testM("sInterStore error when first parameter is not set") {
           for {
-            key <- uuid
-            first <- uuid
+            key    <- uuid
+            first  <- uuid
             second <- uuid
-            value <- uuid
-            _ <- set(first, value, None, None, None)
-            card <- sInterStore(key)(first, second).either
+            value  <- uuid
+            _      <- set(first, value, None, None, None)
+            card   <- sInterStore(key)(first, second).either
           } yield assert(card)(isLeft(isSubtype[WrongType](anything)))
         },
         testM("sInterStore empty with empty first set and second parameter is not set") {
           for {
-            key <- uuid
-            first <- uuid
+            key    <- uuid
+            first  <- uuid
             second <- uuid
-            value <- uuid
-            _ <- set(second, value, None, None, None)
-            card <- sInterStore(key)(first, second)
-            inter <- sMembers(key)
+            value  <- uuid
+            _      <- set(second, value, None, None, None)
+            card   <- sInterStore(key)(first, second)
+            inter  <- sMembers(key)
           } yield assert(card)(equalTo(0L)) &&
-              assert(inter)(isEmpty)
+            assert(inter)(isEmpty)
         },
         testM("sInterStore error with non-empty first set and second parameter is not set") {
           for {
-            key <- uuid
-            first <- uuid
+            key    <- uuid
+            first  <- uuid
             second <- uuid
-            value <- uuid
-            _ <- sAdd(first)("a")
-            _ <- set(second, value, None, None, None)
-            card <- sInterStore(key)(first, second).either
+            value  <- uuid
+            _      <- sAdd(first)("a")
+            _      <- set(second, value, None, None, None)
+            card   <- sInterStore(key)(first, second).either
           } yield assert(card)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
       suite("is member")(
         testM("sIsMember actual element of the non-empty set") {
           for {
-            key <- uuid
-            _ <- sAdd(key)("a", "b", "c")
+            key      <- uuid
+            _        <- sAdd(key)("a", "b", "c")
             isMember <- sIsMember(key, "b")
           } yield assert(isMember)(isTrue)
         },
         testM("sIsMember element that is not present in the set") {
           for {
-            key <- uuid
-            _ <- sAdd(key)("a", "b", "c")
+            key      <- uuid
+            _        <- sAdd(key)("a", "b", "c")
             isMember <- sIsMember(key, "unknown")
           } yield assert(isMember)(isFalse)
         },
         testM("sIsMember of an empty set") {
           for {
-            key <- uuid
+            key      <- uuid
             isMember <- sIsMember(key, "a")
           } yield assert(isMember)(isFalse)
         },
         testM("sIsMember when not set") {
           for {
-            key <- uuid
-            value <- uuid
-            _ <- set(key, value, None, None, None)
+            key      <- uuid
+            value    <- uuid
+            _        <- set(key, value, None, None, None)
             isMember <- sIsMember(key, "a").either
           } yield assert(isMember)(isLeft(isSubtype[WrongType](anything)))
         }
@@ -387,22 +387,22 @@ trait SetsSpec extends BaseSpec {
       suite("members")(
         testM("sMembers non-empty set") {
           for {
-            key <- uuid
-            _ <- sAdd(key)("a", "b", "c")
+            key     <- uuid
+            _       <- sAdd(key)("a", "b", "c")
             members <- sMembers(key)
           } yield assert(members)(hasSameElements(Chunk("a", "b", "c")))
         },
         testM("sMembers empty set") {
           for {
-            key <- uuid
+            key     <- uuid
             members <- sMembers(key)
           } yield assert(members)(isEmpty)
         },
         testM("sMembers when not set") {
           for {
-            key <- uuid
-            value <- uuid
-            _ <- set(key, value, None, None, None)
+            key     <- uuid
+            value   <- uuid
+            _       <- set(key, value, None, None, None)
             members <- sMembers(key).either
           } yield assert(members)(isLeft(isSubtype[WrongType](anything)))
         }
@@ -410,24 +410,24 @@ trait SetsSpec extends BaseSpec {
       suite("move")(
         testM("sMove from non-empty source to non-empty destination") {
           for {
-            src <- uuid
-            dest <- uuid
-            _ <- sAdd(src)("a", "b", "c")
-            _ <- sAdd(dest)("d", "e", "f")
-            moved <- sMove(src, dest, "a")
-            srcMembers <- sMembers(src)
+            src         <- uuid
+            dest        <- uuid
+            _           <- sAdd(src)("a", "b", "c")
+            _           <- sAdd(dest)("d", "e", "f")
+            moved       <- sMove(src, dest, "a")
+            srcMembers  <- sMembers(src)
             destMembers <- sMembers(dest)
           } yield assert(moved)(isTrue) &&
-              assert(srcMembers)(hasSameElements(Chunk("b", "c"))) &&
-              assert(destMembers)(hasSameElements(Chunk("a", "d", "e", "f")))
+            assert(srcMembers)(hasSameElements(Chunk("b", "c"))) &&
+            assert(destMembers)(hasSameElements(Chunk("a", "d", "e", "f")))
         },
         testM("sMove from non-empty source to empty destination") {
           for {
-            src <- uuid
-            dest <- uuid
-            _ <- sAdd(src)("a", "b", "c")
-            moved <- sMove(src, dest, "a")
-            srcMembers <- sMembers(src)
+            src         <- uuid
+            dest        <- uuid
+            _           <- sAdd(src)("a", "b", "c")
+            moved       <- sMove(src, dest, "a")
+            srcMembers  <- sMembers(src)
             destMembers <- sMembers(dest)
           } yield assert(moved)(isTrue) &&
             assert(srcMembers)(hasSameElements(Chunk("b", "c"))) &&
@@ -435,24 +435,24 @@ trait SetsSpec extends BaseSpec {
         },
         testM("sMove element already present in the destination") {
           for {
-            src <- uuid
-            dest <- uuid
-            _ <- sAdd(src)("a", "b", "c")
-            _ <- sAdd(dest)("a", "d", "e")
-            moved <- sMove(src, dest, "a")
-            srcMembers <- sMembers(src)
+            src         <- uuid
+            dest        <- uuid
+            _           <- sAdd(src)("a", "b", "c")
+            _           <- sAdd(dest)("a", "d", "e")
+            moved       <- sMove(src, dest, "a")
+            srcMembers  <- sMembers(src)
             destMembers <- sMembers(dest)
           } yield assert(moved)(isTrue) &&
-              assert(srcMembers)(hasSameElements(Chunk("b", "c"))) &&
-              assert(destMembers)(hasSameElements(Chunk("a", "d", "e")))
+            assert(srcMembers)(hasSameElements(Chunk("b", "c"))) &&
+            assert(destMembers)(hasSameElements(Chunk("a", "d", "e")))
         },
         testM("sMove from empty source to non-empty destination") {
           for {
-            src <- uuid
-            dest <- uuid
-            _ <- sAdd(dest)("b", "c")
-            moved <- sMove(src, dest, "a")
-            srcMembers <- sMembers(src)
+            src         <- uuid
+            dest        <- uuid
+            _           <- sAdd(dest)("b", "c")
+            moved       <- sMove(src, dest, "a")
+            srcMembers  <- sMembers(src)
             destMembers <- sMembers(dest)
           } yield assert(moved)(isFalse) &&
             assert(srcMembers)(isEmpty) &&
@@ -460,43 +460,43 @@ trait SetsSpec extends BaseSpec {
         },
         testM("sMove non-existent element") {
           for {
-            src <- uuid
-            dest <- uuid
-            _ <- sAdd(src)("a", "b")
-            _ <- sAdd(dest)("c", "d")
-            moved <- sMove(src, dest, "unknown")
-            srcMembers <- sMembers(src)
+            src         <- uuid
+            dest        <- uuid
+            _           <- sAdd(src)("a", "b")
+            _           <- sAdd(dest)("c", "d")
+            moved       <- sMove(src, dest, "unknown")
+            srcMembers  <- sMembers(src)
             destMembers <- sMembers(dest)
           } yield assert(moved)(isFalse) &&
-              assert(srcMembers)(hasSameElements(Chunk("a", "b"))) &&
-              assert(destMembers)(hasSameElements(Chunk("c", "d")))
+            assert(srcMembers)(hasSameElements(Chunk("a", "b"))) &&
+            assert(destMembers)(hasSameElements(Chunk("c", "d")))
         },
         testM("sMove from empty source to not set destination") {
           for {
-            src <- uuid
-            dest <- uuid
+            src   <- uuid
+            dest  <- uuid
             value <- uuid
-            _ <- set(dest, value, None, None, None)
+            _     <- set(dest, value, None, None, None)
             moved <- sMove(src, dest, "unknown")
           } yield assert(moved)(isFalse)
         },
         testM("sMove error when non-empty source and not set destination") {
           for {
-            src <- uuid
-            dest <- uuid
+            src   <- uuid
+            dest  <- uuid
             value <- uuid
-            _ <- sAdd(src)("a", "b", "c")
-            _ <- set(dest, value, None, None, None)
+            _     <- sAdd(src)("a", "b", "c")
+            _     <- set(dest, value, None, None, None)
             moved <- sMove(src, dest, "a").either
           } yield assert(moved)(isLeft(isSubtype[WrongType](anything)))
         },
         testM("sMove error when not set source to non-empty destination") {
           for {
-            src <- uuid
-            dest <- uuid
+            src   <- uuid
+            dest  <- uuid
             value <- uuid
-            _ <- set(src, value, None, None, None)
-            _ <- sAdd(dest)("a", "b", "c")
+            _     <- set(src, value, None, None, None)
+            _     <- sAdd(dest)("a", "b", "c")
             moved <- sMove(src, dest, "a").either
           } yield assert(moved)(isLeft(isSubtype[WrongType](anything)))
         }
@@ -504,58 +504,58 @@ trait SetsSpec extends BaseSpec {
       suite("pop")(
         testM("sPop one element from non-empty set") {
           for {
-            key <- uuid
-            _ <- sAdd(key)("a", "b", "c")
-            poped <- sPop(key, None)
+            key     <- uuid
+            _       <- sAdd(key)("a", "b", "c")
+            poped   <- sPop(key, None)
             members <- sMembers(key)
           } yield assert(poped)(isSome) &&
-              assert(members)(hasSize(equalTo(2)))
+            assert(members)(hasSize(equalTo(2)))
         },
         testM("sPop one element from an empty set") {
           for {
-            key <- uuid
+            key   <- uuid
             poped <- sPop(key, None)
           } yield assert(poped)(isNone)
         },
         testM("sPop error when poping one element from not set") {
           for {
-            key <- uuid
+            key   <- uuid
             value <- uuid
-            _ <- set(key, value, None, None, None)
+            _     <- set(key, value, None, None, None)
             poped <- sPop(key, None).either
           } yield assert(poped)(isLeft(isSubtype[WrongType](anything)))
         },
         testM("sPop multiple elements from non-empty set") {
           for {
-            key <- uuid
-            _ <- sAdd(key)("a", "b", "c")
-            poped <- sPop(key, Some(2)).either
+            key     <- uuid
+            _       <- sAdd(key)("a", "b", "c")
+            poped   <- sPop(key, Some(2)).either
             members <- sMembers(key)
           } yield assert(poped)(isRight(isSome)) &&
-              assert(members)(hasSize(equalTo(1)))
+            assert(members)(hasSize(equalTo(1)))
         },
         testM("sPop more elements then there is in non-empty set") {
           for {
-            key <- uuid
-            _ <- sAdd(key)("a", "b", "c")
-            poped <- sPop(key, Some(5)).either
+            key     <- uuid
+            _       <- sAdd(key)("a", "b", "c")
+            poped   <- sPop(key, Some(5)).either
             members <- sMembers(key)
           } yield assert(poped)(isRight(isSome)) &&
-              assert(members)(isEmpty)
+            assert(members)(isEmpty)
         },
         testM("sPop multiple elements from empty set") {
           for {
-            key <- uuid
-            poped <- sPop(key, Some(3)).either
+            key     <- uuid
+            poped   <- sPop(key, Some(3)).either
             members <- sMembers(key)
           } yield assert(poped)(isRight(isNone)) &&
-              assert(members)(isEmpty)
+            assert(members)(isEmpty)
         },
         testM("sPop error when poping multiple elements from not set") {
           for {
-            key <- uuid
+            key   <- uuid
             value <- uuid
-            _ <- set(key, value, None, None, None)
+            _     <- set(key, value, None, None, None)
             poped <- sPop(key, Some(3)).either
           } yield assert(poped)(isLeft(isSubtype[WrongType](anything)))
         }
@@ -563,63 +563,63 @@ trait SetsSpec extends BaseSpec {
       suite("random member")(
         testM("sRandMember one element from non-empty set") {
           for {
-            key <- uuid
-            _ <- sAdd(key)("a", "b", "c")
+            key    <- uuid
+            _      <- sAdd(key)("a", "b", "c")
             member <- sRandMember(key, None).either
           } yield assert(member)(isRight(hasSize(equalTo(1))))
         },
         testM("sRandMember one element from an empty set") {
           for {
-            key <- uuid
+            key    <- uuid
             member <- sRandMember(key, None).either
           } yield assert(member)(isRight(isEmpty))
         },
         testM("sRandMember one element from not set") {
           for {
-            key <- uuid
-            value <- uuid
-            _ <- set(key, value, None, None, None)
+            key    <- uuid
+            value  <- uuid
+            _      <- set(key, value, None, None, None)
             member <- sRandMember(key, None).either
           } yield assert(member)(isLeft(isSubtype[WrongType](anything)))
         },
         testM("sRandMember multiple elements from non-empty set") {
           for {
-            key <- uuid
-            _ <- sAdd(key)("a", "b", "c")
+            key     <- uuid
+            _       <- sAdd(key)("a", "b", "c")
             members <- sRandMember(key, Some(2L))
           } yield assert(members)(hasSize(equalTo(2)))
         },
         testM("sRandMember more elements than there is present in the non-empty set") {
           for {
-            key <- uuid
-            _ <- sAdd(key)("a", "b", "c")
+            key     <- uuid
+            _       <- sAdd(key)("a", "b", "c")
             members <- sRandMember(key, Some(5L))
           } yield assert(members)(hasSize(equalTo(3)))
         },
         testM("sRandMember multiple elements from an empty set") {
           for {
-            key <- uuid
+            key     <- uuid
             members <- sRandMember(key, Some(3L))
           } yield assert(members)(isEmpty)
         },
         testM("sRandMember repeated elements from non-empty set") {
           for {
-            key <- uuid
-            _ <- sAdd(key)("a", "b", "c")
+            key     <- uuid
+            _       <- sAdd(key)("a", "b", "c")
             members <- sRandMember(key, Some(-5L))
           } yield assert(members)(hasSize(equalTo(5)))
         },
         testM("sRandMember repeated elements from an empty set") {
           for {
-            key <- uuid
+            key     <- uuid
             members <- sRandMember(key, Some(-3L))
           } yield assert(members)(isEmpty)
         },
         testM("sRandMember error multiple elements from not set") {
           for {
-            key <- uuid
-            value <- uuid
-            _ <- set(key, value, None, None, None)
+            key     <- uuid
+            value   <- uuid
+            _       <- set(key, value, None, None, None)
             members <- sRandMember(key, Some(3L)).either
           } yield assert(members)(isLeft(isSubtype[WrongType](anything)))
         }
@@ -627,42 +627,42 @@ trait SetsSpec extends BaseSpec {
       suite("remove")(
         testM("sRem existing elements from non-empty set") {
           for {
-            key <- uuid
-            _ <- sAdd(key)("a", "b", "c")
+            key     <- uuid
+            _       <- sAdd(key)("a", "b", "c")
             removed <- sRem(key)("b", "c")
             members <- sMembers(key)
           } yield assert(removed)(equalTo(2L)) &&
-              assert(members)(hasSameElements(Chunk("a")))
+            assert(members)(hasSameElements(Chunk("a")))
         },
         testM("sRem when just part of elements are present in the non-empty set") {
           for {
-            key <- uuid
-            _ <- sAdd(key)("a", "b", "c")
+            key     <- uuid
+            _       <- sAdd(key)("a", "b", "c")
             removed <- sRem(key)("b", "d")
             members <- sMembers(key)
           } yield assert(removed)(equalTo(1L)) &&
-              assert(members)(hasSameElements(Chunk("a", "c")))
+            assert(members)(hasSameElements(Chunk("a", "c")))
         },
         testM("sRem when none of the elements are present in the non-empty set") {
           for {
-            key <- uuid
-            _ <- sAdd(key)("a", "b", "c")
+            key     <- uuid
+            _       <- sAdd(key)("a", "b", "c")
             removed <- sRem(key)("d", "e")
             members <- sMembers(key)
           } yield assert(removed)(equalTo(0L)) &&
-              assert(members)(hasSameElements(Chunk("a", "b", "c")))
+            assert(members)(hasSameElements(Chunk("a", "b", "c")))
         },
         testM("sRem elements from an empty set") {
           for {
-            key <- uuid
+            key     <- uuid
             removed <- sRem(key)("a", "b")
           } yield assert(removed)(equalTo(0L))
         },
         testM("sRem elements from not set") {
           for {
-            key <- uuid
-            value <- uuid
-            _ <- set(key, value, None, None, None)
+            key     <- uuid
+            value   <- uuid
+            _       <- set(key, value, None, None, None)
             removed <- sRem(key)("a", "b").either
           } yield assert(removed)(isLeft(isSubtype[WrongType](anything)))
         }
@@ -670,126 +670,126 @@ trait SetsSpec extends BaseSpec {
       suite("union")(
         testM("sUnion two non-empty sets") {
           for {
-            first <- uuid
+            first  <- uuid
             second <- uuid
-            _ <- sAdd(first)("a", "b", "c", "d")
-            _ <- sAdd(second)("a", "c", "e")
-            union <- sUnion(first, List(second))
+            _      <- sAdd(first)("a", "b", "c", "d")
+            _      <- sAdd(second)("a", "c", "e")
+            union  <- sUnion(first, List(second))
           } yield assert(union)(hasSameElements(Chunk("a", "b", "c", "d", "e")))
         },
         testM("sUnion equal to the non-empty set when the other one is empty") {
           for {
-            first <- uuid
+            first  <- uuid
             second <- uuid
-            _ <- sAdd(first)("a", "b")
-            union <- sUnion(first, List(second))
+            _      <- sAdd(first)("a", "b")
+            union  <- sUnion(first, List(second))
           } yield assert(union)(hasSameElements(Chunk("a", "b")))
         },
         testM("sUnion empty when both sets are empty") {
           for {
-            first <- uuid
+            first  <- uuid
             second <- uuid
-            union <- sUnion(first, List(second))
+            union  <- sUnion(first, List(second))
           } yield assert(union)(isEmpty)
         },
         testM("sUnion non-empty set with multiple non-empty sets") {
           for {
-            first <- uuid
+            first  <- uuid
             second <- uuid
-            third <- uuid
-            _ <- sAdd(first)("a", "b", "c", "d")
-            _ <- sAdd(second)("b", "d")
-            _ <- sAdd(third)("b", "c", "e")
-            union <- sUnion(first, List(second, third))
+            third  <- uuid
+            _      <- sAdd(first)("a", "b", "c", "d")
+            _      <- sAdd(second)("b", "d")
+            _      <- sAdd(third)("b", "c", "e")
+            union  <- sUnion(first, List(second, third))
           } yield assert(union)(hasSameElements(Chunk("a", "b", "c", "d", "e")))
         },
         testM("sUnion error when first parameter is not set") {
           for {
-            first <- uuid
+            first  <- uuid
             second <- uuid
-            value <- uuid
-            _ <- set(first, value, None, None, None)
-            union <- sUnion(first, List(second)).either
+            value  <- uuid
+            _      <- set(first, value, None, None, None)
+            union  <- sUnion(first, List(second)).either
           } yield assert(union)(isLeft(isSubtype[WrongType](anything)))
         },
         testM("sUnion error when the first parameter is set and the second parameter is not set") {
           for {
-            first <- uuid
+            first  <- uuid
             second <- uuid
-            value <- uuid
-            _ <- sAdd(first)("a")
-            _ <- set(second, value, None, None, None)
-            union <- sUnion(first, List(second)).either
+            value  <- uuid
+            _      <- sAdd(first)("a")
+            _      <- set(second, value, None, None, None)
+            union  <- sUnion(first, List(second)).either
           } yield assert(union)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
       suite("store union")(
         testM("sUnionStore two non-empty sets") {
           for {
-            first <- uuid
+            first  <- uuid
             second <- uuid
-            dest <- uuid
-            _ <- sAdd(first)("a", "b", "c", "d")
-            _ <- sAdd(second)("a", "c", "e")
-            card <- sUnionStore(dest)(first, second)
-            union <- sMembers(dest)
+            dest   <- uuid
+            _      <- sAdd(first)("a", "b", "c", "d")
+            _      <- sAdd(second)("a", "c", "e")
+            card   <- sUnionStore(dest)(first, second)
+            union  <- sMembers(dest)
           } yield assert(card)(equalTo(5L)) &&
-              assert(union)(hasSameElements(Chunk("a", "b", "c", "d", "e")))
+            assert(union)(hasSameElements(Chunk("a", "b", "c", "d", "e")))
         },
         testM("sUnionStore equal to the non-empty set when the other one is empty") {
           for {
-            first <- uuid
+            first  <- uuid
             second <- uuid
-            dest <- uuid
-            _ <- sAdd(first)("a", "b")
-            card <- sUnionStore(dest)(first, second)
-            union <- sMembers(dest)
+            dest   <- uuid
+            _      <- sAdd(first)("a", "b")
+            card   <- sUnionStore(dest)(first, second)
+            union  <- sMembers(dest)
           } yield assert(card)(equalTo(2L)) &&
-              assert(union)(hasSameElements(Chunk("a", "b")))
+            assert(union)(hasSameElements(Chunk("a", "b")))
         },
         testM("sUnionStore empty when both sets are empty") {
           for {
-            first <- uuid
+            first  <- uuid
             second <- uuid
-            dest <- uuid
-            card <- sUnionStore(dest)(first, second)
-            union <- sMembers(dest)
+            dest   <- uuid
+            card   <- sUnionStore(dest)(first, second)
+            union  <- sMembers(dest)
           } yield assert(card)(equalTo(0L)) &&
-              assert(union)(isEmpty)
+            assert(union)(isEmpty)
         },
         testM("sUnionStore non-empty set with multiple non-empty sets") {
           for {
-            first <- uuid
+            first  <- uuid
             second <- uuid
-            third <- uuid
-            dest <- uuid
-            _ <- sAdd(first)("a", "b", "c", "d")
-            _ <- sAdd(second)("b", "d")
-            _ <- sAdd(third)("b", "c", "e")
-            card <- sUnionStore(dest)(first, second, third)
-            union <- sMembers(dest)
+            third  <- uuid
+            dest   <- uuid
+            _      <- sAdd(first)("a", "b", "c", "d")
+            _      <- sAdd(second)("b", "d")
+            _      <- sAdd(third)("b", "c", "e")
+            card   <- sUnionStore(dest)(first, second, third)
+            union  <- sMembers(dest)
           } yield assert(card)(equalTo(5L)) &&
-              assert(union)(hasSameElements(Chunk("a", "b", "c", "d", "e")))
+            assert(union)(hasSameElements(Chunk("a", "b", "c", "d", "e")))
         },
         testM("sUnionStore error when the first parameter is not set") {
           for {
-            first <- uuid
+            first  <- uuid
             second <- uuid
-            dest <- uuid
-            value <- uuid
-            _ <- set(first, value, None, None, None)
-            card <- sUnionStore(dest)(first, second).either
+            dest   <- uuid
+            value  <- uuid
+            _      <- set(first, value, None, None, None)
+            card   <- sUnionStore(dest)(first, second).either
           } yield assert(card)(isLeft(isSubtype[WrongType](anything)))
         },
         testM("sUnionStore error when the first parameter is set and the second parameter is not set") {
           for {
-            first <- uuid
+            first  <- uuid
             second <- uuid
-            dest <- uuid
-            value <- uuid
-            _ <- sAdd(first)("a")
-            _ <- set(second, value, None, None, None)
-            card <- sUnionStore(dest)(first, second).either
+            dest   <- uuid
+            value  <- uuid
+            _      <- sAdd(first)("a")
+            _      <- set(second, value, None, None, None)
+            card   <- sUnionStore(dest)(first, second).either
           } yield assert(card)(isLeft(isSubtype[WrongType](anything)))
         }
       )

--- a/redis/src/test/scala/zio/redis/SetsSpec.scala
+++ b/redis/src/test/scala/zio/redis/SetsSpec.scala
@@ -462,13 +462,13 @@ trait SetsSpec extends BaseSpec {
             key     <- uuid
             _       <- sAdd(key)("a", "b", "c")
             poped   <- sPop(key, None)
-          } yield assert(poped)(isSome)
+          } yield assert(poped)(isNonEmpty)
         },
         testM("one element from an empty set") {
           for {
             key   <- uuid
             poped <- sPop(key, None)
-          } yield assert(poped)(isNone)
+          } yield assert(poped)(isEmpty)
         },
         testM("error when poping one element from not set") {
           for {
@@ -482,21 +482,21 @@ trait SetsSpec extends BaseSpec {
           for {
             key     <- uuid
             _       <- sAdd(key)("a", "b", "c")
-            poped   <- sPop(key, Some(2)).either
-          } yield assert(poped)(isRight(isSome))
+            poped   <- sPop(key, Some(2L))
+          } yield assert(poped)(hasSize(equalTo(2)))
         },
         testM("more elements then there is in non-empty set") {
           for {
             key     <- uuid
             _       <- sAdd(key)("a", "b", "c")
-            poped   <- sPop(key, Some(5)).either
-          } yield assert(poped)(isRight(isSome))
+            poped   <- sPop(key, Some(5L))
+          } yield assert(poped)(hasSize(equalTo(3)))
         },
         testM("multiple elements from empty set") {
           for {
             key     <- uuid
-            poped   <- sPop(key, Some(3)).either
-          } yield assert(poped)(isRight(isNone))
+            poped   <- sPop(key, Some(3))
+          } yield assert(poped)(isEmpty)
         },
         testM("error when poping multiple elements from not set") {
           for {
@@ -512,16 +512,16 @@ trait SetsSpec extends BaseSpec {
           for {
             key    <- uuid
             _      <- sAdd(key)("a", "b", "c")
-            member <- sRandMember(key, None).either
-          } yield assert(member)(isRight(hasSize(equalTo(1))))
+            member <- sRandMember(key, None)
+          } yield assert(member)(hasSize(equalTo(1)))
         },
         testM("one element from an empty set") {
           for {
             key    <- uuid
-            member <- sRandMember(key, None).either
-          } yield assert(member)(isRight(isEmpty))
+            member <- sRandMember(key, None)
+          } yield assert(member)(isEmpty)
         },
-        testM("one element from not set") {
+        testM("error when one element from not set") {
           for {
             key    <- uuid
             value  <- uuid

--- a/redis/src/test/scala/zio/redis/SetsSpec.scala
+++ b/redis/src/test/scala/zio/redis/SetsSpec.scala
@@ -559,6 +559,70 @@ trait SetsSpec extends BaseSpec {
             poped <- sPop(key, Some(3)).either
           } yield assert(poped)(isLeft(isSubtype[WrongType](anything)))
         }
+      ),
+      suite("random member")(
+        testM("sRandMember one element from non-empty set") {
+          for {
+            key <- uuid
+            _ <- sAdd(key)("a", "b", "c")
+            member <- sRandMember(key, None).either
+          } yield assert(member)(isRight(hasSize(equalTo(1))))
+        },
+        testM("sRandMember one element from an empty set") {
+          for {
+            key <- uuid
+            member <- sRandMember(key, None).either
+          } yield assert(member)(isRight(isEmpty))
+        },
+        testM("sRandMember one element from not set") {
+          for {
+            key <- uuid
+            value <- uuid
+            _ <- set(key, value, None, None, None)
+            member <- sRandMember(key, None).either
+          } yield assert(member)(isLeft(isSubtype[WrongType](anything)))
+        },
+        testM("sRandMember multiple elements from non-empty set") {
+          for {
+            key <- uuid
+            _ <- sAdd(key)("a", "b", "c")
+            members <- sRandMember(key, Some(2L))
+          } yield assert(members)(hasSize(equalTo(2)))
+        },
+        testM("sRandMember more elements than there is present in the non-empty set") {
+          for {
+            key <- uuid
+            _ <- sAdd(key)("a", "b", "c")
+            members <- sRandMember(key, Some(5L))
+          } yield assert(members)(hasSize(equalTo(3)))
+        },
+        testM("sRandMember multiple elements from an empty set") {
+          for {
+            key <- uuid
+            members <- sRandMember(key, Some(3L))
+          } yield assert(members)(isEmpty)
+        },
+        testM("sRandMember repeated elements from non-empty set") {
+          for {
+            key <- uuid
+            _ <- sAdd(key)("a", "b", "c")
+            members <- sRandMember(key, Some(-5L))
+          } yield assert(members)(hasSize(equalTo(5)))
+        },
+        testM("sRandMember repeated elements from an empty set") {
+          for {
+            key <- uuid
+            members <- sRandMember(key, Some(-3L))
+          } yield assert(members)(isEmpty)
+        },
+        testM("sRandMember error multiple elements from not set") {
+          for {
+            key <- uuid
+            value <- uuid
+            _ <- set(key, value, None, None, None)
+            members <- sRandMember(key, Some(3L)).either
+          } yield assert(members)(isLeft(isSubtype[WrongType](anything)))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/SetsSpec.scala
+++ b/redis/src/test/scala/zio/redis/SetsSpec.scala
@@ -500,6 +500,65 @@ trait SetsSpec extends BaseSpec {
             moved <- sMove(src, dest, "a").either
           } yield assert(moved)(isLeft(isSubtype[WrongType](anything)))
         }
+      ),
+      suite("pop")(
+        testM("sPop one element from non-empty set") {
+          for {
+            key <- uuid
+            _ <- sAdd(key)("a", "b", "c")
+            poped <- sPop(key, None)
+            members <- sMembers(key)
+          } yield assert(poped)(isSome) &&
+              assert(members)(hasSize(equalTo(2)))
+        },
+        testM("sPop one element from an empty set") {
+          for {
+            key <- uuid
+            poped <- sPop(key, None)
+          } yield assert(poped)(isNone)
+        },
+        testM("sPop error when poping one element from not set") {
+          for {
+            key <- uuid
+            value <- uuid
+            _ <- set(key, value, None, None, None)
+            poped <- sPop(key, None).either
+          } yield assert(poped)(isLeft(isSubtype[WrongType](anything)))
+        },
+        testM("sPop multiple elements from non-empty set") {
+          for {
+            key <- uuid
+            _ <- sAdd(key)("a", "b", "c")
+            poped <- sPop(key, Some(2)).either
+            members <- sMembers(key)
+          } yield assert(poped)(isRight(isSome)) &&
+              assert(members)(hasSize(equalTo(1)))
+        },
+        testM("sPop more elements then there is in non-empty set") {
+          for {
+            key <- uuid
+            _ <- sAdd(key)("a", "b", "c")
+            poped <- sPop(key, Some(5)).either
+            members <- sMembers(key)
+          } yield assert(poped)(isRight(isSome)) &&
+              assert(members)(isEmpty)
+        },
+        testM("sPop multiple elements from empty set") {
+          for {
+            key <- uuid
+            poped <- sPop(key, Some(3)).either
+            members <- sMembers(key)
+          } yield assert(poped)(isRight(isNone)) &&
+              assert(members)(isEmpty)
+        },
+        testM("sPop error when poping multiple elements from not set") {
+          for {
+            key <- uuid
+            value <- uuid
+            _ <- set(key, value, None, None, None)
+            poped <- sPop(key, Some(3)).either
+          } yield assert(poped)(isLeft(isSubtype[WrongType](anything)))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/SetsSpec.scala
+++ b/redis/src/test/scala/zio/redis/SetsSpec.scala
@@ -353,6 +353,36 @@ trait SetsSpec extends BaseSpec {
             card <- sInterStore(key)(first, second).either
           } yield assert(card)(isLeft(isSubtype[WrongType](anything)))
         }
+      ),
+      suite("is member")(
+        testM("sIsMember actual element of the non-empty set") {
+          for {
+            key <- uuid
+            _ <- sAdd(key)("a", "b", "c")
+            isMember <- sIsMember(key, "b")
+          } yield assert(isMember)(isTrue)
+        },
+        testM("sIsMember element that is not present in the set") {
+          for {
+            key <- uuid
+            _ <- sAdd(key)("a", "b", "c")
+            isMember <- sIsMember(key, "unknown")
+          } yield assert(isMember)(isFalse)
+        },
+        testM("sIsMember of an empty set") {
+          for {
+            key <- uuid
+            isMember <- sIsMember(key, "a")
+          } yield assert(isMember)(isFalse)
+        },
+        testM("sIsMember when not set") {
+          for {
+            key <- uuid
+            value <- uuid
+            _ <- set(key, value, None, None, None)
+            isMember <- sIsMember(key, "a").either
+          } yield assert(isMember)(isLeft(isSubtype[WrongType](anything)))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/SetsSpec.scala
+++ b/redis/src/test/scala/zio/redis/SetsSpec.scala
@@ -623,6 +623,49 @@ trait SetsSpec extends BaseSpec {
             members <- sRandMember(key, Some(3L)).either
           } yield assert(members)(isLeft(isSubtype[WrongType](anything)))
         }
+      ),
+      suite("remove")(
+        testM("sRem existing elements from non-empty set") {
+          for {
+            key <- uuid
+            _ <- sAdd(key)("a", "b", "c")
+            removed <- sRem(key)("b", "c")
+            members <- sMembers(key)
+          } yield assert(removed)(equalTo(2L)) &&
+              assert(members)(hasSameElements(Chunk("a")))
+        },
+        testM("sRem when just part of elements are present in the non-empty set") {
+          for {
+            key <- uuid
+            _ <- sAdd(key)("a", "b", "c")
+            removed <- sRem(key)("b", "d")
+            members <- sMembers(key)
+          } yield assert(removed)(equalTo(1L)) &&
+              assert(members)(hasSameElements(Chunk("a", "c")))
+        },
+        testM("sRem when none of the elements are present in the non-empty set") {
+          for {
+            key <- uuid
+            _ <- sAdd(key)("a", "b", "c")
+            removed <- sRem(key)("d", "e")
+            members <- sMembers(key)
+          } yield assert(removed)(equalTo(0L)) &&
+              assert(members)(hasSameElements(Chunk("a", "b", "c")))
+        },
+        testM("sRem elements from an empty set") {
+          for {
+            key <- uuid
+            removed <- sRem(key)("a", "b")
+          } yield assert(removed)(equalTo(0L))
+        },
+        testM("sRem elements from not set") {
+          for {
+            key <- uuid
+            value <- uuid
+            _ <- set(key, value, None, None, None)
+            removed <- sRem(key)("a", "b").either
+          } yield assert(removed)(isLeft(isSubtype[WrongType](anything)))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/SetsSpec.scala
+++ b/redis/src/test/scala/zio/redis/SetsSpec.scala
@@ -1,0 +1,48 @@
+package zio.redis
+
+import zio.Chunk
+import zio.redis.RedisError.WrongType
+import zio.test._
+import zio.test.Assertion._
+
+trait SetsSpec extends BaseSpec {
+  val setsSuite =
+    suite("sets")(
+      suite("add")(
+        testM("sAdd to the empty set") {
+          for {
+            key <- uuid
+            added <- sAdd(key)("hello")
+            members <- sMembers(key)
+          } yield assert(added)(equalTo(1L)) &&
+              assert(members)(hasSameElements(Chunk("hello")))
+        },
+        testM("sAdd to the non-empty set") {
+          for {
+            key <- uuid
+            _ <- sAdd(key)("hello")
+            added <- sAdd(key)("world")
+            members <- sMembers(key)
+          } yield assert(added)(equalTo(1L)) &&
+              assert(members)(hasSameElements(Chunk("hello", "world")))
+        },
+        testM("sAdd existing element to the set") {
+          for {
+            key <- uuid
+            _ <- sAdd(key)("hello")
+            added <- sAdd(key)("hello")
+            members <- sMembers(key)
+          } yield assert(added)(equalTo(0L)) &&
+            assert(members)(hasSameElements(Chunk("hello")))
+        },
+        testM("sAdd error when not set") {
+          for {
+            key <- uuid
+            value <- uuid
+            _ <- set(key, value, None, None, None)
+            added <- sAdd(key)("hello").either
+          } yield assert(added)(isLeft(isSubtype[WrongType](anything)))
+        }
+      )
+    )
+}

--- a/redis/src/test/scala/zio/redis/SetsSpec.scala
+++ b/redis/src/test/scala/zio/redis/SetsSpec.scala
@@ -11,22 +11,22 @@ trait SetsSpec extends BaseSpec {
       suite("sAdd")(
         testM("to empty set") {
           for {
-            key     <- uuid
-            added   <- sAdd(key)("hello")
+            key   <- uuid
+            added <- sAdd(key)("hello")
           } yield assert(added)(equalTo(1L))
         },
         testM("to the non-empty set") {
           for {
-            key     <- uuid
-            _       <- sAdd(key)("hello")
-            added   <- sAdd(key)("world")
+            key   <- uuid
+            _     <- sAdd(key)("hello")
+            added <- sAdd(key)("world")
           } yield assert(added)(equalTo(1L))
         },
         testM("existing element to set") {
           for {
-            key     <- uuid
-            _       <- sAdd(key)("hello")
-            added   <- sAdd(key)("hello")
+            key   <- uuid
+            _     <- sAdd(key)("hello")
+            added <- sAdd(key)("hello")
           } yield assert(added)(equalTo(0L))
         },
         testM("error when not set") {
@@ -384,45 +384,45 @@ trait SetsSpec extends BaseSpec {
       suite("sMove")(
         testM("from non-empty source to non-empty destination") {
           for {
-            src         <- uuid
-            dest        <- uuid
-            _           <- sAdd(src)("a", "b", "c")
-            _           <- sAdd(dest)("d", "e", "f")
-            moved       <- sMove(src, dest, "a")
+            src   <- uuid
+            dest  <- uuid
+            _     <- sAdd(src)("a", "b", "c")
+            _     <- sAdd(dest)("d", "e", "f")
+            moved <- sMove(src, dest, "a")
           } yield assert(moved)(isTrue)
         },
         testM("from non-empty source to empty destination") {
           for {
-            src         <- uuid
-            dest        <- uuid
-            _           <- sAdd(src)("a", "b", "c")
-            moved       <- sMove(src, dest, "a")
+            src   <- uuid
+            dest  <- uuid
+            _     <- sAdd(src)("a", "b", "c")
+            moved <- sMove(src, dest, "a")
           } yield assert(moved)(isTrue)
         },
         testM("element already present in the destination") {
           for {
-            src         <- uuid
-            dest        <- uuid
-            _           <- sAdd(src)("a", "b", "c")
-            _           <- sAdd(dest)("a", "d", "e")
-            moved       <- sMove(src, dest, "a")
+            src   <- uuid
+            dest  <- uuid
+            _     <- sAdd(src)("a", "b", "c")
+            _     <- sAdd(dest)("a", "d", "e")
+            moved <- sMove(src, dest, "a")
           } yield assert(moved)(isTrue)
         },
         testM("from empty source to non-empty destination") {
           for {
-            src         <- uuid
-            dest        <- uuid
-            _           <- sAdd(dest)("b", "c")
-            moved       <- sMove(src, dest, "a")
+            src   <- uuid
+            dest  <- uuid
+            _     <- sAdd(dest)("b", "c")
+            moved <- sMove(src, dest, "a")
           } yield assert(moved)(isFalse)
         },
         testM("non-existent element") {
           for {
-            src         <- uuid
-            dest        <- uuid
-            _           <- sAdd(src)("a", "b")
-            _           <- sAdd(dest)("c", "d")
-            moved       <- sMove(src, dest, "unknown")
+            src   <- uuid
+            dest  <- uuid
+            _     <- sAdd(src)("a", "b")
+            _     <- sAdd(dest)("c", "d")
+            moved <- sMove(src, dest, "unknown")
           } yield assert(moved)(isFalse)
         },
         testM("from empty source to not set destination") {
@@ -458,9 +458,9 @@ trait SetsSpec extends BaseSpec {
       suite("sPop")(
         testM("one element from non-empty set") {
           for {
-            key     <- uuid
-            _       <- sAdd(key)("a", "b", "c")
-            poped   <- sPop(key, None)
+            key   <- uuid
+            _     <- sAdd(key)("a", "b", "c")
+            poped <- sPop(key, None)
           } yield assert(poped)(isNonEmpty)
         },
         testM("one element from an empty set") {
@@ -479,22 +479,22 @@ trait SetsSpec extends BaseSpec {
         },
         testM("multiple elements from non-empty set") {
           for {
-            key     <- uuid
-            _       <- sAdd(key)("a", "b", "c")
-            poped   <- sPop(key, Some(2L))
+            key   <- uuid
+            _     <- sAdd(key)("a", "b", "c")
+            poped <- sPop(key, Some(2L))
           } yield assert(poped)(hasSize(equalTo(2)))
         },
         testM("more elements then there is in non-empty set") {
           for {
-            key     <- uuid
-            _       <- sAdd(key)("a", "b", "c")
-            poped   <- sPop(key, Some(5L))
+            key   <- uuid
+            _     <- sAdd(key)("a", "b", "c")
+            poped <- sPop(key, Some(5L))
           } yield assert(poped)(hasSize(equalTo(3)))
         },
         testM("multiple elements from empty set") {
           for {
-            key     <- uuid
-            poped   <- sPop(key, Some(3))
+            key   <- uuid
+            poped <- sPop(key, Some(3))
           } yield assert(poped)(isEmpty)
         },
         testM("error when poping multiple elements from not set") {
@@ -728,45 +728,45 @@ trait SetsSpec extends BaseSpec {
       suite("sScan")(
         testM("non-empty set") {
           for {
-            key <- uuid
-            _ <- sAdd(key)("a", "b", "c")
-            scan <- sScan(key, 0L, None, None)
+            key              <- uuid
+            _                <- sAdd(key)("a", "b", "c")
+            scan             <- sScan(key, 0L, None, None)
             (cursor, members) = scan
           } yield assert(cursor)(isNonEmptyString) &&
             assert(members)(isNonEmpty)
         },
         testM("empty set") {
           for {
-            key <- uuid
-            scan <- sScan(key, 0L, None, None)
+            key              <- uuid
+            scan             <- sScan(key, 0L, None, None)
             (cursor, members) = scan
           } yield assert(cursor)(equalTo("0")) &&
             assert(members)(isEmpty)
         },
         testM("with match over non-empty set") {
           for {
-            key <- uuid
-            _ <- sAdd(key)("one", "two", "three")
-            scan <- sScan(key, 0L, Some("t[a-z]*".r), None)
+            key              <- uuid
+            _                <- sAdd(key)("one", "two", "three")
+            scan             <- sScan(key, 0L, Some("t[a-z]*".r), None)
             (cursor, members) = scan
           } yield assert(cursor)(isNonEmptyString) &&
             assert(members)(isNonEmpty)
         },
         testM("with count over non-empty set") {
           for {
-            key <- uuid
-            _ <- sAdd(key)("a", "b", "c", "d", "e")
-            scan <- sScan(key, 0L, None, Some(Count(3L)))
+            key              <- uuid
+            _                <- sAdd(key)("a", "b", "c", "d", "e")
+            scan             <- sScan(key, 0L, None, Some(Count(3L)))
             (cursor, members) = scan
           } yield assert(cursor)(isNonEmptyString) &&
             assert(members)(isNonEmpty)
         },
         testM("error when not set") {
           for {
-            key <- uuid
+            key   <- uuid
             value <- uuid
-            _ <- set(key, value, None, None, None)
-            scan <- sScan(key, 0L, None, None).either
+            _     <- set(key, value, None, None, None)
+            scan  <- sScan(key, 0L, None, None).either
           } yield assert(scan)(isLeft(isSubtype[WrongType](anything)))
         }
       )

--- a/redis/src/test/scala/zio/redis/SetsSpec.scala
+++ b/redis/src/test/scala/zio/redis/SetsSpec.scala
@@ -29,6 +29,12 @@ trait SetsSpec extends BaseSpec {
             added <- sAdd(key)("hello")
           } yield assert(added)(equalTo(0L))
         },
+        testM("multiple elements to set") {
+          for {
+            key   <- uuid
+            added <- sAdd(key)("a", "b", "c")
+          } yield assert(added)(equalTo(3L))
+        },
         testM("error when not set") {
           for {
             key   <- uuid
@@ -70,18 +76,18 @@ trait SetsSpec extends BaseSpec {
         },
         testM("non-empty set and empty set") {
           for {
-            first  <- uuid
-            second <- uuid
-            _      <- sAdd(first)("a", "b")
-            diff   <- sDiff(first, List(second))
+            nonEmpty <- uuid
+            empty    <- uuid
+            _        <- sAdd(nonEmpty)("a", "b")
+            diff     <- sDiff(nonEmpty, List(empty))
           } yield assert(diff)(hasSameElements(Chunk("a", "b")))
         },
         testM("empty set and non-empty set") {
           for {
-            first  <- uuid
-            second <- uuid
-            _      <- sAdd(second)("a", "b")
-            diff   <- sDiff(first, List(second))
+            empty    <- uuid
+            nonEmpty <- uuid
+            _        <- sAdd(nonEmpty)("a", "b")
+            diff     <- sDiff(empty, List(nonEmpty))
           } yield assert(diff)(isEmpty)
         },
         testM("empty when both sets are empty") {
@@ -124,70 +130,70 @@ trait SetsSpec extends BaseSpec {
       suite("sDiffStore")(
         testM("two non-empty sets") {
           for {
-            key    <- uuid
+            dest   <- uuid
             first  <- uuid
             second <- uuid
             _      <- sAdd(first)("a", "b", "c", "d")
             _      <- sAdd(second)("a", "c")
-            card   <- sDiffStore(key)(first, second)
+            card   <- sDiffStore(dest)(first, second)
           } yield assert(card)(equalTo(2L))
         },
         testM("non-empty set and empty set") {
           for {
-            key    <- uuid
-            first  <- uuid
-            second <- uuid
-            _      <- sAdd(first)("a", "b")
-            card   <- sDiffStore(key)(first, second)
+            dest     <- uuid
+            nonEmpty <- uuid
+            empty    <- uuid
+            _        <- sAdd(nonEmpty)("a", "b")
+            card     <- sDiffStore(dest)(nonEmpty, empty)
           } yield assert(card)(equalTo(2L))
         },
         testM("empty set and non-empty set") {
           for {
-            key    <- uuid
-            first  <- uuid
-            second <- uuid
-            _      <- sAdd(second)("a", "b")
-            card   <- sDiffStore(key)(first, second)
+            dest     <- uuid
+            empty    <- uuid
+            nonEmpty <- uuid
+            _        <- sAdd(nonEmpty)("a", "b")
+            card     <- sDiffStore(dest)(empty, nonEmpty)
           } yield assert(card)(equalTo(0L))
         },
         testM("empty when both sets are empty") {
           for {
-            key    <- uuid
+            dest   <- uuid
             first  <- uuid
             second <- uuid
-            card   <- sDiffStore(key)(first, second)
+            card   <- sDiffStore(dest)(first, second)
           } yield assert(card)(equalTo(0L))
         },
         testM("non-empty set with multiple non-empty sets") {
           for {
-            key    <- uuid
+            dest   <- uuid
             first  <- uuid
             second <- uuid
             third  <- uuid
             _      <- sAdd(first)("a", "b", "c", "d")
             _      <- sAdd(second)("b", "d")
             _      <- sAdd(third)("b", "c")
-            card   <- sDiffStore(key)(first, second, third)
+            card   <- sDiffStore(dest)(first, second, third)
           } yield assert(card)(equalTo(1L))
         },
         testM("error when first parameter is not set") {
           for {
-            key    <- uuid
+            dest   <- uuid
             first  <- uuid
             second <- uuid
             value  <- uuid
             _      <- set(first, value, None, None, None)
-            card   <- sDiffStore(key)(first, second).either
+            card   <- sDiffStore(dest)(first, second).either
           } yield assert(card)(isLeft(isSubtype[WrongType](anything)))
         },
         testM("error when second parameter is not set") {
           for {
-            key    <- uuid
+            dest   <- uuid
             first  <- uuid
             second <- uuid
             value  <- uuid
             _      <- set(second, value, None, None, None)
-            card   <- sDiffStore(key)(first, second).either
+            card   <- sDiffStore(dest)(first, second).either
           } yield assert(card)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
@@ -203,10 +209,10 @@ trait SetsSpec extends BaseSpec {
         },
         testM("empty when one of the sets is empty") {
           for {
-            first  <- uuid
-            second <- uuid
-            _      <- sAdd(first)("a", "b")
-            inter  <- sInter(first, List(second))
+            nonEmpty <- uuid
+            empty    <- uuid
+            _        <- sAdd(nonEmpty)("a", "b")
+            inter    <- sInter(nonEmpty, List(empty))
           } yield assert(inter)(isEmpty)
         },
         testM("empty when both sets are empty") {
@@ -259,72 +265,72 @@ trait SetsSpec extends BaseSpec {
       suite("sInterStore")(
         testM("two non-empty sets") {
           for {
-            key    <- uuid
+            dest   <- uuid
             first  <- uuid
             second <- uuid
             _      <- sAdd(first)("a", "b", "c", "d")
             _      <- sAdd(second)("a", "c", "e")
-            card   <- sInterStore(key)(first, second)
+            card   <- sInterStore(dest)(first, second)
           } yield assert(card)(equalTo(2L))
         },
         testM("empty when one of the sets is empty") {
           for {
-            key    <- uuid
-            first  <- uuid
-            second <- uuid
-            _      <- sAdd(first)("a", "b")
-            card   <- sInterStore(key)(first, second)
+            dest     <- uuid
+            nonEmpty <- uuid
+            empty    <- uuid
+            _        <- sAdd(nonEmpty)("a", "b")
+            card     <- sInterStore(dest)(nonEmpty, empty)
           } yield assert(card)(equalTo(0L))
         },
         testM("empty when both sets are empty") {
           for {
-            key    <- uuid
+            dest   <- uuid
             first  <- uuid
             second <- uuid
-            card   <- sInterStore(key)(first, second)
+            card   <- sInterStore(dest)(first, second)
           } yield assert(card)(equalTo(0L))
         },
         testM("non-empty set with multiple non-empty sets") {
           for {
-            key    <- uuid
+            dest   <- uuid
             first  <- uuid
             second <- uuid
             third  <- uuid
             _      <- sAdd(first)("a", "b", "c", "d")
             _      <- sAdd(second)("b", "d")
             _      <- sAdd(third)("b", "c")
-            card   <- sInterStore(key)(first, second, third)
+            card   <- sInterStore(dest)(first, second, third)
           } yield assert(card)(equalTo(1L))
         },
         testM("error when first parameter is not set") {
           for {
-            key    <- uuid
+            dest   <- uuid
             first  <- uuid
             second <- uuid
             value  <- uuid
             _      <- set(first, value, None, None, None)
-            card   <- sInterStore(key)(first, second).either
+            card   <- sInterStore(dest)(first, second).either
           } yield assert(card)(isLeft(isSubtype[WrongType](anything)))
         },
         testM("empty with empty first set and second parameter is not set") {
           for {
-            key    <- uuid
+            dest   <- uuid
             first  <- uuid
             second <- uuid
             value  <- uuid
             _      <- set(second, value, None, None, None)
-            card   <- sInterStore(key)(first, second)
+            card   <- sInterStore(dest)(first, second)
           } yield assert(card)(equalTo(0L))
         },
         testM("error with non-empty first set and second parameter is not set") {
           for {
-            key    <- uuid
+            dest   <- uuid
             first  <- uuid
             second <- uuid
             value  <- uuid
             _      <- sAdd(first)("a")
             _      <- set(second, value, None, None, None)
-            card   <- sInterStore(key)(first, second).either
+            card   <- sInterStore(dest)(first, second).either
           } yield assert(card)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
@@ -619,10 +625,10 @@ trait SetsSpec extends BaseSpec {
         },
         testM("equal to the non-empty set when the other one is empty") {
           for {
-            first  <- uuid
-            second <- uuid
-            _      <- sAdd(first)("a", "b")
-            union  <- sUnion(first, List(second))
+            nonEmpty <- uuid
+            empty    <- uuid
+            _        <- sAdd(nonEmpty)("a", "b")
+            union    <- sUnion(nonEmpty, List(empty))
           } yield assert(union)(hasSameElements(Chunk("a", "b")))
         },
         testM("empty when both sets are empty") {
@@ -676,11 +682,11 @@ trait SetsSpec extends BaseSpec {
         },
         testM("equal to the non-empty set when the other one is empty") {
           for {
-            first  <- uuid
-            second <- uuid
-            dest   <- uuid
-            _      <- sAdd(first)("a", "b")
-            card   <- sUnionStore(dest)(first, second)
+            nonEmpty <- uuid
+            empty    <- uuid
+            dest     <- uuid
+            _        <- sAdd(nonEmpty)("a", "b")
+            card     <- sUnionStore(dest)(nonEmpty, empty)
           } yield assert(card)(equalTo(2L))
         },
         testM("empty when both sets are empty") {

--- a/redis/src/test/scala/zio/redis/SetsSpec.scala
+++ b/redis/src/test/scala/zio/redis/SetsSpec.scala
@@ -4,7 +4,6 @@ import zio.Chunk
 import zio.redis.RedisError.WrongType
 import zio.test._
 import zio.test.Assertion._
-import zio.test.TestAspect.ignore
 
 trait SetsSpec extends BaseSpec {
   val setsSuite =
@@ -748,7 +747,7 @@ trait SetsSpec extends BaseSpec {
           for {
             key <- uuid
             _ <- sAdd(key)("one", "two", "three")
-            scan <- sScan(key, 0L, Some("t\\w*".r), None)
+            scan <- sScan(key, 0L, Some("t[a-z]*".r), None)
             (cursor, members) = scan
           } yield assert(cursor)(isNonEmptyString) &&
             assert(members)(isNonEmpty)
@@ -757,7 +756,7 @@ trait SetsSpec extends BaseSpec {
           for {
             key <- uuid
             _ <- sAdd(key)("a", "b", "c", "d", "e")
-            scan <- sScan(key, 0L, None, Some(3L))
+            scan <- sScan(key, 0L, None, Some(Count(3L)))
             (cursor, members) = scan
           } yield assert(cursor)(isNonEmptyString) &&
             assert(members)(isNonEmpty)

--- a/redis/src/test/scala/zio/redis/SetsSpec.scala
+++ b/redis/src/test/scala/zio/redis/SetsSpec.scala
@@ -206,6 +206,71 @@ trait SetsSpec extends BaseSpec {
             card <- sDiffStore(key)(first, second).either
           } yield assert(card)(isLeft(isSubtype[WrongType](anything)))
         }
+      ),
+      suite("intersection")(
+        testM("sInter two non-empty sets") {
+          for {
+            first <- uuid
+            second <- uuid
+            _ <- sAdd(first)("a", "b", "c", "d")
+            _ <- sAdd(second)("a", "c", "e")
+            inter <- sInter(first, List(second))
+          } yield assert(inter)(hasSameElements(Chunk("a", "c")))
+        },
+        testM("sInter empty when one of the sets is empty") {
+          for {
+            first <- uuid
+            second <- uuid
+            _ <- sAdd(first)("a", "b")
+            inter <- sInter(first, List(second))
+          } yield assert(inter)(isEmpty)
+        },
+        testM("sInter empty when both sets are empty") {
+          for {
+            first <- uuid
+            second <- uuid
+            inter <- sInter(first, List(second))
+          } yield assert(inter)(isEmpty)
+        },
+        testM("sInter non-empty set with multiple non-empty sets") {
+          for {
+            first <- uuid
+            second <- uuid
+            third <- uuid
+            _ <- sAdd(first)("a", "b", "c", "d")
+            _ <- sAdd(second)("b", "d")
+            _ <- sAdd(third)("b", "c")
+            inter <- sInter(first, List(second, third))
+          } yield assert(inter)(hasSameElements(Chunk("b")))
+        },
+        testM("sInter error when first parameter is not set") {
+          for {
+            first <- uuid
+            second <- uuid
+            value <- uuid
+            _ <- set(first, value, None, None, None)
+            inter <- sInter(first, List(second)).either
+          } yield assert(inter)(isLeft(isSubtype[WrongType](anything)))
+        },
+        testM("sInter empty with empty first set and second parameter is not set") {
+          for {
+            first <- uuid
+            second <- uuid
+            value <- uuid
+            _ <- set(second, value, None, None, None)
+            inter <- sInter(first, List(second))
+          } yield assert(inter)(isEmpty)
+        },
+        testM("sInter error with non-empty first set and second parameter is not set") {
+          for {
+            first <- uuid
+            second <- uuid
+            value <- uuid
+            _ <- sAdd(first)("a")
+            _ <- set(second, value, None, None, None)
+            inter <- sInter(first, List(second)).either
+          } yield assert(inter)(isLeft(isSubtype[WrongType](anything)))
+        }
       )
     )
 }


### PR DESCRIPTION
This PR resolves #63.

**Summary:** Implement tests for the sets API.

**Notes:**
1. Looks like `SSCAN` command is missing `key` parameter.
2. Some of the tests for `SPOP` are failing for an unknown reason. From what I can tell, something breaks when parsing output.
3. Tests for `SRANDMEMBER` are failing when there is no count, i.e. output consists of only one element.