### PR TITLE
Add missing lists commands

### DIFF
--- a/redis/src/main/scala/zio/redis/Input.scala
+++ b/redis/src/main/scala/zio/redis/Input.scala
@@ -73,6 +73,10 @@ object Input {
     def encode(data: Count): Chunk[String] = Chunk(wrap("COUNT"), wrap(data.count.toString))
   }
 
+  case object PositionInput extends Input[Position] {
+    def encode(data: Position): Chunk[String] = Chunk.single(wrap(data.stringify))
+  }
+
   case object DoubleInput extends Input[Double] {
     def encode(data: Double): Chunk[String] = Chunk.single(wrap(data.toString))
   }

--- a/redis/src/main/scala/zio/redis/Output.scala
+++ b/redis/src/main/scala/zio/redis/Output.scala
@@ -146,6 +146,18 @@ object Output {
     }
   }
 
+  case class BLPopOutput extends Output[(String, String)] {
+    protected def tryDecode(text: String): (String, String) =
+      if (text.startsWith("*2"))
+        parse(text)
+      else
+        throw ProtocolError(s"$text isn't blPop output.")
+
+    private[this] def parse(text: String): (String, String) = {
+      val items = unsafeReadChunk(text, 0)
+      (items(0), items(1))
+  }
+
   case object StringOutput extends Output[String] {
     protected def tryDecode(text: String): String =
       if (text.startsWith("+"))

--- a/redis/src/main/scala/zio/redis/Output.scala
+++ b/redis/src/main/scala/zio/redis/Output.scala
@@ -146,16 +146,19 @@ object Output {
     }
   }
 
-  case class BLPopOutput extends Output[(String, String)] {
-    protected def tryDecode(text: String): (String, String) =
-      if (text.startsWith("*2"))
-        parse(text)
+  case object BLPopOutput extends Output[Option[(String, String)]] {
+    protected def tryDecode(text: String): Option[(String, String)] =
+      if (text.startsWith("*-1\r\n"))
+        None
+      else if (text.startsWith("*2\r\n"))
+        Some(parse(text))
       else
         throw ProtocolError(s"$text isn't blPop output.")
 
     private[this] def parse(text: String): (String, String) = {
       val items = unsafeReadChunk(text, 0)
       (items(0), items(1))
+    }
   }
 
   case object StringOutput extends Output[String] {

--- a/redis/src/main/scala/zio/redis/Output.scala
+++ b/redis/src/main/scala/zio/redis/Output.scala
@@ -146,7 +146,7 @@ object Output {
     }
   }
 
-  case object BLPopOutput extends Output[Option[(String, String)]] {
+  case object KeyElemOutput extends Output[Option[(String, String)]] {
     protected def tryDecode(text: String): Option[(String, String)] =
       if (text.startsWith("*-1\r\n"))
         None

--- a/redis/src/main/scala/zio/redis/RedisCommand.scala
+++ b/redis/src/main/scala/zio/redis/RedisCommand.scala
@@ -71,7 +71,8 @@ object RedisCommand {
       command.run((a, b, (c, cs.toList), d, e))
   }
 
-  implicit final class VarargsArg1[-A, -B, +Out](private val command: RedisCommand[((A, List[A]), B), Out]) extends AnyVal {
+  implicit final class VarargsArg1[-A, -B, +Out](private val command: RedisCommand[((A, List[A]), B), Out])
+      extends AnyVal {
     def apply(a: A, as: A*)(b: B): ZIO[RedisExecutor, RedisError, Out] = command.run(((a, as.toList), b))
   }
 }

--- a/redis/src/main/scala/zio/redis/RedisCommand.scala
+++ b/redis/src/main/scala/zio/redis/RedisCommand.scala
@@ -70,4 +70,8 @@ object RedisCommand {
     def apply(a: A, b: B)(c: C, cs: C*)(d: D, e: E): ZIO[RedisExecutor, RedisError, Out] =
       command.run((a, b, (c, cs.toList), d, e))
   }
+
+  implicit final class VarargsArg1[-A, -B, +Out](private val command: RedisCommand[((A, List[A]), B), Out]) extends AnyVal {
+    def apply(a: A, as: A*)(b: B): ZIO[RedisExecutor, RedisError, Out] = command.run(((a, as.toList), b))
+  }
 }

--- a/redis/src/main/scala/zio/redis/api/Lists.scala
+++ b/redis/src/main/scala/zio/redis/api/Lists.scala
@@ -26,5 +26,7 @@ trait Lists {
   final val rPush     = RedisCommand("RPUSH", Tuple2(StringInput, NonEmptyList(StringInput)), LongOutput)
   final val rPushX    = RedisCommand("RPUSHX", Tuple2(StringInput, NonEmptyList(StringInput)), LongOutput)
   final val blPop     =
-    RedisCommand("BLPOP", Tuple2(NonEmptyList(StringInput), DurationSecondsInput), BLPopOutput)
+    RedisCommand("BLPOP", Tuple2(NonEmptyList(StringInput), DurationSecondsInput), KeyElemOutput)
+  final val brPop     =
+    RedisCommand("BRPOP", Tuple2(NonEmptyList(StringInput), DurationSecondsInput), KeyElemOutput)
 }

--- a/redis/src/main/scala/zio/redis/api/Lists.scala
+++ b/redis/src/main/scala/zio/redis/api/Lists.scala
@@ -25,4 +25,6 @@ trait Lists {
   final val rPopLPush = RedisCommand("RPOPLPUSH", Tuple2(StringInput, StringInput), OptionalOutput(MultiStringOutput))
   final val rPush     = RedisCommand("RPUSH", Tuple2(StringInput, NonEmptyList(StringInput)), LongOutput)
   final val rPushX    = RedisCommand("RPUSHX", Tuple2(StringInput, NonEmptyList(StringInput)), LongOutput)
+  final val blPop     =
+    RedisCommand("BLPOP", Tuple2(NonEmptyList(StringInput), TimeSecondsInput), OptionalOutput(BLPopOutput))
 }

--- a/redis/src/main/scala/zio/redis/api/Lists.scala
+++ b/redis/src/main/scala/zio/redis/api/Lists.scala
@@ -29,4 +29,6 @@ trait Lists {
     RedisCommand("BLPOP", Tuple2(NonEmptyList(StringInput), DurationSecondsInput), KeyElemOutput)
   final val brPop     =
     RedisCommand("BRPOP", Tuple2(NonEmptyList(StringInput), DurationSecondsInput), KeyElemOutput)
+  final val lInsert   =
+    RedisCommand("LINSERT", Tuple4(StringInput, PositionInput, StringInput, StringInput), LongOutput)
 }

--- a/redis/src/main/scala/zio/redis/api/Lists.scala
+++ b/redis/src/main/scala/zio/redis/api/Lists.scala
@@ -26,5 +26,5 @@ trait Lists {
   final val rPush     = RedisCommand("RPUSH", Tuple2(StringInput, NonEmptyList(StringInput)), LongOutput)
   final val rPushX    = RedisCommand("RPUSHX", Tuple2(StringInput, NonEmptyList(StringInput)), LongOutput)
   final val blPop     =
-    RedisCommand("BLPOP", Tuple2(NonEmptyList(StringInput), TimeSecondsInput), OptionalOutput(BLPopOutput))
+    RedisCommand("BLPOP", Tuple2(NonEmptyList(StringInput), DurationSecondsInput), BLPopOutput)
 }

--- a/redis/src/main/scala/zio/redis/options/Lists.scala
+++ b/redis/src/main/scala/zio/redis/options/Lists.scala
@@ -10,7 +10,7 @@ trait Lists {
   }
 
   object Position {
-    final case object Before extends Position
-    final case object After  extends Position
+    case object Before extends Position
+    case object After  extends Position
   }
 }

--- a/redis/src/main/scala/zio/redis/options/Lists.scala
+++ b/redis/src/main/scala/zio/redis/options/Lists.scala
@@ -1,0 +1,16 @@
+package zio.redis.options
+
+trait Lists {
+  sealed trait Position { self =>
+    private[redis] final def stringify: String =
+      self match {
+        case Position.Before => "BEFORE"
+        case Position.After  => "AFTER"
+      }
+  }
+
+  object Position {
+    final case object Before extends Position
+    final case object After  extends Position
+  }
+}

--- a/redis/src/main/scala/zio/redis/package.scala
+++ b/redis/src/main/scala/zio/redis/package.scala
@@ -15,4 +15,5 @@ package object redis
     with options.Shared
     with options.SortedSets
     with options.Strings
+    with options.Lists
     with Interpreter

--- a/redis/src/test/scala/zio/redis/ListSpec.scala
+++ b/redis/src/test/scala/zio/redis/ListSpec.scala
@@ -418,6 +418,50 @@ trait ListSpec extends BaseSpec {
             poped <- blPop(key)(1.seconds).either
           } yield assert(poped)(isLeft)
         }
+      ),
+      suite("brPop")(
+        testM("from single list") {
+          for {
+            key <- uuid
+            _ <- lPush(key)("a", "b", "c")
+            oPoped <- brPop(key)(1.seconds)
+            poped <- ZIO.fromOption(oPoped)
+            (src, elem) = poped
+          } yield assert(src)(equalTo(key)) &&
+            assert(elem)(equalTo("a"))
+        },
+        testM("from one empty and one non-empty list") {
+          for {
+            empty <- uuid
+            nonEmpty <- uuid
+            _ <- lPush(nonEmpty)("a", "b", "c")
+            oPoped <- brPop(empty, nonEmpty)(1.seconds)
+            poped <- ZIO.fromOption(oPoped)
+            (src, elem) = poped
+          } yield assert(src)(equalTo(nonEmpty)) &&
+            assert(elem)(equalTo("a"))
+        },
+        testM("from one empty list") {
+          for {
+            key <- uuid
+            poped <- brPop(key)(1.seconds)
+          } yield assert(poped)(isNone)
+        },
+        testM("from multiple empty lists") {
+          for {
+            first <- uuid
+            second <- uuid
+            poped <- brPop(first, second)(1.seconds)
+          } yield assert(poped)(isNone)
+        },
+        testM("from not list") {
+          for {
+            key <- uuid
+            value <- uuid
+            _ <- set(key, value, None, None, None)
+            poped <- brPop(key)(1.seconds).either
+          } yield assert(poped)(isLeft)
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/ListSpec.scala
+++ b/redis/src/test/scala/zio/redis/ListSpec.scala
@@ -381,8 +381,8 @@ trait ListSpec extends BaseSpec {
           for {
             key        <- uuid
             _          <- lPush(key)("a", "b", "c")
-            poped      <- blPop(key)(1.second).some
-            (src, elem) = poped
+            popped     <- blPop(key)(1.second).some
+            (src, elem) = popped
           } yield assert(src)(equalTo(key)) &&
             assert(elem)(equalTo("c"))
         },
@@ -391,40 +391,40 @@ trait ListSpec extends BaseSpec {
             empty      <- uuid
             nonEmpty   <- uuid
             _          <- lPush(nonEmpty)("a", "b", "c")
-            poped      <- blPop(empty, nonEmpty)(1.second).some
-            (src, elem) = poped
+            popped     <- blPop(empty, nonEmpty)(1.second).some
+            (src, elem) = popped
           } yield assert(src)(equalTo(nonEmpty)) &&
             assert(elem)(equalTo("c"))
         },
         testM("from one empty list") {
           for {
-            key   <- uuid
-            poped <- blPop(key)(1.second)
-          } yield assert(poped)(isNone)
+            key    <- uuid
+            popped <- blPop(key)(1.second)
+          } yield assert(popped)(isNone)
         },
         testM("from multiple empty lists") {
           for {
             first  <- uuid
             second <- uuid
-            poped  <- blPop(first, second)(1.second)
-          } yield assert(poped)(isNone)
+            popped <- blPop(first, second)(1.second)
+          } yield assert(popped)(isNone)
         },
         testM("from non-empty list with timeout 0s") {
           for {
             key        <- uuid
             _          <- lPush(key)("a", "b", "c")
-            poped      <- blPop(key)(0.seconds).some
-            (src, elem) = poped
+            popped     <- blPop(key)(0.seconds).some
+            (src, elem) = popped
           } yield assert(src)(equalTo(key)) &&
             assert(elem)(equalTo("c"))
         },
         testM("from not list") {
           for {
-            key   <- uuid
-            value <- uuid
-            _     <- set(key, value, None, None, None)
-            poped <- blPop(key)(1.second).either
-          } yield assert(poped)(isLeft(isSubtype[WrongType](anything)))
+            key    <- uuid
+            value  <- uuid
+            _      <- set(key, value, None, None, None)
+            popped <- blPop(key)(1.second).either
+          } yield assert(popped)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
       suite("brPop")(
@@ -432,8 +432,8 @@ trait ListSpec extends BaseSpec {
           for {
             key        <- uuid
             _          <- lPush(key)("a", "b", "c")
-            poped      <- brPop(key)(1.second).some
-            (src, elem) = poped
+            popped     <- brPop(key)(1.second).some
+            (src, elem) = popped
           } yield assert(src)(equalTo(key)) &&
             assert(elem)(equalTo("a"))
         },
@@ -442,40 +442,40 @@ trait ListSpec extends BaseSpec {
             empty      <- uuid
             nonEmpty   <- uuid
             _          <- lPush(nonEmpty)("a", "b", "c")
-            poped      <- brPop(empty, nonEmpty)(1.second).some
-            (src, elem) = poped
+            popped     <- brPop(empty, nonEmpty)(1.second).some
+            (src, elem) = popped
           } yield assert(src)(equalTo(nonEmpty)) &&
             assert(elem)(equalTo("a"))
         },
         testM("from one empty list") {
           for {
-            key   <- uuid
-            poped <- brPop(key)(1.second)
-          } yield assert(poped)(isNone)
+            key    <- uuid
+            popped <- brPop(key)(1.second)
+          } yield assert(popped)(isNone)
         },
         testM("from multiple empty lists") {
           for {
             first  <- uuid
             second <- uuid
-            poped  <- brPop(first, second)(1.second)
-          } yield assert(poped)(isNone)
+            popped <- brPop(first, second)(1.second)
+          } yield assert(popped)(isNone)
         },
         testM("from non-empty list with timeout 0s") {
           for {
             key        <- uuid
             _          <- lPush(key)("a", "b", "c")
-            poped      <- brPop(key)(0.seconds).some
-            (src, elem) = poped
+            popped     <- brPop(key)(0.seconds).some
+            (src, elem) = popped
           } yield assert(src)(equalTo(key)) &&
             assert(elem)(equalTo("a"))
         },
         testM("from not list") {
           for {
-            key   <- uuid
-            value <- uuid
-            _     <- set(key, value, None, None, None)
-            poped <- brPop(key)(1.second).either
-          } yield assert(poped)(isLeft(isSubtype[WrongType](anything)))
+            key    <- uuid
+            value  <- uuid
+            _      <- set(key, value, None, None, None)
+            popped <- brPop(key)(1.second).either
+          } yield assert(popped)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
       suite("lInsert")(

--- a/redis/src/test/scala/zio/redis/OutputSpec.scala
+++ b/redis/src/test/scala/zio/redis/OutputSpec.scala
@@ -213,8 +213,32 @@ object OutputSpec extends BaseSpec {
           } yield assert(res)(isSome(equalTo(("key", "a"))))
         },
         testM("report invalid input as protocol error") {
+          val input = "*3\r\n$1\r\n1\r\n$1\r\n2\r\n$1\r\n3\r\n"
           for {
-            res <- Task(KeyElemOutput.unsafeDecode("*3\r\n$1\r\n1\r\n$1\r\n2\r\n$1\r\n3\r\n")).either
+            res <- Task(KeyElemOutput.unsafeDecode(input)).either
+          } yield assert(res)(isLeft(isSubtype[ProtocolError](anything)))
+        }
+      ),
+      suite("multiStringChunk")(
+        testM("extract one empty value") {
+          for {
+            res <- Task(MultiStringChunkOutput.unsafeDecode("$-1\r\n"))
+          } yield assert(res)(isEmpty)
+        },
+        testM("extract one multi-string value") {
+          for {
+            res <- Task(MultiStringChunkOutput.unsafeDecode("$2\r\nab\r\n"))
+          } yield assert(res)(hasSameElements(Chunk("ab")))
+        },
+        testM("extract one array value") {
+          val input = "*3\r\n$1\r\n1\r\n$1\r\n2\r\n$1\r\n3\r\n"
+          for {
+            res <- Task(MultiStringChunkOutput.unsafeDecode(input))
+          } yield assert(res)(hasSameElements(Chunk("1", "2", "3")))
+        },
+        testM("error when extracting from an invalid value") {
+          for {
+            res <- Task(MultiStringChunkOutput.unsafeDecode("invalid")).either
           } yield assert(res)(isLeft(isSubtype[ProtocolError](anything)))
         }
       )

--- a/redis/src/test/scala/zio/redis/OutputSpec.scala
+++ b/redis/src/test/scala/zio/redis/OutputSpec.scala
@@ -200,6 +200,23 @@ object OutputSpec extends BaseSpec {
             res <- Task(UnitOutput.unsafeDecode(Noise)).either
           } yield assert(res)(isLeft(equalTo(ProtocolError(s"$Noise isn't unit."))))
         }
+      ),
+      suite("keyElem")(
+        testM("extract none") {
+          for {
+            res <- Task(KeyElemOutput.unsafeDecode(s"*-1\r\n"))
+          } yield assert(res)(isNone)
+        },
+        testM("extract key and element") {
+          for {
+            res <- Task(KeyElemOutput.unsafeDecode("*2\r\n$3\r\nkey\r\n$1\r\na\r\n"))
+          } yield assert(res)(isSome(equalTo(("key", "a"))))
+        },
+        testM("report invalid input as protocol error") {
+          for {
+            res <- Task(KeyElemOutput.unsafeDecode("*3\r\n$1\r\n1\r\n$1\r\n2\r\n$1\r\n3\r\n")).either
+          } yield assert(res)(isLeft(isSubtype[ProtocolError](anything)))
+        }
       )
     )
 

--- a/redis/src/test/scala/zio/redis/SetsSpec.scala
+++ b/redis/src/test/scala/zio/redis/SetsSpec.scala
@@ -464,52 +464,52 @@ trait SetsSpec extends BaseSpec {
       suite("sPop")(
         testM("one element from non-empty set") {
           for {
-            key   <- uuid
-            _     <- sAdd(key)("a", "b", "c")
-            poped <- sPop(key, None)
-          } yield assert(poped)(isNonEmpty)
+            key    <- uuid
+            _      <- sAdd(key)("a", "b", "c")
+            popped <- sPop(key, None)
+          } yield assert(popped)(isNonEmpty)
         },
         testM("one element from an empty set") {
           for {
-            key   <- uuid
-            poped <- sPop(key, None)
-          } yield assert(poped)(isEmpty)
+            key    <- uuid
+            popped <- sPop(key, None)
+          } yield assert(popped)(isEmpty)
         },
         testM("error when poping one element from not set") {
           for {
-            key   <- uuid
-            value <- uuid
-            _     <- set(key, value, None, None, None)
-            poped <- sPop(key, None).either
-          } yield assert(poped)(isLeft(isSubtype[WrongType](anything)))
+            key    <- uuid
+            value  <- uuid
+            _      <- set(key, value, None, None, None)
+            popped <- sPop(key, None).either
+          } yield assert(popped)(isLeft(isSubtype[WrongType](anything)))
         },
         testM("multiple elements from non-empty set") {
           for {
-            key   <- uuid
-            _     <- sAdd(key)("a", "b", "c")
-            poped <- sPop(key, Some(2L))
-          } yield assert(poped)(hasSize(equalTo(2)))
+            key    <- uuid
+            _      <- sAdd(key)("a", "b", "c")
+            popped <- sPop(key, Some(2L))
+          } yield assert(popped)(hasSize(equalTo(2)))
         },
         testM("more elements then there is in non-empty set") {
           for {
-            key   <- uuid
-            _     <- sAdd(key)("a", "b", "c")
-            poped <- sPop(key, Some(5L))
-          } yield assert(poped)(hasSize(equalTo(3)))
+            key    <- uuid
+            _      <- sAdd(key)("a", "b", "c")
+            popped <- sPop(key, Some(5L))
+          } yield assert(popped)(hasSize(equalTo(3)))
         },
         testM("multiple elements from empty set") {
           for {
-            key   <- uuid
-            poped <- sPop(key, Some(3))
-          } yield assert(poped)(isEmpty)
+            key    <- uuid
+            popped <- sPop(key, Some(3))
+          } yield assert(popped)(isEmpty)
         },
         testM("error when poping multiple elements from not set") {
           for {
-            key   <- uuid
-            value <- uuid
-            _     <- set(key, value, None, None, None)
-            poped <- sPop(key, Some(3)).either
-          } yield assert(poped)(isLeft(isSubtype[WrongType](anything)))
+            key    <- uuid
+            value  <- uuid
+            _      <- set(key, value, None, None, None)
+            popped <- sPop(key, Some(3)).either
+          } yield assert(popped)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
       suite("sRandMember")(


### PR DESCRIPTION
This PR resolves #10.

**Summary:**
1. Added `BLPOP` command and tests for it.
2. Added `BRPOP` command and tests for it.
3. Added `LINSERT` command and tests for it.
4. Added `KeyElemOutput` and added tests for it.
5. Added tests for `MultiStringChunkOutput`.