### PR TITLE
Test strings API

### DIFF
--- a/redis/src/main/scala/zio/redis/Input.scala
+++ b/redis/src/main/scala/zio/redis/Input.scala
@@ -92,6 +92,13 @@ object Input {
     }
   }
 
+  case object DurationTTLInput extends Input[Duration] {
+    def encode(data: Duration): Chunk[String] = {
+      val milliseconds = data.toMillis
+      Chunk(wrap("PX"), wrap(milliseconds.toString))
+    }
+  }
+
   case object FreqInput extends Input[Freq] {
     def encode(data: Freq): Chunk[String] = Chunk(wrap("FREQ"), wrap(data.frequency))
   }

--- a/redis/src/main/scala/zio/redis/RedisCommand.scala
+++ b/redis/src/main/scala/zio/redis/RedisCommand.scala
@@ -64,6 +64,12 @@ object RedisCommand {
     def apply(a: A)(b: B, bs: B*)(c: C): ZIO[RedisExecutor, RedisError, Out] = command.run((a, (b, bs.toList), c))
   }
 
+  implicit final class Arg2Varargs[-A, -B, -C, +Out](
+    private val command: RedisCommand[(A, B, (C, List[C])), Out]
+  ) extends AnyVal {
+    def apply(a: A, b: B)(c: C, cs: C*): ZIO[RedisExecutor, RedisError, Out] = command.run((a, b, (c, cs.toList)))
+  }
+
   implicit final class Arg2VarargsArg2[-A, -B, -C, -D, -E, +Out](
     private val command: RedisCommand[(A, B, (C, List[C]), D, E), Out]
   ) extends AnyVal {

--- a/redis/src/main/scala/zio/redis/RedisCommand.scala
+++ b/redis/src/main/scala/zio/redis/RedisCommand.scala
@@ -54,6 +54,10 @@ object RedisCommand {
       command.run((a, b, c, d, e, f, g, h, i, j, k))
   }
 
+  implicit final class Varargs[-A, -B, +Out](private val command: RedisCommand[(A, List[A]), Out]) extends AnyVal {
+    def apply(a: A, as: A*): ZIO[RedisExecutor, RedisError, Out] = command.run((a, as.toList))
+  }
+
   implicit final class Arg1Varargs[-A, -B, +Out](private val command: RedisCommand[(A, (B, List[B])), Out])
       extends AnyVal {
     def apply(a: A)(b: B, bs: B*): ZIO[RedisExecutor, RedisError, Out] = command.run((a, (b, bs.toList)))

--- a/redis/src/main/scala/zio/redis/api/Strings.scala
+++ b/redis/src/main/scala/zio/redis/api/Strings.scala
@@ -52,7 +52,7 @@ trait Strings {
     OptionalOutput(UnitOutput)
   )
 
-  final val setBit   = RedisCommand("SETBIT", Tuple3(StringInput, LongInput, StringInput), LongOutput)
+  final val setBit   = RedisCommand("SETBIT", Tuple3(StringInput, LongInput, BoolInput), BoolOutput)
   final val setEx    = RedisCommand("SETEX", Tuple3(StringInput, DurationSecondsInput, StringInput), UnitOutput)
   final val setNx    = RedisCommand("SETNX", Tuple2(StringInput, StringInput), BoolOutput)
   final val setRange = RedisCommand("SETRANGE", Tuple3(StringInput, LongInput, StringInput), LongOutput)

--- a/redis/src/main/scala/zio/redis/api/Strings.scala
+++ b/redis/src/main/scala/zio/redis/api/Strings.scala
@@ -45,7 +45,7 @@ trait Strings {
     Tuple5(
       StringInput,
       StringInput,
-      OptionalInput(DurationSecondsInput),
+      OptionalInput(DurationTTLInput),
       OptionalInput(UpdateInput),
       OptionalInput(KeepTtlInput)
     ),

--- a/redis/src/main/scala/zio/redis/api/Strings.scala
+++ b/redis/src/main/scala/zio/redis/api/Strings.scala
@@ -35,7 +35,7 @@ trait Strings {
   final val incr        = RedisCommand("INCR", StringInput, LongOutput)
   final val incrBy      = RedisCommand("INCRBY", Tuple2(StringInput, LongInput), LongOutput)
   final val incrByFloat = RedisCommand("INCRBYFLOAT", Tuple2(StringInput, DoubleInput), MultiStringOutput)
-  final val mGet        = RedisCommand("MGET", NonEmptyList(StringInput), ChunkOutput)
+  final val mGet        = RedisCommand("MGET", NonEmptyList(StringInput), ChunkOptionalMultiStringOutput)
   final val mSet        = RedisCommand("MSET", NonEmptyList(Tuple2(StringInput, StringInput)), UnitOutput)
   final val mSetNx      = RedisCommand("MSETNX", NonEmptyList(Tuple2(StringInput, StringInput)), BoolOutput)
   final val pSetEx      = RedisCommand("PSETEX", Tuple3(StringInput, DurationMillisecondsInput, StringInput), UnitOutput)

--- a/redis/src/main/scala/zio/redis/options/Strings.scala
+++ b/redis/src/main/scala/zio/redis/options/Strings.scala
@@ -42,6 +42,7 @@ trait Strings {
         case BitOperation.AND => "AND"
         case BitOperation.OR  => "OR"
         case BitOperation.XOR => "XOR"
+        case BitOperation.NOT => "NOT"
       }
   }
 
@@ -49,6 +50,7 @@ trait Strings {
     case object AND extends BitOperation
     case object OR  extends BitOperation
     case object XOR extends BitOperation
+    case object NOT extends BitOperation
   }
 
   sealed case class BitPosRange(start: Long, end: Option[Long])

--- a/redis/src/test/scala/zio/redis/ApiSpec.scala
+++ b/redis/src/test/scala/zio/redis/ApiSpec.scala
@@ -3,13 +3,14 @@ package zio.redis
 import zio.test._
 import zio.clock.Clock
 
-object ApiSpec extends KeysSpec with ListSpec with SetsSpec with GeoSpec with HyperLogLogSpec {
+object ApiSpec extends KeysSpec with ListSpec with SetsSpec with StringsSpec with GeoSpec with HyperLogLogSpec {
 
   def spec =
     suite("Redis commands")(
       keysSuite,
       listSuite,
       setsSuite,
+      stringsSuite,
       geoSuite,
       hyperLogLogSuite
     ).provideCustomLayerShared(Executor ++ Clock.live)

--- a/redis/src/test/scala/zio/redis/HyperLogLogSpec.scala
+++ b/redis/src/test/scala/zio/redis/HyperLogLogSpec.scala
@@ -33,14 +33,14 @@ trait HyperLogLogSpec extends BaseSpec {
       suite("count elements")(
         testM("pfCount zero at undefined key") {
           for {
-            count <- pfCount("noKey", Nil)
+            count <- pfCount("noKey")
           } yield assert(count)(equalTo(0L))
         },
         testM("pfCount values at key") {
           for {
             key   <- uuid
             add   <- pfAdd(key)("one", "two", "three")
-            count <- pfCount(key, Nil)
+            count <- pfCount(key)
           } yield assert(add)(equalTo(true)) && assert(count)(equalTo(3L))
         },
         testM("pfCount union key with key2") {
@@ -49,7 +49,7 @@ trait HyperLogLogSpec extends BaseSpec {
             key2  <- uuid
             add   <- pfAdd(key)("one", "two", "three")
             add2  <- pfAdd(key2)("four", "five", "six")
-            count <- pfCount(key, List(key2))
+            count <- pfCount(key, key2)
           } yield assert(add)(equalTo(true)) && assert(add2)(equalTo(true)) && assert(count)(equalTo(6L))
         },
         testM("error when not hyperloglog") {
@@ -57,7 +57,7 @@ trait HyperLogLogSpec extends BaseSpec {
             key   <- uuid
             value <- uuid
             _     <- set(key, value, None, None, None)
-            count <- pfCount(key, Nil).either
+            count <- pfCount(key).either
           } yield assert(count)(isLeft)
         }
       ),
@@ -70,7 +70,7 @@ trait HyperLogLogSpec extends BaseSpec {
             _     <- pfAdd(key)("one", "two", "three", "four")
             _     <- pfAdd(key2)("five", "six", "seven")
             _     <- pfMerge(key3)(key2, key)
-            count <- pfCount(key3, Nil)
+            count <- pfCount(key3)
           } yield assert(count)(equalTo(7L))
         },
         testM("pfMerge two hyperloglogs with already existing destination values") {
@@ -82,7 +82,7 @@ trait HyperLogLogSpec extends BaseSpec {
             _     <- pfAdd(key2)("five", "six", "seven")
             _     <- pfAdd(key3)("eight", "nine", "ten")
             _     <- pfMerge(key3)(key2, key)
-            count <- pfCount(key3, Nil)
+            count <- pfCount(key3)
           } yield assert(count)(equalTo(10L))
         },
         testM("pfMerge error when source not hyperloglog") {

--- a/redis/src/test/scala/zio/redis/KeysSpec.scala
+++ b/redis/src/test/scala/zio/redis/KeysSpec.scala
@@ -111,11 +111,10 @@ trait KeysSpec extends BaseSpec {
           for {
             key   <- uuid
             value <- uuid
-            _     <- set(key, value, None, None, None)
-            _     <- pExpire(key, 1000.millis)
+            _     <- pSetEx(key, 1000.millis, value)
             ttl   <- ttl(key).either
           } yield assert(ttl)(isRight)
-        },
+        } @@ eventually,
         testM("check ttl for non-existing key") {
           for {
             key <- uuid
@@ -126,11 +125,10 @@ trait KeysSpec extends BaseSpec {
           for {
             key   <- uuid
             value <- uuid
-            _     <- set(key, value, None, None, None)
-            _     <- pExpire(key, 1000.millis)
+            _     <- pSetEx(key, 1000.millis, value)
             pTtl  <- pTtl(key).either
           } yield assert(pTtl)(isRight)
-        },
+        } @@ eventually,
         testM("check pTtl for non-existing key") {
           for {
             key  <- uuid

--- a/redis/src/test/scala/zio/redis/KeysSpec.scala
+++ b/redis/src/test/scala/zio/redis/KeysSpec.scala
@@ -36,8 +36,8 @@ trait KeysSpec extends BaseSpec {
           key   <- uuid
           value <- uuid
           _     <- set(key, value, None, None, None)
-          e1    <- exists(key, Nil)
-          e2    <- exists("unknown", Nil)
+          e1    <- exists(key)
+          e2    <- exists("unknown")
         } yield assert(e1)(isTrue) && assert(e2)(isFalse)
       },
       testM("delete existing key") {
@@ -45,7 +45,7 @@ trait KeysSpec extends BaseSpec {
           key     <- uuid
           value   <- uuid
           _       <- set(key, value, None, None, None)
-          deleted <- del(key, Nil)
+          deleted <- del(key)
         } yield assert(deleted)(equalTo(1L))
       },
       testM("find all keys matching pattern") {
@@ -63,7 +63,7 @@ trait KeysSpec extends BaseSpec {
           key     <- uuid
           value   <- uuid
           _       <- set(key, value, None, None, None)
-          removed <- unlink(key, Nil)
+          removed <- unlink(key)
         } yield assert(removed)(equalTo(1L))
       },
       testM("touch two existing keys") {
@@ -74,7 +74,7 @@ trait KeysSpec extends BaseSpec {
           key2    <- uuid
           value2  <- uuid
           _       <- set(key2, value2, None, None, None)
-          touched <- touch(key1, List(key2))
+          touched <- touch(key1, key2)
         } yield assert(touched)(equalTo(2L))
       },
       testM("scan entries") {
@@ -101,7 +101,7 @@ trait KeysSpec extends BaseSpec {
           value    <- uuid
           _        <- set(key, value, None, None, None)
           dumped   <- dump(key)
-          _        <- del(key, Nil)
+          _        <- del(key)
           restore  <- restore(key, 0L, dumped, None, None, None, None).either
           restored <- get(key)
         } yield assert(restore)(isRight) && assert(restored)(isSome(equalTo(value)))
@@ -145,9 +145,9 @@ trait KeysSpec extends BaseSpec {
             value     <- uuid
             _         <- set(key, value, None, None, None)
             exp       <- pExpire(key, 2000.millis)
-            response1 <- exists(key, Nil)
+            response1 <- exists(key)
             _         <- ZIO.sleep(2050.millis)
-            response2 <- exists(key, Nil)
+            response2 <- exists(key)
           } yield assert(exp)(isTrue) && assert(response1)(isTrue) && assert(response2)(isFalse)
         } @@ eventually,
         testM("set key expiration with pExpireAt command") {
@@ -157,9 +157,9 @@ trait KeysSpec extends BaseSpec {
             expiresAt <- instantOf(2000)
             _         <- set(key, value, None, None, None)
             exp       <- pExpireAt(key, expiresAt)
-            response1 <- exists(key, Nil)
+            response1 <- exists(key)
             _         <- ZIO.sleep(2050.millis)
-            response2 <- exists(key, Nil)
+            response2 <- exists(key)
           } yield assert(exp)(isTrue) && assert(response1)(isTrue) && assert(response2)(isFalse)
         } @@ eventually,
         testM("expire followed by persist") {
@@ -178,9 +178,9 @@ trait KeysSpec extends BaseSpec {
             expiresAt <- instantOf(2000)
             _         <- set(key, value, None, None, None)
             exp       <- expireAt(key, expiresAt)
-            response1 <- exists(key, Nil)
+            response1 <- exists(key)
             _         <- ZIO.sleep(2050.millis)
-            response2 <- exists(key, Nil)
+            response2 <- exists(key)
           } yield assert(exp)(isTrue) && assert(response1)(isTrue) && assert(response2)(isFalse)
         } @@ eventually
       ),

--- a/redis/src/test/scala/zio/redis/SetsSpec.scala
+++ b/redis/src/test/scala/zio/redis/SetsSpec.scala
@@ -71,7 +71,7 @@ trait SetsSpec extends BaseSpec {
             second <- uuid
             _      <- sAdd(first)("a", "b", "c", "d")
             _      <- sAdd(second)("a", "c")
-            diff   <- sDiff(first, List(second))
+            diff   <- sDiff(first, second)
           } yield assert(diff)(hasSameElements(Chunk("b", "d")))
         },
         testM("non-empty set and empty set") {
@@ -79,7 +79,7 @@ trait SetsSpec extends BaseSpec {
             nonEmpty <- uuid
             empty    <- uuid
             _        <- sAdd(nonEmpty)("a", "b")
-            diff     <- sDiff(nonEmpty, List(empty))
+            diff     <- sDiff(nonEmpty, empty)
           } yield assert(diff)(hasSameElements(Chunk("a", "b")))
         },
         testM("empty set and non-empty set") {
@@ -87,14 +87,14 @@ trait SetsSpec extends BaseSpec {
             empty    <- uuid
             nonEmpty <- uuid
             _        <- sAdd(nonEmpty)("a", "b")
-            diff     <- sDiff(empty, List(nonEmpty))
+            diff     <- sDiff(empty, nonEmpty)
           } yield assert(diff)(isEmpty)
         },
         testM("empty when both sets are empty") {
           for {
             first  <- uuid
             second <- uuid
-            diff   <- sDiff(first, List(second))
+            diff   <- sDiff(first, second)
           } yield assert(diff)(isEmpty)
         },
         testM("non-empty set with multiple non-empty sets") {
@@ -105,7 +105,7 @@ trait SetsSpec extends BaseSpec {
             _      <- sAdd(first)("a", "b", "c", "d")
             _      <- sAdd(second)("b", "d")
             _      <- sAdd(third)("b", "c")
-            diff   <- sDiff(first, List(second, third))
+            diff   <- sDiff(first, second, third)
           } yield assert(diff)(hasSameElements(Chunk("a")))
         },
         testM("error when first parameter is not set") {
@@ -114,7 +114,7 @@ trait SetsSpec extends BaseSpec {
             second <- uuid
             value  <- uuid
             _      <- set(first, value, None, None, None)
-            diff   <- sDiff(first, List(second)).either
+            diff   <- sDiff(first, second).either
           } yield assert(diff)(isLeft(isSubtype[WrongType](anything)))
         },
         testM("error when second parameter is not set") {
@@ -123,7 +123,7 @@ trait SetsSpec extends BaseSpec {
             second <- uuid
             value  <- uuid
             _      <- set(second, value, None, None, None)
-            diff   <- sDiff(first, List(second)).either
+            diff   <- sDiff(first, second).either
           } yield assert(diff)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
@@ -204,7 +204,7 @@ trait SetsSpec extends BaseSpec {
             second <- uuid
             _      <- sAdd(first)("a", "b", "c", "d")
             _      <- sAdd(second)("a", "c", "e")
-            inter  <- sInter(first, List(second))
+            inter  <- sInter(first, second)
           } yield assert(inter)(hasSameElements(Chunk("a", "c")))
         },
         testM("empty when one of the sets is empty") {
@@ -212,14 +212,14 @@ trait SetsSpec extends BaseSpec {
             nonEmpty <- uuid
             empty    <- uuid
             _        <- sAdd(nonEmpty)("a", "b")
-            inter    <- sInter(nonEmpty, List(empty))
+            inter    <- sInter(nonEmpty, empty)
           } yield assert(inter)(isEmpty)
         },
         testM("empty when both sets are empty") {
           for {
             first  <- uuid
             second <- uuid
-            inter  <- sInter(first, List(second))
+            inter  <- sInter(first, second)
           } yield assert(inter)(isEmpty)
         },
         testM("non-empty set with multiple non-empty sets") {
@@ -230,7 +230,7 @@ trait SetsSpec extends BaseSpec {
             _      <- sAdd(first)("a", "b", "c", "d")
             _      <- sAdd(second)("b", "d")
             _      <- sAdd(third)("b", "c")
-            inter  <- sInter(first, List(second, third))
+            inter  <- sInter(first, second, third)
           } yield assert(inter)(hasSameElements(Chunk("b")))
         },
         testM("error when first parameter is not set") {
@@ -239,7 +239,7 @@ trait SetsSpec extends BaseSpec {
             second <- uuid
             value  <- uuid
             _      <- set(first, value, None, None, None)
-            inter  <- sInter(first, List(second)).either
+            inter  <- sInter(first, second).either
           } yield assert(inter)(isLeft(isSubtype[WrongType](anything)))
         },
         testM("empty with empty first set and second parameter is not set") {
@@ -248,7 +248,7 @@ trait SetsSpec extends BaseSpec {
             second <- uuid
             value  <- uuid
             _      <- set(second, value, None, None, None)
-            inter  <- sInter(first, List(second))
+            inter  <- sInter(first, second)
           } yield assert(inter)(isEmpty)
         },
         testM("error with non-empty first set and second parameter is not set") {
@@ -258,7 +258,7 @@ trait SetsSpec extends BaseSpec {
             value  <- uuid
             _      <- sAdd(first)("a")
             _      <- set(second, value, None, None, None)
-            inter  <- sInter(first, List(second)).either
+            inter  <- sInter(first, second).either
           } yield assert(inter)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
@@ -620,7 +620,7 @@ trait SetsSpec extends BaseSpec {
             second <- uuid
             _      <- sAdd(first)("a", "b", "c", "d")
             _      <- sAdd(second)("a", "c", "e")
-            union  <- sUnion(first, List(second))
+            union  <- sUnion(first, second)
           } yield assert(union)(hasSameElements(Chunk("a", "b", "c", "d", "e")))
         },
         testM("equal to the non-empty set when the other one is empty") {
@@ -628,14 +628,14 @@ trait SetsSpec extends BaseSpec {
             nonEmpty <- uuid
             empty    <- uuid
             _        <- sAdd(nonEmpty)("a", "b")
-            union    <- sUnion(nonEmpty, List(empty))
+            union    <- sUnion(nonEmpty, empty)
           } yield assert(union)(hasSameElements(Chunk("a", "b")))
         },
         testM("empty when both sets are empty") {
           for {
             first  <- uuid
             second <- uuid
-            union  <- sUnion(first, List(second))
+            union  <- sUnion(first, second)
           } yield assert(union)(isEmpty)
         },
         testM("non-empty set with multiple non-empty sets") {
@@ -646,7 +646,7 @@ trait SetsSpec extends BaseSpec {
             _      <- sAdd(first)("a", "b", "c", "d")
             _      <- sAdd(second)("b", "d")
             _      <- sAdd(third)("b", "c", "e")
-            union  <- sUnion(first, List(second, third))
+            union  <- sUnion(first, second, third)
           } yield assert(union)(hasSameElements(Chunk("a", "b", "c", "d", "e")))
         },
         testM("error when first parameter is not set") {
@@ -655,7 +655,7 @@ trait SetsSpec extends BaseSpec {
             second <- uuid
             value  <- uuid
             _      <- set(first, value, None, None, None)
-            union  <- sUnion(first, List(second)).either
+            union  <- sUnion(first, second).either
           } yield assert(union)(isLeft(isSubtype[WrongType](anything)))
         },
         testM("error when the first parameter is set and the second parameter is not set") {
@@ -665,7 +665,7 @@ trait SetsSpec extends BaseSpec {
             value  <- uuid
             _      <- sAdd(first)("a")
             _      <- set(second, value, None, None, None)
-            union  <- sUnion(first, List(second)).either
+            union  <- sUnion(first, second).either
           } yield assert(union)(isLeft(isSubtype[WrongType](anything)))
         }
       ),

--- a/redis/src/test/scala/zio/redis/StringsSpec.scala
+++ b/redis/src/test/scala/zio/redis/StringsSpec.scala
@@ -541,6 +541,28 @@ trait StringsSpec extends BaseSpec {
             result <- decrBy(key, 3).either
           } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
         }
+      ),
+      suite("get")(
+        testM("non-emtpy string") {
+          for {
+            key    <- uuid
+            _      <- set(key, "value", None, None, None)
+            result <- get(key)
+          } yield assert(result)(isSome(equalTo("value")))
+        },
+        testM("emtpy string") {
+          for {
+            key    <- uuid
+            result <- get(key)
+          } yield assert(result)(isNone)
+        },
+        testM("error when not string") {
+          for {
+            key    <- uuid
+            _      <- sAdd(key)("a")
+            result <- get(key).either
+          } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/StringsSpec.scala
+++ b/redis/src/test/scala/zio/redis/StringsSpec.scala
@@ -1,0 +1,46 @@
+package zio.redis
+
+import zio.redis.RedisError.WrongType
+import zio.test._
+import zio.test.Assertion._
+
+trait StringsSpec extends BaseSpec {
+  val stringsSuite =
+    suite("strings")(
+      suite("append")(
+        testM("to the end of non-empty string") {
+          for {
+            key <- uuid
+            _   <- set(key, "val", None, None, None)
+            len <- append(key, "ue")
+          } yield assert(len)(equalTo(5L))
+        },
+        testM("to the end of empty string") {
+          for {
+            key <- uuid
+            len <- append(key, "value")
+          } yield assert(len)(equalTo(5L))
+        },
+        testM("empty value to the end of non-empty string") {
+          for {
+            key <- uuid
+            _   <- set(key, "value", None, None, None)
+            len <- append(key, "")
+          } yield assert(len)(equalTo(5L))
+        },
+        testM("empty value to the end of empty string") {
+          for {
+            key <- uuid
+            len <- append(key, "")
+          } yield assert(len)(equalTo(0L))
+        },
+        testM("error when not string") {
+          for {
+            key <- uuid
+            _   <- sAdd(key)("a")
+            len <- append(key, "b").either
+          } yield assert(len)(isLeft(isSubtype[WrongType](anything)))
+        }
+      )
+    )
+}

--- a/redis/src/test/scala/zio/redis/StringsSpec.scala
+++ b/redis/src/test/scala/zio/redis/StringsSpec.scala
@@ -41,6 +41,69 @@ trait StringsSpec extends BaseSpec {
             len <- append(key, "b").either
           } yield assert(len)(isLeft(isSubtype[WrongType](anything)))
         }
+      ),
+      suite("bitCount")(
+        testM("over non-empty string") {
+          for {
+            key   <- uuid
+            _     <- set(key, "value", None, None, None)
+            count <- bitCount(key, None)
+          } yield assert(count)(equalTo(21L))
+        },
+        testM("over empty string") {
+          for {
+            key   <- uuid
+            count <- bitCount(key, None)
+          } yield assert(count)(equalTo(0L))
+        },
+        testM("error when not string") {
+          for {
+            key   <- uuid
+            _     <- sAdd(key)("a")
+            count <- bitCount(key, None).either
+          } yield assert(count)(isLeft(isSubtype[WrongType](anything)))
+        },
+        testM("over non-empty string with range") {
+          for {
+            key   <- uuid
+            _     <- set(key, "value", None, None, None)
+            count <- bitCount(key, Some(1 to 3))
+          } yield assert(count)(equalTo(12L))
+        },
+        testM("over non-empty string with range that is too large") {
+          for {
+            key   <- uuid
+            _     <- set(key, "value", None, None, None)
+            count <- bitCount(key, Some(1 to 20))
+          } yield assert(count)(equalTo(16L))
+        },
+        testM("over non-empty string with range that ends with the string") {
+          for {
+            key   <- uuid
+            _     <- set(key, "value", None, None, None)
+            count <- bitCount(key, Some(1 to -1))
+          } yield assert(count)(equalTo(16L))
+        },
+        testM("over non-empty string with range whose start is bigger then end") {
+          for {
+            key   <- uuid
+            _     <- set(key, "value", None, None, None)
+            count <- bitCount(key, Some(3 to 1))
+          } yield assert(count)(equalTo(0L))
+        },
+        testM("over empty string with range") {
+          for {
+            key   <- uuid
+            count <- bitCount(key, Some(1 to 3))
+          } yield assert(count)(equalTo(0L))
+        },
+        testM("over not string with range") {
+          for {
+            key   <- uuid
+            _     <- sAdd(key)("a")
+            count <- bitCount(key, Some(1 to 3)).either
+          } yield assert(count)(isLeft(isSubtype[WrongType](anything)))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/StringsSpec.scala
+++ b/redis/src/test/scala/zio/redis/StringsSpec.scala
@@ -512,6 +512,35 @@ trait StringsSpec extends BaseSpec {
             result <- decr(key).either
           } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
         }
+      ),
+      suite("decrBy")(
+        testM("3 when non-empty integer") {
+          for {
+            key    <- uuid
+            _      <- set(key, "10", None, None, None)
+            result <- decrBy(key, 3L)
+          } yield assert(result)(equalTo(7L))
+        },
+        testM("3 when empty integer") {
+          for {
+            key    <- uuid
+            result <- decrBy(key, 3L)
+          } yield assert(result)(equalTo(-3L))
+        },
+        testM("error when out of range integer") {
+          for {
+            key    <- uuid
+            _      <- set(key, "234293482390480948029348230948", None, None, None)
+            result <- decrBy(key, 3).either
+          } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
+        },
+        testM("error when not integer") {
+          for {
+            key    <- uuid
+            _      <- set(key, "not-integer", None, None, None)
+            result <- decrBy(key, 3).either
+          } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/StringsSpec.scala
+++ b/redis/src/test/scala/zio/redis/StringsSpec.scala
@@ -697,6 +697,35 @@ trait StringsSpec extends BaseSpec {
             oldVal <- getSet(key, "value").either
           } yield assert(oldVal)(isLeft(isSubtype[WrongType](anything)))
         }
+      ),
+      suite("incr")(
+        testM("non-empty integer") {
+          for {
+            key    <- uuid
+            _      <- set(key, "5", None, None, None)
+            result <- incr(key)
+          } yield assert(result)(equalTo(6L))
+        },
+        testM("empty integer") {
+          for {
+            key    <- uuid
+            result <- incr(key)
+          } yield assert(result)(equalTo(1L))
+        },
+        testM("error when out of range integer") {
+          for {
+            key    <- uuid
+            _      <- set(key, "234293482390480948029348230948", None, None, None)
+            result <- incr(key).either
+          } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
+        },
+        testM("error when not integer") {
+          for {
+            key    <- uuid
+            _      <- set(key, "not-integer", None, None, None)
+            result <- incr(key).either
+          } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/StringsSpec.scala
+++ b/redis/src/test/scala/zio/redis/StringsSpec.scala
@@ -1173,6 +1173,31 @@ trait StringsSpec extends BaseSpec {
             result <- setEx(key, (-1).second, value).either
           } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
         }
+      ),
+      suite("setNx")(
+        testM("new value") {
+          for {
+            key    <- uuid
+            value  <- uuid
+            result <- setNx(key, value)
+          } yield assert(result)(isTrue)
+        },
+        testM("existing value") {
+          for {
+            key    <- uuid
+            value  <- uuid
+            _      <- set(key, "value", None, None, None)
+            result <- setNx(key, value)
+          } yield assert(result)(isFalse)
+        },
+        testM("not string") {
+          for {
+            key    <- uuid
+            value  <- uuid
+            _      <- sAdd(key)("a")
+            result <- setNx(key, value)
+          } yield assert(result)(isFalse)
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/StringsSpec.scala
+++ b/redis/src/test/scala/zio/redis/StringsSpec.scala
@@ -655,6 +655,41 @@ trait StringsSpec extends BaseSpec {
             substr <- getRange(key, 1 to 3).either
           } yield assert(substr)(isLeft(isSubtype[WrongType](anything)))
         }
+      ),
+      suite("getSet")(
+        testM("non-empty value to the existing string") {
+          for {
+            key    <- uuid
+            _      <- set(key, "value", None, None, None)
+            oldVal <- getSet(key, "abc")
+          } yield assert(oldVal)(isSome(equalTo("value")))
+        },
+        testM("empty value to the existing string") {
+          for {
+            key    <- uuid
+            _      <- set(key, "value", None, None, None)
+            oldVal <- getSet(key, "")
+          } yield assert(oldVal)(isSome(equalTo("value")))
+        },
+        testM("non-empty value to the empty string") {
+          for {
+            key    <- uuid
+            oldVal <- getSet(key, "value")
+          } yield assert(oldVal)(isNone)
+        },
+        testM("empty value to the empty string") {
+          for {
+            key    <- uuid
+            oldVal <- getSet(key, "")
+          } yield assert(oldVal)(isNone)
+        },
+        testM("error when not string") {
+          for {
+            key    <- uuid
+            _      <- sAdd(key)("a")
+            oldVal <- getSet(key, "value").either
+          } yield assert(oldVal)(isLeft(isSubtype[WrongType](anything)))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/StringsSpec.scala
+++ b/redis/src/test/scala/zio/redis/StringsSpec.scala
@@ -84,7 +84,7 @@ trait StringsSpec extends BaseSpec {
             count <- bitCount(key, Some(1 to -1))
           } yield assert(count)(equalTo(16L))
         },
-        testM("over non-empty string with range whose start is bigger then end") {
+        testM("over non-empty string with range whose start is bigger than end") {
           for {
             key   <- uuid
             _     <- set(key, "value", None, None, None)
@@ -363,14 +363,14 @@ trait StringsSpec extends BaseSpec {
             pos <- bitPos(key, false, Some(BitPosRange(2L, None)))
           } yield assert(pos)(equalTo(16L))
         },
-        testM("of 1 when start is greater then non-empty string length") {
+        testM("of 1 when start is greater than non-empty string length") {
           for {
             key <- uuid
             _   <- set(key, "value", None, None, None)
             pos <- bitPos(key, true, Some(BitPosRange(10L, None)))
           } yield assert(pos)(equalTo(-1L))
         },
-        testM("of 0 when start is greater then non-empty string length") {
+        testM("of 0 when start is greater than non-empty string length") {
           for {
             key <- uuid
             _   <- set(key, "value", None, None, None)
@@ -403,14 +403,14 @@ trait StringsSpec extends BaseSpec {
             pos <- bitPos(key, false, Some(BitPosRange(2L, Some(4L))))
           } yield assert(pos)(equalTo(16L))
         },
-        testM("of 1 when start is greater then end with non-empty string") {
+        testM("of 1 when start is greater than end with non-empty string") {
           for {
             key <- uuid
             _   <- set(key, "value", None, None, None)
             pos <- bitPos(key, true, Some(BitPosRange(4L, Some(2L))))
           } yield assert(pos)(equalTo(-1L))
         },
-        testM("of 0 when start is greater then end with non-empty string") {
+        testM("of 0 when start is greater than end with non-empty string") {
           for {
             key <- uuid
             _   <- set(key, "value", None, None, None)
@@ -457,13 +457,13 @@ trait StringsSpec extends BaseSpec {
             pos <- bitPos(key, false, Some(BitPosRange(2L, Some(4L))))
           } yield assert(pos)(equalTo(0L))
         },
-        testM("of 1 when start is greater then end with empty string") {
+        testM("of 1 when start is greater than end with empty string") {
           for {
             key <- uuid
             pos <- bitPos(key, true, Some(BitPosRange(4L, Some(2L))))
           } yield assert(pos)(equalTo(-1L))
         },
-        testM("of 0 when start is greater then end with empty string") {
+        testM("of 0 when start is greater than end with empty string") {
           for {
             key <- uuid
             pos <- bitPos(key, false, Some(BitPosRange(4L, Some(2L))))
@@ -476,12 +476,41 @@ trait StringsSpec extends BaseSpec {
             pos <- bitPos(key, true, None).either
           } yield assert(pos)(isLeft(isSubtype[WrongType](anything)))
         },
-        testM("error when not string and start is greater then end") {
+        testM("error when not string and start is greater than end") {
           for {
             key <- uuid
             _   <- sAdd(key)("a")
             pos <- bitPos(key, false, Some(BitPosRange(4L, Some(2L)))).either
           } yield assert(pos)(isLeft(isSubtype[WrongType](anything)))
+        }
+      ),
+      suite("decr")(
+        testM("non-empty integer") {
+          for {
+            key    <- uuid
+            _      <- set(key, "5", None, None, None)
+            result <- decr(key)
+          } yield assert(result)(equalTo(4L))
+        },
+        testM("empty integer") {
+          for {
+            key    <- uuid
+            result <- decr(key)
+          } yield assert(result)(equalTo(-1L))
+        },
+        testM("error when out of range integer") {
+          for {
+            key    <- uuid
+            _      <- set(key, "234293482390480948029348230948", None, None, None)
+            result <- decr(key).either
+          } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
+        },
+        testM("error when not integer") {
+          for {
+            key    <- uuid
+            _      <- set(key, "not-integer", None, None, None)
+            result <- decr(key).either
+          } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
         }
       )
     )

--- a/redis/src/test/scala/zio/redis/StringsSpec.scala
+++ b/redis/src/test/scala/zio/redis/StringsSpec.scala
@@ -863,15 +863,15 @@ trait StringsSpec extends BaseSpec {
         },
         testM("replace existing values") {
           for {
-            first          <- uuid
-            second         <- uuid
-            firstVal       <- uuid
-            secondVal      <- uuid
-            replacementVal <- uuid
-            _              <- mSet((first, firstVal), (second, secondVal))
-            _              <- mSet((first, replacementVal), (second, replacementVal))
-            result         <- mGet(first, second)
-          } yield assert(result)(equalTo(Chunk(Some(replacementVal), Some(replacementVal))))
+            first       <- uuid
+            second      <- uuid
+            firstVal    <- uuid
+            secondVal   <- uuid
+            replacement <- uuid
+            _           <- mSet((first, firstVal), (second, secondVal))
+            _           <- mSet((first, replacement), (second, replacement))
+            result      <- mGet(first, second)
+          } yield assert(result)(equalTo(Chunk(Some(replacement), Some(replacement))))
         },
         testM("one value multiple times at once") {
           for {
@@ -882,13 +882,58 @@ trait StringsSpec extends BaseSpec {
             result    <- get(key)
           } yield assert(result)(isSome(equalTo(secondVal)))
         },
-        testM("not string value") {
+        testM("replace not string value") {
           for {
             key    <- uuid
             value  <- uuid
             _      <- sAdd(key)("a")
             result <- mSet((key, value)).either
           } yield assert(result)(isRight)
+        }
+      ),
+      suite("mSetNx")(
+        testM("one new value") {
+          for {
+            key   <- uuid
+            value <- uuid
+            set   <- mSetNx((key, value))
+          } yield assert(set)(isTrue)
+        },
+        testM("multiple new values") {
+          for {
+            first     <- uuid
+            second    <- uuid
+            firstVal  <- uuid
+            secondVal <- uuid
+            set       <- mSetNx((first, firstVal), (second, secondVal))
+          } yield assert(set)(isTrue)
+        },
+        testM("replace existing values") {
+          for {
+            first       <- uuid
+            second      <- uuid
+            firstVal    <- uuid
+            secondVal   <- uuid
+            replacement <- uuid
+            _           <- mSetNx((first, firstVal), (second, secondVal))
+            set         <- mSetNx((first, replacement), (second, replacement))
+          } yield assert(set)(isFalse)
+        },
+        testM("one value multiple times at once") {
+          for {
+            key       <- uuid
+            firstVal  <- uuid
+            secondVal <- uuid
+            set       <- mSetNx((key, firstVal), (key, secondVal))
+          } yield assert(set)(isTrue)
+        },
+        testM("replace not string value") {
+          for {
+            key   <- uuid
+            value <- uuid
+            _     <- sAdd(key)("a")
+            set   <- mSetNx((key, value))
+          } yield assert(set)(isFalse)
         }
       )
     )

--- a/redis/src/test/scala/zio/redis/StringsSpec.scala
+++ b/redis/src/test/scala/zio/redis/StringsSpec.scala
@@ -762,6 +762,42 @@ trait StringsSpec extends BaseSpec {
             result <- incrBy(key, 3).either
           } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
         }
+      ),
+      suite("incrByFloat")(
+        testM("3.4 when non-empty float") {
+          for {
+            key    <- uuid
+            _      <- set(key, "5.1", None, None, None)
+            result <- incrByFloat(key, 3.4d)
+          } yield assert(result)(equalTo("8.5"))
+        },
+        testM("3.4 when empty float") {
+          for {
+            key    <- uuid
+            result <- incrByFloat(key, 3.4d)
+          } yield assert(result)(equalTo("3.4"))
+        },
+        testM("-3.4 when non-empty float") {
+          for {
+            key    <- uuid
+            _      <- set(key, "5", None, None, None)
+            result <- incrByFloat(key, -3.4d)
+          } yield assert(result)(equalTo("1.6"))
+        },
+        testM("error when out of range value") {
+          for {
+            key    <- uuid
+            _      <- set(key, s"${Double.MaxValue.toString}1234", None, None, None)
+            result <- incrByFloat(key, 3d).either
+          } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
+        },
+        testM("error when not integer") {
+          for {
+            key    <- uuid
+            _      <- set(key, "not-integer", None, None, None)
+            result <- incrByFloat(key, 3).either
+          } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/StringsSpec.scala
+++ b/redis/src/test/scala/zio/redis/StringsSpec.scala
@@ -321,6 +321,168 @@ trait StringsSpec extends BaseSpec {
             result <- bitOp(BitOperation.NOT, dest)(key).either
           } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
         }
+      ),
+      suite("bitPos")(
+        testM("of 1 when non-empty string") {
+          for {
+            key <- uuid
+            _   <- set(key, "value", None, None, None)
+            pos <- bitPos(key, true, None)
+          } yield assert(pos)(equalTo(1L))
+        },
+        testM("of 0 when non-empty string") {
+          for {
+            key <- uuid
+            _   <- set(key, "value", None, None, None)
+            pos <- bitPos(key, false, None)
+          } yield assert(pos)(equalTo(0L))
+        },
+        testM("of 1 when empty string") {
+          for {
+            key <- uuid
+            pos <- bitPos(key, true, None)
+          } yield assert(pos)(equalTo(-1L))
+        },
+        testM("of 0 when empty string") {
+          for {
+            key <- uuid
+            pos <- bitPos(key, false, None)
+          } yield assert(pos)(equalTo(0L))
+        },
+        testM("of 1 when non-empty string with start") {
+          for {
+            key <- uuid
+            _   <- set(key, "value", None, None, None)
+            pos <- bitPos(key, true, Some(BitPosRange(2L, None)))
+          } yield assert(pos)(equalTo(17L))
+        },
+        testM("of 0 when non-empty string with start") {
+          for {
+            key <- uuid
+            _   <- set(key, "value", None, None, None)
+            pos <- bitPos(key, false, Some(BitPosRange(2L, None)))
+          } yield assert(pos)(equalTo(16L))
+        },
+        testM("of 1 when start is greater then non-empty string length") {
+          for {
+            key <- uuid
+            _   <- set(key, "value", None, None, None)
+            pos <- bitPos(key, true, Some(BitPosRange(10L, None)))
+          } yield assert(pos)(equalTo(-1L))
+        },
+        testM("of 0 when start is greater then non-empty string length") {
+          for {
+            key <- uuid
+            _   <- set(key, "value", None, None, None)
+            pos <- bitPos(key, false, Some(BitPosRange(10L, None)))
+          } yield assert(pos)(equalTo(-1L))
+        },
+        testM("of 1 when empty string with start") {
+          for {
+            key <- uuid
+            pos <- bitPos(key, true, Some(BitPosRange(1L, None)))
+          } yield assert(pos)(equalTo(-1L))
+        },
+        testM("of 0 when empty string with start") {
+          for {
+            key <- uuid
+            pos <- bitPos(key, false, Some(BitPosRange(10L, None)))
+          } yield assert(pos)(equalTo(0L))
+        },
+        testM("of 1 when non-empty string with start and end") {
+          for {
+            key <- uuid
+            _   <- set(key, "value", None, None, None)
+            pos <- bitPos(key, true, Some(BitPosRange(2L, Some(4L))))
+          } yield assert(pos)(equalTo(17L))
+        },
+        testM("of 0 when non-empty string with start and end") {
+          for {
+            key <- uuid
+            _   <- set(key, "value", None, None, None)
+            pos <- bitPos(key, false, Some(BitPosRange(2L, Some(4L))))
+          } yield assert(pos)(equalTo(16L))
+        },
+        testM("of 1 when start is greater then end with non-empty string") {
+          for {
+            key <- uuid
+            _   <- set(key, "value", None, None, None)
+            pos <- bitPos(key, true, Some(BitPosRange(4L, Some(2L))))
+          } yield assert(pos)(equalTo(-1L))
+        },
+        testM("of 0 when start is greater then end with non-empty string") {
+          for {
+            key <- uuid
+            _   <- set(key, "value", None, None, None)
+            pos <- bitPos(key, false, Some(BitPosRange(4L, Some(2L))))
+          } yield assert(pos)(equalTo(-1L))
+        },
+        testM("of 1 when range is out of non-empty string") {
+          for {
+            key <- uuid
+            _   <- set(key, "value", None, None, None)
+            pos <- bitPos(key, true, Some(BitPosRange(10L, Some(15L))))
+          } yield assert(pos)(equalTo(-1L))
+        },
+        testM("of 0 when range is out of non-empty string") {
+          for {
+            key <- uuid
+            _   <- set(key, "value", None, None, None)
+            pos <- bitPos(key, false, Some(BitPosRange(10L, Some(15L))))
+          } yield assert(pos)(equalTo(-1L))
+        },
+        testM("of 1 when start is equal to end with non-empty string") {
+          for {
+            key <- uuid
+            _   <- set(key, "value", None, None, None)
+            pos <- bitPos(key, true, Some(BitPosRange(1L, Some(1L))))
+          } yield assert(pos)(equalTo(9L))
+        },
+        testM("of 0 when start is equal to end with non-empty string") {
+          for {
+            key <- uuid
+            _   <- set(key, "value", None, None, None)
+            pos <- bitPos(key, false, Some(BitPosRange(1L, Some(1L))))
+          } yield assert(pos)(equalTo(8L))
+        },
+        testM("of 1 when empty string with start and end") {
+          for {
+            key <- uuid
+            pos <- bitPos(key, true, Some(BitPosRange(2L, Some(4L))))
+          } yield assert(pos)(equalTo(-1L))
+        },
+        testM("of 0 when empty string with start and end") {
+          for {
+            key <- uuid
+            pos <- bitPos(key, false, Some(BitPosRange(2L, Some(4L))))
+          } yield assert(pos)(equalTo(0L))
+        },
+        testM("of 1 when start is greater then end with empty string") {
+          for {
+            key <- uuid
+            pos <- bitPos(key, true, Some(BitPosRange(4L, Some(2L))))
+          } yield assert(pos)(equalTo(-1L))
+        },
+        testM("of 0 when start is greater then end with empty string") {
+          for {
+            key <- uuid
+            pos <- bitPos(key, false, Some(BitPosRange(4L, Some(2L))))
+          } yield assert(pos)(equalTo(0L))
+        },
+        testM("error when not string") {
+          for {
+            key <- uuid
+            _   <- sAdd(key)("a")
+            pos <- bitPos(key, true, None).either
+          } yield assert(pos)(isLeft(isSubtype[WrongType](anything)))
+        },
+        testM("error when not string and start is greater then end") {
+          for {
+            key <- uuid
+            _   <- sAdd(key)("a")
+            pos <- bitPos(key, false, Some(BitPosRange(4L, Some(2L)))).either
+          } yield assert(pos)(isLeft(isSubtype[WrongType](anything)))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/StringsSpec.scala
+++ b/redis/src/test/scala/zio/redis/StringsSpec.scala
@@ -726,6 +726,42 @@ trait StringsSpec extends BaseSpec {
             result <- incr(key).either
           } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
         }
+      ),
+      suite("incrBy")(
+        testM("3 when non-empty integer") {
+          for {
+            key    <- uuid
+            _      <- set(key, "10", None, None, None)
+            result <- incrBy(key, 3L)
+          } yield assert(result)(equalTo(13L))
+        },
+        testM("3 when empty integer") {
+          for {
+            key    <- uuid
+            result <- incrBy(key, 3L)
+          } yield assert(result)(equalTo(3L))
+        },
+        testM("-3 when non-empty integer") {
+          for {
+            key    <- uuid
+            _      <- set(key, "10", None, None, None)
+            result <- incrBy(key, -3L)
+          } yield assert(result)(equalTo(7L))
+        },
+        testM("error when out of range integer") {
+          for {
+            key    <- uuid
+            _      <- set(key, "234293482390480948029348230948", None, None, None)
+            result <- incrBy(key, 3).either
+          } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
+        },
+        testM("error when not integer") {
+          for {
+            key    <- uuid
+            _      <- set(key, "not-integer", None, None, None)
+            result <- incrBy(key, 3).either
+          } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/StringsSpec.scala
+++ b/redis/src/test/scala/zio/redis/StringsSpec.scala
@@ -598,6 +598,63 @@ trait StringsSpec extends BaseSpec {
             bit <- getBit(key, 10L).either
           } yield assert(bit)(isLeft(isSubtype[WrongType](anything)))
         }
+      ),
+      suite("getRange")(
+        testM("from non-empty string") {
+          for {
+            key    <- uuid
+            _      <- set(key, "value", None, None, None)
+            substr <- getRange(key, 1 to 3)
+          } yield assert(substr)(equalTo("alu"))
+        },
+        testM("with range that exceeds non-empty string length") {
+          for {
+            key    <- uuid
+            _      <- set(key, "value", None, None, None)
+            substr <- getRange(key, 1 to 10)
+          } yield assert(substr)(equalTo("alue"))
+        },
+        testM("with range that is outside of non-empty string") {
+          for {
+            key    <- uuid
+            _      <- set(key, "value", None, None, None)
+            substr <- getRange(key, 10 to 15)
+          } yield assert(substr)(equalTo(""))
+        },
+        testM("with inverse range of non-empty string") {
+          for {
+            key    <- uuid
+            _      <- set(key, "value", None, None, None)
+            substr <- getRange(key, 15 to 3)
+          } yield assert(substr)(equalTo(""))
+        },
+        testM("with negative range end from non-empty string") {
+          for {
+            key    <- uuid
+            _      <- set(key, "value", None, None, None)
+            substr <- getRange(key, 1 to -1)
+          } yield assert(substr)(equalTo("alue"))
+        },
+        testM("with start and end equal from non-empty string") {
+          for {
+            key    <- uuid
+            _      <- set(key, "value", None, None, None)
+            substr <- getRange(key, 1 to 1)
+          } yield assert(substr)(equalTo("a"))
+        },
+        testM("from empty string") {
+          for {
+            key    <- uuid
+            substr <- getRange(key, 1 to 3)
+          } yield assert(substr)(equalTo(""))
+        },
+        testM("error when not string") {
+          for {
+            key    <- uuid
+            _      <- sAdd(key)("a")
+            substr <- getRange(key, 1 to 3).either
+          } yield assert(substr)(isLeft(isSubtype[WrongType](anything)))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/StringsSpec.scala
+++ b/redis/src/test/scala/zio/redis/StringsSpec.scala
@@ -527,6 +527,13 @@ trait StringsSpec extends BaseSpec {
             result <- decrBy(key, 3L)
           } yield assert(result)(equalTo(-3L))
         },
+        testM("-3 when non-empty integer") {
+          for {
+            key    <- uuid
+            _      <- set(key, "10", None, None, None)
+            result <- decrBy(key, -3L)
+          } yield assert(result)(equalTo(13L))
+        },
         testM("error when out of range integer") {
           for {
             key    <- uuid

--- a/redis/src/test/scala/zio/redis/StringsSpec.scala
+++ b/redis/src/test/scala/zio/redis/StringsSpec.scala
@@ -563,6 +563,41 @@ trait StringsSpec extends BaseSpec {
             result <- get(key).either
           } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
         }
+      ),
+      suite("getBit")(
+        testM("from non-empty string") {
+          for {
+            key <- uuid
+            _   <- set(key, "value", None, None, None)
+            bit <- getBit(key, 17L)
+          } yield assert(bit)(equalTo(1L))
+        },
+        testM("with offset larger then string length") {
+          for {
+            key <- uuid
+            _   <- set(key, "value", None, None, None)
+            bit <- getBit(key, 100L)
+          } yield assert(bit)(equalTo(0L))
+        },
+        testM("with empty string") {
+          for {
+            key <- uuid
+            bit <- getBit(key, 10L)
+          } yield assert(bit)(equalTo(0L))
+        },
+        testM("error when negative offset") {
+          for {
+            key <- uuid
+            bit <- getBit(key, -1L).either
+          } yield assert(bit)(isLeft(isSubtype[ProtocolError](anything)))
+        },
+        testM("error when not string") {
+          for {
+            key <- uuid
+            _   <- sAdd(key)("a")
+            bit <- getBit(key, 10L).either
+          } yield assert(bit)(isLeft(isSubtype[WrongType](anything)))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/StringsSpec.scala
+++ b/redis/src/test/scala/zio/redis/StringsSpec.scala
@@ -1198,6 +1198,41 @@ trait StringsSpec extends BaseSpec {
             result <- setNx(key, value)
           } yield assert(result)(isFalse)
         }
+      ),
+      suite("setRange")(
+        testM("in existing string") {
+          for {
+            key <- uuid
+            _   <- set(key, "val", None, None, None)
+            len <- setRange(key, 3L, "ue")
+          } yield assert(len)(equalTo(5L))
+        },
+        testM("in non-existent string") {
+          for {
+            key <- uuid
+            len <- setRange(key, 2L, "value")
+          } yield assert(len)(equalTo(7L))
+        },
+        testM("when offset is larger then string length") {
+          for {
+            key <- uuid
+            _   <- set(key, "value", None, None, None)
+            len <- setRange(key, 7L, "value")
+          } yield assert(len)(equalTo(12L))
+        },
+        testM("error when negative offset") {
+          for {
+            key <- uuid
+            len <- setRange(key, -1L, "value").either
+          } yield assert(len)(isLeft(isSubtype[ProtocolError](anything)))
+        },
+        testM("error when not string") {
+          for {
+            key <- uuid
+            _   <- sAdd(key)("a")
+            len <- setRange(key, 1L, "value").either
+          } yield assert(len)(isLeft(isSubtype[WrongType](anything)))
+        }
       )
     )
 }


### PR DESCRIPTION
This PR resolves #64.

**Summary:**
1. Add support for `NOT` for `bitOp` command,
2. Update API with support for `varargs` only params,
3. Add new output type for `mGet`,
4. Fix input for `set` command,
5. Fix input and output for `setBit` command.

**Note:** Command `bitField` should be redefined and tests will be added after it has been fixed (#98).