### PR TITLE
Fix BITFIELD command

### DIFF
--- a/redis/src/main/scala/zio/redis/Input.scala
+++ b/redis/src/main/scala/zio/redis/Input.scala
@@ -32,15 +32,16 @@ object Input {
   }
 
   case object BitFieldCommandInput extends Input[BitFieldCommand] {
-    def encode(data: BitFieldCommand): Chunk[String] =
+    def encode(data: BitFieldCommand): Chunk[String] = {
+      import BitFieldCommand._
+
       data match {
-        case BitFieldCommand.BitFieldGet(t, o)     => Chunk(wrap("GET"), wrap(t.stringify), wrap(o.toString))
-        case BitFieldCommand.BitFieldSet(t, o, v)  =>
-          Chunk(wrap("SET"), wrap(t.stringify), wrap(o.toString), wrap(v.toString))
-        case BitFieldCommand.BitFieldIncr(t, o, i) =>
-          Chunk(wrap("INCRBY"), wrap(t.stringify), wrap(o.toString), wrap(i.toString))
-        case bfo: BitFieldCommand.BitFieldOverflow => Chunk(wrap("OVERFLOW"), wrap(bfo.stringify))
+        case BitFieldGet(t, o)     => Chunk(wrap("GET"), wrap(t.stringify), wrap(o.toString))
+        case BitFieldSet(t, o, v)  => Chunk(wrap("SET"), wrap(t.stringify), wrap(o.toString), wrap(v.toString))
+        case BitFieldIncr(t, o, i) => Chunk(wrap("INCRBY"), wrap(t.stringify), wrap(o.toString), wrap(i.toString))
+        case bfo: BitFieldOverflow => Chunk(wrap("OVERFLOW"), wrap(bfo.stringify))
       }
+    }
   }
 
   case object BitOperationInput extends Input[BitOperation] {

--- a/redis/src/main/scala/zio/redis/Input.scala
+++ b/redis/src/main/scala/zio/redis/Input.scala
@@ -31,23 +31,16 @@ object Input {
     def encode(data: Boolean): Chunk[String] = Chunk.single(wrap(if (data) "1" else "0"))
   }
 
-  case object BitFieldGetInput extends Input[BitFieldGet] {
-    def encode(data: BitFieldGet): Chunk[String] =
-      Chunk(wrap("GET"), wrap(data.`type`.stringify), wrap(data.offset.toString))
-  }
-
-  case object BitFieldSetInput extends Input[BitFieldSet] {
-    def encode(data: BitFieldSet): Chunk[String] =
-      Chunk(wrap("SET"), wrap(data.`type`.stringify), wrap(data.offset.toString), wrap(data.value.toString))
-  }
-
-  case object BitFieldIncrInput extends Input[BitFieldIncr] {
-    def encode(data: BitFieldIncr): Chunk[String] =
-      Chunk(wrap("INCRBY"), wrap(data.`type`.stringify), wrap(data.offset.toString), wrap(data.increment.toString))
-  }
-
-  case object BitFieldOverflowInput extends Input[BitFieldOverflow] {
-    def encode(data: BitFieldOverflow): Chunk[String] = Chunk(wrap("OVERFLOW"), wrap(data.stringify))
+  case object BitFieldCommandInput extends Input[BitFieldCommand] {
+    def encode(data: BitFieldCommand): Chunk[String] =
+      data match {
+        case BitFieldCommand.BitFieldGet(t, o)     => Chunk(wrap("GET"), wrap(t.stringify), wrap(o.toString))
+        case BitFieldCommand.BitFieldSet(t, o, v)  =>
+          Chunk(wrap("SET"), wrap(t.stringify), wrap(o.toString), wrap(v.toString))
+        case BitFieldCommand.BitFieldIncr(t, o, i) =>
+          Chunk(wrap("INCRBY"), wrap(t.stringify), wrap(o.toString), wrap(i.toString))
+        case bfo: BitFieldCommand.BitFieldOverflow => Chunk(wrap("OVERFLOW"), wrap(bfo.stringify))
+      }
   }
 
   case object BitOperationInput extends Input[BitOperation] {

--- a/redis/src/main/scala/zio/redis/api/Strings.scala
+++ b/redis/src/main/scala/zio/redis/api/Strings.scala
@@ -10,14 +10,11 @@ trait Strings {
 
   final val bitField = RedisCommand(
     "BITFIELD",
-    Tuple5(
+    Tuple2(
       StringInput,
-      OptionalInput(NonEmptyList(BitFieldGetInput)),
-      OptionalInput(NonEmptyList(BitFieldSetInput)),
-      OptionalInput(NonEmptyList(BitFieldIncrInput)),
-      OptionalInput(NonEmptyList(BitFieldOverflowInput))
+      NonEmptyList(BitFieldCommandInput)
     ),
-    ChunkOutput
+    ChunkOptionalLongOutput
   )
 
   final val bitOp =

--- a/redis/src/main/scala/zio/redis/options/Strings.scala
+++ b/redis/src/main/scala/zio/redis/options/Strings.scala
@@ -2,25 +2,29 @@ package zio.redis.options
 
 trait Strings {
 
-  sealed case class BitFieldGet(`type`: BitFieldType, offset: Int)
+  sealed trait BitFieldCommand
 
-  sealed case class BitFieldIncr(`type`: BitFieldType, offset: Int, increment: Long)
+  object BitFieldCommand {
+    sealed case class BitFieldGet(`type`: BitFieldType, offset: Int) extends BitFieldCommand
 
-  sealed case class BitFieldSet(`type`: BitFieldType, offset: Int, value: Long)
+    sealed case class BitFieldSet(`type`: BitFieldType, offset: Int, value: Long) extends BitFieldCommand
 
-  sealed trait BitFieldOverflow { self =>
-    private[redis] final def stringify: String =
-      self match {
-        case BitFieldOverflow.Fail => "FAIL"
-        case BitFieldOverflow.Sat  => "SAT"
-        case BitFieldOverflow.Wrap => "WRAP"
-      }
-  }
+    sealed case class BitFieldIncr(`type`: BitFieldType, offset: Int, increment: Long) extends BitFieldCommand
 
-  object BitFieldOverflow {
-    case object Fail extends BitFieldOverflow
-    case object Sat  extends BitFieldOverflow
-    case object Wrap extends BitFieldOverflow
+    sealed trait BitFieldOverflow extends BitFieldCommand { self =>
+      private[redis] final def stringify: String =
+        self match {
+          case BitFieldOverflow.Fail => "FAIL"
+          case BitFieldOverflow.Sat  => "SAT"
+          case BitFieldOverflow.Wrap => "WRAP"
+        }
+    }
+
+    object BitFieldOverflow {
+      case object Fail extends BitFieldOverflow
+      case object Sat  extends BitFieldOverflow
+      case object Wrap extends BitFieldOverflow
+    }
   }
 
   sealed trait BitFieldType { self =>

--- a/redis/src/test/scala/zio/redis/OutputSpec.scala
+++ b/redis/src/test/scala/zio/redis/OutputSpec.scala
@@ -270,6 +270,30 @@ object OutputSpec extends BaseSpec {
             res <- Task(ChunkOptionalMultiStringOutput.unsafeDecode(Noise)).either
           } yield assert(res)(isLeft(isSubtype[ProtocolError](anything)))
         }
+      ),
+      suite("chunkOptionalLong")(
+        testM("extract one empty value") {
+          for {
+            res <- Task(ChunkOptionalLongOutput.unsafeDecode("*0\r\n"))
+          } yield assert(res)(isEmpty)
+        },
+        testM("extract array with empty and non-empty elements") {
+          val input = "*4\r\n:1\r\n$-1\r\n:2\r\n:3\r\n"
+          for {
+            res <- Task(ChunkOptionalLongOutput.unsafeDecode(input))
+          } yield assert(res)(equalTo(Chunk(Some(1L), None, Some(2L), Some(3L))))
+        },
+        testM("extract array with non-empty elements") {
+          val input = "*4\r\n:1\r\n:1\r\n:2\r\n:3\r\n"
+          for {
+            res <- Task(ChunkOptionalLongOutput.unsafeDecode(input))
+          } yield assert(res)(equalTo(Chunk(Some(1L), Some(1L), Some(2L), Some(3L))))
+        },
+        testM("error when extracting from an invalid value") {
+          for {
+            res <- Task(ChunkOptionalLongOutput.unsafeDecode(Noise)).either
+          } yield assert(res)(isLeft(isSubtype[ProtocolError](anything)))
+        }
       )
     )
 


### PR DESCRIPTION
This PR fixes #98.

**Summary:**
1. Fixed input and output for `bitField` command.
2. Added tests for the new `ChunkOptionalLongOutput`.
3. Added tests for `bitField` command.

**Note:** It's not possible to call `bitField` with key as the only parameter and get an empty array using current API, but I think that this is not a big issue as it isn't useful use-case.