### PR TITLE
Test input encoding

### DIFF
--- a/redis/src/main/scala/zio/redis/Input.scala
+++ b/redis/src/main/scala/zio/redis/Input.scala
@@ -217,7 +217,8 @@ object Input {
     _7: Input[G]
   ) extends Input[(A, B, C, D, E, F, G)] {
     def encode(data: (A, B, C, D, E, F, G)): Chunk[String] =
-      _1.encode(data._1) ++ _2.encode(data._2) ++ _3.encode(data._3) ++ _4.encode(data._4) ++ _5.encode(data._5)
+      _1.encode(data._1) ++ _2.encode(data._2) ++ _3.encode(data._3) ++ _4.encode(data._4) ++ _5.encode(data._5) ++ _6
+        .encode(data._6) ++ _7.encode(data._7)
   }
 
   final case class Tuple9[-A, -B, -C, -D, -E, -F, -G, -H, -I](

--- a/redis/src/main/scala/zio/redis/Input.scala
+++ b/redis/src/main/scala/zio/redis/Input.scala
@@ -86,7 +86,7 @@ object Input {
     }
   }
 
-  case object DurationTTLInput extends Input[Duration] {
+  case object DurationTtlInput extends Input[Duration] {
     def encode(data: Duration): Chunk[String] = {
       val milliseconds = data.toMillis
       Chunk(wrap("PX"), wrap(milliseconds.toString))

--- a/redis/src/main/scala/zio/redis/Input.scala
+++ b/redis/src/main/scala/zio/redis/Input.scala
@@ -217,8 +217,8 @@ object Input {
     _7: Input[G]
   ) extends Input[(A, B, C, D, E, F, G)] {
     def encode(data: (A, B, C, D, E, F, G)): Chunk[String] =
-      _1.encode(data._1) ++ _2.encode(data._2) ++ _3.encode(data._3) ++ _4.encode(data._4) ++ _5.encode(data._5) ++ _6
-        .encode(data._6) ++ _7.encode(data._7)
+      _1.encode(data._1) ++ _2.encode(data._2) ++ _3.encode(data._3) ++ _4.encode(data._4) ++ _5.encode(data._5) ++
+        _6.encode(data._6) ++ _7.encode(data._7)
   }
 
   final case class Tuple9[-A, -B, -C, -D, -E, -F, -G, -H, -I](
@@ -233,8 +233,8 @@ object Input {
     _9: Input[I]
   ) extends Input[(A, B, C, D, E, F, G, H, I)] {
     def encode(data: (A, B, C, D, E, F, G, H, I)): Chunk[String] =
-      _1.encode(data._1) ++ _2.encode(data._2) ++ _3.encode(data._3) ++ _4.encode(data._4) ++
-        _5.encode(data._5) ++ _6.encode(data._6) ++ _7.encode(data._7)
+      _1.encode(data._1) ++ _2.encode(data._2) ++ _3.encode(data._3) ++ _4.encode(data._4) ++ _5.encode(data._5) ++
+        _6.encode(data._6) ++ _7.encode(data._7) ++ _8.encode(data._8) ++ _9.encode(data._9)
   }
 
   final case class Tuple11[-A, -B, -C, -D, -E, -F, -G, -H, -I, -J, -K](

--- a/redis/src/main/scala/zio/redis/api/Strings.scala
+++ b/redis/src/main/scala/zio/redis/api/Strings.scala
@@ -42,7 +42,7 @@ trait Strings {
     Tuple5(
       StringInput,
       StringInput,
-      OptionalInput(DurationTTLInput),
+      OptionalInput(DurationTtlInput),
       OptionalInput(UpdateInput),
       OptionalInput(KeepTtlInput)
     ),

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -814,6 +814,13 @@ object InputSpec extends BaseSpec {
             result <- Task(WithCoordInput.encode(WithCoord))
           } yield assert(result)(equalTo(Chunk.single("$9\r\nWITHCOORD\r\n")))
         }
+      ),
+      suite("WithDist")(
+        testM("valid value") {
+          for {
+            result <- Task(WithDistInput.encode(WithDist))
+          } yield assert(result)(equalTo(Chunk.single("$8\r\nWITHDIST\r\n")))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -544,6 +544,53 @@ object InputSpec extends BaseSpec {
             result <- Task(StoreInput.encode(Store("")))
           } yield assert(result)(equalTo(Chunk("$5\r\nSTORE\r\n", "$0\r\n\r\n")))
         }
+      ),
+      suite("ScoreRange")(
+        testM("with infinite min and infinite max") {
+          for {
+            result <- Task(ScoreRangeInput.encode(ScoreRange(ScoreMinimum.Infinity, ScoreMaximum.Infinity)))
+          } yield assert(result)(equalTo(Chunk("$4\r\n-inf\r\n", "$4\r\n+inf\r\n")))
+        },
+        testM("with open min and infinite max") {
+          for {
+            result <- Task(ScoreRangeInput.encode(ScoreRange(ScoreMinimum.Open(4.2d), ScoreMaximum.Infinity)))
+          } yield assert(result)(equalTo(Chunk("$4\r\n(4.2\r\n", "$4\r\n+inf\r\n")))
+        },
+        testM("with closed min and infinite max") {
+          for {
+            result <- Task(ScoreRangeInput.encode(ScoreRange(ScoreMinimum.Closed(4.2d), ScoreMaximum.Infinity)))
+          } yield assert(result)(equalTo(Chunk("$4\r\n[4.2\r\n", "$4\r\n+inf\r\n")))
+        },
+        testM("with infinite min and open max") {
+          for {
+            result <- Task(ScoreRangeInput.encode(ScoreRange(ScoreMinimum.Infinity, ScoreMaximum.Open(5.2d))))
+          } yield assert(result)(equalTo(Chunk("$4\r\n-inf\r\n", "$4\r\n(5.2\r\n")))
+        },
+        testM("with open min and open max") {
+          for {
+            result <- Task(ScoreRangeInput.encode(ScoreRange(ScoreMinimum.Open(4.2d), ScoreMaximum.Open(5.2d))))
+          } yield assert(result)(equalTo(Chunk("$4\r\n(4.2\r\n", "$4\r\n(5.2\r\n")))
+        },
+        testM("with closed min and open max") {
+          for {
+            result <- Task(ScoreRangeInput.encode(ScoreRange(ScoreMinimum.Closed(4.2d), ScoreMaximum.Open(5.2d))))
+          } yield assert(result)(equalTo(Chunk("$4\r\n[4.2\r\n", "$4\r\n(5.2\r\n")))
+        },
+        testM("with infinite min and closed max") {
+          for {
+            result <- Task(ScoreRangeInput.encode(ScoreRange(ScoreMinimum.Infinity, ScoreMaximum.Closed(5.2d))))
+          } yield assert(result)(equalTo(Chunk("$4\r\n-inf\r\n", "$4\r\n[5.2\r\n")))
+        },
+        testM("with open min and closed max") {
+          for {
+            result <- Task(ScoreRangeInput.encode(ScoreRange(ScoreMinimum.Open(4.2d), ScoreMaximum.Closed(5.2d))))
+          } yield assert(result)(equalTo(Chunk("$4\r\n(4.2\r\n", "$4\r\n[5.2\r\n")))
+        },
+        testM("with closed min and closed max") {
+          for {
+            result <- Task(ScoreRangeInput.encode(ScoreRange(ScoreMinimum.Closed(4.2d), ScoreMaximum.Closed(5.2d))))
+          } yield assert(result)(equalTo(Chunk("$4\r\n[4.2\r\n", "$4\r\n[5.2\r\n")))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -443,6 +443,18 @@ object InputSpec extends BaseSpec {
             result <- Task(NonEmptyList(StringInput).encode(("a", List.empty)))
           } yield assert(result)(equalTo(Chunk.single("$1\r\na\r\n")))
         }
+      ),
+      suite("Order")(
+        testM("ascending") {
+          for {
+            result <- Task(OrderInput.encode(Order.Ascending))
+          } yield assert(result)(equalTo(Chunk.single("$3\r\nASC\r\n")))
+        },
+        testM("descending") {
+          for {
+            result <- Task(OrderInput.encode(Order.Descending))
+          } yield assert(result)(equalTo(Chunk.single("$4\r\nDESC\r\n")))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -591,6 +591,18 @@ object InputSpec extends BaseSpec {
             result <- Task(ScoreRangeInput.encode(ScoreRange(ScoreMinimum.Closed(4.2d), ScoreMaximum.Closed(5.2d))))
           } yield assert(result)(equalTo(Chunk("$4\r\n[4.2\r\n", "$4\r\n[5.2\r\n")))
         }
+      ),
+      suite("String")(
+        testM("non-empty value") {
+          for {
+            result <- Task(StringInput.encode("non-empty"))
+          } yield assert(result)(equalTo(Chunk.single("$9\r\nnon-empty\r\n")))
+        },
+        testM("empty value") {
+          for {
+            result <- Task(StringInput.encode(""))
+          } yield assert(result)(equalTo(Chunk.single("$0\r\n\r\n")))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -513,6 +513,13 @@ object InputSpec extends BaseSpec {
             result <- Task(RegexInput.encode("".r))
           } yield assert(result)(equalTo(Chunk("$5\r\nMATCH\r\n", "$0\r\n\r\n")))
         }
+      ),
+      suite("Replace")(
+        testM("valid value") {
+          for {
+            result <- Task(ReplaceInput.encode(Replace))
+          } yield assert(result)(equalTo(Chunk.single("$7\r\nREPLACE\r\n")))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -285,7 +285,14 @@ object InputSpec extends BaseSpec {
         testM("valid value") {
           for {
             result <- Task(IncrementInput.encode(Increment))
-          } yield assert(result)(equalTo(Chunk("$4\r\nINCR\r\n")))
+          } yield assert(result)(equalTo(Chunk.single("$4\r\nINCR\r\n")))
+        }
+      ),
+      suite("KeepTtl")(
+        testM("valid value") {
+          for {
+            result <- Task(KeepTtlInput.encode(KeepTtl))
+          } yield assert(result)(equalTo(Chunk.single("$7\r\nKEEPTTL\r\n")))
         }
       )
     )

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -7,18 +7,19 @@ import zio.test.Assertion._
 import BitFieldCommand._
 import BitFieldType._
 import BitOperation._
+import zio.duration._
 
 object InputSpec extends BaseSpec {
   def spec: ZSpec[environment.TestEnvironment, Any] =
     suite("Input encoders")(
-      suite("abs ttl")(
+      suite("AbsTtl")(
         testM("valid value") {
           for {
             result <- Task(AbsTtlInput.encode(AbsTtl))
           } yield assert(result)(equalTo(Chunk.single("$6\r\nABSTTL\r\n")))
         }
       ),
-      suite("aggregate")(
+      suite("Aggregate")(
         testM("max") {
           for {
             result <- Task(AggregateInput.encode(Aggregate.Max))
@@ -35,7 +36,7 @@ object InputSpec extends BaseSpec {
           } yield assert(result)(equalTo(Chunk.single("$3\r\nSUM\r\n")))
         }
       ),
-      suite("auth")(
+      suite("Auth")(
         testM("with empty password") {
           for {
             result <- Task(AuthInput.encode(Auth("")))
@@ -47,7 +48,7 @@ object InputSpec extends BaseSpec {
           } yield assert(result)(equalTo(Chunk("$4\r\nAUTH\r\n", "$4\r\npass\r\n")))
         }
       ),
-      suite("bool")(
+      suite("Bool")(
         testM("true") {
           for {
             result <- Task(BoolInput.encode(true))
@@ -59,7 +60,7 @@ object InputSpec extends BaseSpec {
           } yield assert(result)(equalTo(Chunk.single("$1\r\n0\r\n")))
         }
       ),
-      suite("bit field command")(
+      suite("BitFieldCommand")(
         testM("get with unsigned type and positive offset") {
           for {
             result <- Task(BitFieldCommandInput.encode(BitFieldGet(UnsignedInt(3), 2)))
@@ -121,7 +122,7 @@ object InputSpec extends BaseSpec {
           } yield assert(result)(equalTo(Chunk("$8\r\nOVERFLOW\r\n", "$4\r\nWRAP\r\n")))
         }
       ),
-      suite("bit operation")(
+      suite("BitOperation")(
         testM("and") {
           for {
             result <- Task(BitOperationInput.encode(AND))
@@ -141,6 +142,18 @@ object InputSpec extends BaseSpec {
           for {
             result <- Task(BitOperationInput.encode(NOT))
           } yield assert(result)(equalTo(Chunk.single("$3\r\nNOT\r\n")))
+        }
+      ),
+      suite("BitPosRange")(
+        testM("with only start") {
+          for {
+            result <- Task(BitPosRangeInput.encode(BitPosRange(1.second.toMillis, None)))
+          } yield assert(result)(equalTo(Chunk.single("$4\r\n1000\r\n")))
+        },
+        testM("with start and the end") {
+          for {
+            result <- Task(BitPosRangeInput.encode(BitPosRange(0.second.toMillis, Some(1.second.toMillis))))
+          } yield assert(result)(equalTo(Chunk("$1\r\n0\r\n", "$4\r\n1000\r\n")))
         }
       )
     )

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -198,6 +198,23 @@ object InputSpec extends BaseSpec {
             result <- Task(PositionInput.encode(Position.After))
           } yield assert(result)(equalTo(Chunk.single("$5\r\nAFTER\r\n")))
         }
+      ),
+      suite("Double")(
+        testM("positive value") {
+          for {
+            result <- Task(DoubleInput.encode(4.2d))
+          } yield assert(result)(equalTo(Chunk.single("$3\r\n4.2\r\n")))
+        },
+        testM("negative value") {
+          for {
+            result <- Task(DoubleInput.encode(-4.2d))
+          } yield assert(result)(equalTo(Chunk.single("$4\r\n-4.2\r\n")))
+        },
+        testM("zero value") {
+          for {
+            result <- Task(DoubleInput.encode(0d))
+          } yield assert(result)(equalTo(Chunk.single("$3\r\n0.0\r\n")))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -162,6 +162,13 @@ object InputSpec extends BaseSpec {
             result <- Task(ChangedInput.encode(Changed))
           } yield assert(result)(equalTo(Chunk("$2\r\nCH\r\n")))
         }
+      ),
+      suite("Copy")(
+        testM("valid value") {
+          for {
+            result <- Task(CopyInput.encode(Copy))
+          } yield assert(result)(equalTo(Chunk("$4\r\nCOPY\r\n")))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -215,6 +215,18 @@ object InputSpec extends BaseSpec {
             result <- Task(DoubleInput.encode(0d))
           } yield assert(result)(equalTo(Chunk.single("$3\r\n0.0\r\n")))
         }
+      ),
+      suite("DurationMilliseconds")(
+        testM("1 second") {
+          for {
+            result <- Task(DurationMillisecondsInput.encode(1.second))
+          } yield assert(result)(equalTo(Chunk("$4\r\n1000\r\n")))
+        },
+        testM("100 milliseconds") {
+          for {
+            result <- Task(DurationMillisecondsInput.encode(100.millis))
+          } yield assert(result)(equalTo(Chunk("$3\r\n100\r\n")))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -501,6 +501,18 @@ object InputSpec extends BaseSpec {
             result <- Task(RangeInput.encode(Range(-1, -5)))
           } yield assert(result)(equalTo(Chunk("$2\r\n-1\r\n", "$2\r\n-5\r\n")))
         }
+      ),
+      suite("Regex")(
+        testM("with valid pattern") {
+          for {
+            result <- Task(RegexInput.encode("\\d{3}".r))
+          } yield assert(result)(equalTo(Chunk("$5\r\nMATCH\r\n", "$5\r\n\\d{3}\r\n")))
+        },
+        testM("with empty pattern") {
+          for {
+            result <- Task(RegexInput.encode("".r))
+          } yield assert(result)(equalTo(Chunk("$5\r\nMATCH\r\n", "$0\r\n\r\n")))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -633,6 +633,23 @@ object InputSpec extends BaseSpec {
             result <- Task(TimeSecondsInput.encode(Instant.ofEpochSecond(-3L)))
           } yield assert(result)(equalTo(Chunk("$2\r\n-3\r\n")))
         }
+      ),
+      suite("TimeMilliseconds")(
+        testM("positiv value") {
+          for {
+            result <- Task(TimeMillisecondsInput.encode(Instant.ofEpochSecond(3L)))
+          } yield assert(result)(equalTo(Chunk("$4\r\n3000\r\n")))
+        },
+        testM("zero value") {
+          for {
+            result <- Task(TimeMillisecondsInput.encode(Instant.ofEpochSecond(0L)))
+          } yield assert(result)(equalTo(Chunk("$1\r\n0\r\n")))
+        },
+        testM("negative value") {
+          for {
+            result <- Task(TimeMillisecondsInput.encode(Instant.ofEpochSecond(-3L)))
+          } yield assert(result)(equalTo(Chunk("$5\r\n-3000\r\n")))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -706,6 +706,39 @@ object InputSpec extends BaseSpec {
             )
           )
         }
+      ),
+      suite("Tuple9")(
+        testM("valid value") {
+          for {
+            result <- Task(
+                        Tuple9(
+                          StringInput,
+                          LongInput,
+                          StringInput,
+                          LongInput,
+                          StringInput,
+                          LongInput,
+                          StringInput,
+                          LongInput,
+                          StringInput
+                        ).encode(("one", 2, "three", 4, "five", 6, "seven", 8, "nine"))
+                      )
+          } yield assert(result)(
+            equalTo(
+              Chunk(
+                "$3\r\none\r\n",
+                "$1\r\n2\r\n",
+                "$5\r\nthree\r\n",
+                "$1\r\n4\r\n",
+                "$4\r\nfive\r\n",
+                "$1\r\n6\r\n",
+                "$5\r\nseven\r\n",
+                "$1\r\n8\r\n",
+                "$4\r\nnine\r\n"
+              )
+            )
+          )
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -10,6 +10,7 @@ import BitOperation._
 import zio.duration._
 import Order._
 import RadiusUnit._
+import java.time.Instant
 
 object InputSpec extends BaseSpec {
   def spec: ZSpec[environment.TestEnvironment, Any] =
@@ -614,6 +615,23 @@ object InputSpec extends BaseSpec {
           for {
             result <- Task(OptionalInput(LongInput).encode(Some(2L)))
           } yield assert(result)(equalTo(Chunk.single("$1\r\n2\r\n")))
+        }
+      ),
+      suite("TimeSeconds")(
+        testM("positiv value") {
+          for {
+            result <- Task(TimeSecondsInput.encode(Instant.ofEpochSecond(3L)))
+          } yield assert(result)(equalTo(Chunk("$1\r\n3\r\n")))
+        },
+        testM("zero value") {
+          for {
+            result <- Task(TimeSecondsInput.encode(Instant.ofEpochSecond(0L)))
+          } yield assert(result)(equalTo(Chunk("$1\r\n0\r\n")))
+        },
+        testM("negative value") {
+          for {
+            result <- Task(TimeSecondsInput.encode(Instant.ofEpochSecond(-3L)))
+          } yield assert(result)(equalTo(Chunk("$2\r\n-3\r\n")))
         }
       )
     )

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -14,6 +14,23 @@ object InputSpec extends BaseSpec {
             result <- Task(AbsTtlInput.encode(AbsTtl))
           } yield assert(result)(equalTo(Chunk.single("$6\r\nABSTTL\r\n")))
         }
+      ),
+      suite("aggregate")(
+        testM("max") {
+          for {
+            result <- Task(AggregateInput.encode(Aggregate.Max))
+          } yield assert(result)(equalTo(Chunk.single("$3\r\nMAX\r\n")))
+        },
+        testM("min") {
+          for {
+            result <- Task(AggregateInput.encode(Aggregate.Min))
+          } yield assert(result)(equalTo(Chunk.single("$3\r\nMIN\r\n")))
+        },
+        testM("sum") {
+          for {
+            result <- Task(AggregateInput.encode(Aggregate.Sum))
+          } yield assert(result)(equalTo(Chunk.single("$3\r\nSUM\r\n")))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -186,6 +186,18 @@ object InputSpec extends BaseSpec {
             result <- Task(CountInput.encode(Count(0L)))
           } yield assert(result)(equalTo(Chunk("$5\r\nCOUNT\r\n", "$1\r\n0\r\n")))
         }
+      ),
+      suite("Position")(
+        testM("before") {
+          for {
+            result <- Task(PositionInput.encode(Position.Before))
+          } yield assert(result)(equalTo(Chunk.single("$6\r\nBEFORE\r\n")))
+        },
+        testM("after") {
+          for {
+            result <- Task(PositionInput.encode(Position.After))
+          } yield assert(result)(equalTo(Chunk.single("$5\r\nAFTER\r\n")))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -684,6 +684,28 @@ object InputSpec extends BaseSpec {
             equalTo(Chunk("$3\r\none\r\n", "$1\r\n2\r\n", "$5\r\nthree\r\n", "$1\r\n4\r\n", "$4\r\nfive\r\n"))
           )
         }
+      ),
+      suite("Tuple7")(
+        testM("valid value") {
+          for {
+            result <- Task(
+                        Tuple7(StringInput, LongInput, StringInput, LongInput, StringInput, LongInput, StringInput)
+                          .encode(("one", 2, "three", 4, "five", 6, "seven"))
+                      )
+          } yield assert(result)(
+            equalTo(
+              Chunk(
+                "$3\r\none\r\n",
+                "$1\r\n2\r\n",
+                "$5\r\nthree\r\n",
+                "$1\r\n4\r\n",
+                "$4\r\nfive\r\n",
+                "$1\r\n6\r\n",
+                "$5\r\nseven\r\n"
+              )
+            )
+          )
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -345,13 +345,13 @@ object InputSpec extends BaseSpec {
       suite("Limit")(
         testM("with positive offset and positive count") {
           for {
-            result <- Task(LimitInput.encode(Limit(5L, 5L)))
-          } yield assert(result)(equalTo(Chunk("$5\r\nLIMIT\r\n", "$1\r\n5\r\n", "$1\r\n5\r\n")))
+            result <- Task(LimitInput.encode(Limit(4L, 5L)))
+          } yield assert(result)(equalTo(Chunk("$5\r\nLIMIT\r\n", "$1\r\n4\r\n", "$1\r\n5\r\n")))
         },
         testM("with negative offset and negative count") {
           for {
-            result <- Task(LimitInput.encode(Limit(-5L, -5L)))
-          } yield assert(result)(equalTo(Chunk("$5\r\nLIMIT\r\n", "$2\r\n-5\r\n", "$2\r\n-5\r\n")))
+            result <- Task(LimitInput.encode(Limit(-4L, -5L)))
+          } yield assert(result)(equalTo(Chunk("$5\r\nLIMIT\r\n", "$2\r\n-4\r\n", "$2\r\n-5\r\n")))
         },
         testM("with zero offset and zero count") {
           for {
@@ -374,6 +374,23 @@ object InputSpec extends BaseSpec {
           for {
             result <- Task(LongInput.encode(0L))
           } yield assert(result)(equalTo(Chunk.single("$1\r\n0\r\n")))
+        }
+      ),
+      suite("LongLat")(
+        testM("positive longitude and latitude") {
+          for {
+            result <- Task(LongLatInput.encode(LongLat(4.2d, 5.2d)))
+          } yield assert(result)(equalTo(Chunk("$3\r\n4.2\r\n", "$3\r\n5.2\r\n")))
+        },
+        testM("negative longitude and latitude") {
+          for {
+            result <- Task(LongLatInput.encode(LongLat(-4.2d, -5.2d)))
+          } yield assert(result)(equalTo(Chunk("$4\r\n-4.2\r\n", "$4\r\n-5.2\r\n")))
+        },
+        testM("zero longitude and latitude") {
+          for {
+            result <- Task(LongLatInput.encode(LongLat(0d, 0d)))
+          } yield assert(result)(equalTo(Chunk("$3\r\n0.0\r\n", "$3\r\n0.0\r\n")))
         }
       )
     )

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -6,6 +6,7 @@ import zio.test._
 import zio.test.Assertion._
 import BitFieldCommand._
 import BitFieldType._
+import BitOperation._
 
 object InputSpec extends BaseSpec {
   def spec: ZSpec[environment.TestEnvironment, Any] =
@@ -118,6 +119,28 @@ object InputSpec extends BaseSpec {
           for {
             result <- Task(BitFieldCommandInput.encode(BitFieldOverflow.Wrap))
           } yield assert(result)(equalTo(Chunk("$8\r\nOVERFLOW\r\n", "$4\r\nWRAP\r\n")))
+        }
+      ),
+      suite("bit operation")(
+        testM("and") {
+          for {
+            result <- Task(BitOperationInput.encode(AND))
+          } yield assert(result)(equalTo(Chunk.single("$3\r\nAND\r\n")))
+        },
+        testM("or") {
+          for {
+            result <- Task(BitOperationInput.encode(OR))
+          } yield assert(result)(equalTo(Chunk.single("$2\r\nOR\r\n")))
+        },
+        testM("xor") {
+          for {
+            result <- Task(BitOperationInput.encode(XOR))
+          } yield assert(result)(equalTo(Chunk.single("$3\r\nXOR\r\n")))
+        },
+        testM("not") {
+          for {
+            result <- Task(BitOperationInput.encode(NOT))
+          } yield assert(result)(equalTo(Chunk.single("$3\r\nNOT\r\n")))
         }
       )
     )

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -1,16 +1,17 @@
 package zio.redis
 
-import zio.{ Chunk, Task }
-import zio.redis.Input._
-import zio.test._
-import zio.test.Assertion._
+import java.time.Instant
+
 import BitFieldCommand._
 import BitFieldType._
 import BitOperation._
-import zio.duration._
 import Order._
 import RadiusUnit._
-import java.time.Instant
+import zio.duration._
+import zio.redis.Input._
+import zio.test.Assertion._
+import zio.test._
+import zio.{ Chunk, Task }
 
 object InputSpec extends BaseSpec {
   def spec: ZSpec[environment.TestEnvironment, Any] =
@@ -663,6 +664,13 @@ object InputSpec extends BaseSpec {
           for {
             result <- Task(Tuple3(StringInput, LongInput, StringInput).encode(("one", 2, "three")))
           } yield assert(result)(equalTo(Chunk("$3\r\none\r\n", "$1\r\n2\r\n", "$5\r\nthree\r\n")))
+        }
+      ),
+      suite("Tuple4")(
+        testM("valid value") {
+          for {
+            result <- Task(Tuple4(StringInput, LongInput, StringInput, LongInput).encode(("one", 2, "three", 4)))
+          } yield assert(result)(equalTo(Chunk("$3\r\none\r\n", "$1\r\n2\r\n", "$5\r\nthree\r\n", "$1\r\n4\r\n")))
         }
       )
     )

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -4,6 +4,8 @@ import zio.{ Chunk, Task }
 import zio.redis.Input._
 import zio.test._
 import zio.test.Assertion._
+import BitFieldCommand._
+import BitFieldType._
 
 object InputSpec extends BaseSpec {
   def spec: ZSpec[environment.TestEnvironment, Any] =
@@ -54,6 +56,68 @@ object InputSpec extends BaseSpec {
           for {
             result <- Task(BoolInput.encode(false))
           } yield assert(result)(equalTo(Chunk.single("$1\r\n0\r\n")))
+        }
+      ),
+      suite("bit field command")(
+        testM("get with unsigned type and positive offset") {
+          for {
+            result <- Task(BitFieldCommandInput.encode(BitFieldGet(UnsignedInt(3), 2)))
+          } yield assert(result)(equalTo(Chunk("$3\r\nGET\r\n", "$2\r\nu3\r\n", "$1\r\n2\r\n")))
+        },
+        testM("get with signed type and negative offset") {
+          for {
+            result <- Task(BitFieldCommandInput.encode(BitFieldGet(SignedInt(3), -2)))
+          } yield assert(result)(equalTo(Chunk("$3\r\nGET\r\n", "$2\r\ni3\r\n", "$2\r\n-2\r\n")))
+        },
+        testM("get with unsigned type and zero offset") {
+          for {
+            result <- Task(BitFieldCommandInput.encode(BitFieldGet(UnsignedInt(3), 0)))
+          } yield assert(result)(equalTo(Chunk("$3\r\nGET\r\n", "$2\r\nu3\r\n", "$1\r\n0\r\n")))
+        },
+        testM("set with unsigned type, positive offset and positive value") {
+          for {
+            result <- Task(BitFieldCommandInput.encode(BitFieldSet(UnsignedInt(3), 2, 100L)))
+          } yield assert(result)(equalTo(Chunk("$3\r\nSET\r\n", "$2\r\nu3\r\n", "$1\r\n2\r\n", "$3\r\n100\r\n")))
+        },
+        testM("set with signed type, negative offset and negative value") {
+          for {
+            result <- Task(BitFieldCommandInput.encode(BitFieldSet(SignedInt(3), -2, -100L)))
+          } yield assert(result)(equalTo(Chunk("$3\r\nSET\r\n", "$2\r\ni3\r\n", "$2\r\n-2\r\n", "$4\r\n-100\r\n")))
+        },
+        testM("set with unsigned type, zero offset and zero value") {
+          for {
+            result <- Task(BitFieldCommandInput.encode(BitFieldSet(UnsignedInt(3), 0, 0L)))
+          } yield assert(result)(equalTo(Chunk("$3\r\nSET\r\n", "$2\r\nu3\r\n", "$1\r\n0\r\n", "$1\r\n0\r\n")))
+        },
+        testM("incr with unsigned type, positive offset and positive value") {
+          for {
+            result <- Task(BitFieldCommandInput.encode(BitFieldIncr(UnsignedInt(3), 2, 100L)))
+          } yield assert(result)(equalTo(Chunk("$6\r\nINCRBY\r\n", "$2\r\nu3\r\n", "$1\r\n2\r\n", "$3\r\n100\r\n")))
+        },
+        testM("incr with signed type, negative offset and negative value") {
+          for {
+            result <- Task(BitFieldCommandInput.encode(BitFieldIncr(SignedInt(3), -2, -100L)))
+          } yield assert(result)(equalTo(Chunk("$6\r\nINCRBY\r\n", "$2\r\ni3\r\n", "$2\r\n-2\r\n", "$4\r\n-100\r\n")))
+        },
+        testM("incr with unsigned type, zero offset and zero value") {
+          for {
+            result <- Task(BitFieldCommandInput.encode(BitFieldIncr(UnsignedInt(3), 0, 0L)))
+          } yield assert(result)(equalTo(Chunk("$6\r\nINCRBY\r\n", "$2\r\nu3\r\n", "$1\r\n0\r\n", "$1\r\n0\r\n")))
+        },
+        testM("overflow sat") {
+          for {
+            result <- Task(BitFieldCommandInput.encode(BitFieldOverflow.Sat))
+          } yield assert(result)(equalTo(Chunk("$8\r\nOVERFLOW\r\n", "$3\r\nSAT\r\n")))
+        },
+        testM("overflow fail") {
+          for {
+            result <- Task(BitFieldCommandInput.encode(BitFieldOverflow.Fail))
+          } yield assert(result)(equalTo(Chunk("$8\r\nOVERFLOW\r\n", "$4\r\nFAIL\r\n")))
+        },
+        testM("overflow warp") {
+          for {
+            result <- Task(BitFieldCommandInput.encode(BitFieldOverflow.Wrap))
+          } yield assert(result)(equalTo(Chunk("$8\r\nOVERFLOW\r\n", "$4\r\nWRAP\r\n")))
         }
       )
     )

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -268,6 +268,18 @@ object InputSpec extends BaseSpec {
             result <- Task(FreqInput.encode(Freq("frequency")))
           } yield assert(result)(equalTo(Chunk("$4\r\nFREQ\r\n", "$9\r\nfrequency\r\n")))
         }
+      ),
+      suite("IdleTime")(
+        testM("0 seconds") {
+          for {
+            result <- Task(IdleTimeInput.encode(IdleTime(0)))
+          } yield assert(result)(equalTo(Chunk("$8\r\nIDLETIME\r\n", "$1\r\n0\r\n")))
+        },
+        testM("5 seconds") {
+          for {
+            result <- Task(IdleTimeInput.encode(IdleTime(5)))
+          } yield assert(result)(equalTo(Chunk("$8\r\nIDLETIME\r\n", "$1\r\n5\r\n")))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -31,6 +31,18 @@ object InputSpec extends BaseSpec {
             result <- Task(AggregateInput.encode(Aggregate.Sum))
           } yield assert(result)(equalTo(Chunk.single("$3\r\nSUM\r\n")))
         }
+      ),
+      suite("auth")(
+        testM("with empty password") {
+          for {
+            result <- Task(AuthInput.encode(Auth("")))
+          } yield assert(result)(equalTo(Chunk("$4\r\nAUTH\r\n", "$0\r\n\r\n")))
+        },
+        testM("with non-empty password") {
+          for {
+            result <- Task(AuthInput.encode(Auth("pass")))
+          } yield assert(result)(equalTo(Chunk("$4\r\nAUTH\r\n", "$4\r\npass\r\n")))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -650,6 +650,13 @@ object InputSpec extends BaseSpec {
             result <- Task(TimeMillisecondsInput.encode(Instant.ofEpochSecond(-3L)))
           } yield assert(result)(equalTo(Chunk("$5\r\n-3000\r\n")))
         }
+      ),
+      suite("Tuple2")(
+        testM("valid value") {
+          for {
+            result <- Task(Tuple2(StringInput, LongInput).encode(("one", 2L)))
+          } yield assert(result)(equalTo(Chunk("$3\r\none\r\n", "$1\r\n2\r\n")))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -341,6 +341,23 @@ object InputSpec extends BaseSpec {
             result <- Task(LexRangeInput.encode(LexRange(LexMinimum.Closed("a"), LexMaximum.Closed("z"))))
           } yield assert(result)(equalTo(Chunk("$2\r\n[a\r\n", "$2\r\n[z\r\n")))
         }
+      ),
+      suite("Limit")(
+        testM("with positive offset and positive count") {
+          for {
+            result <- Task(LimitInput.encode(Limit(5L, 5L)))
+          } yield assert(result)(equalTo(Chunk("$5\r\nLIMIT\r\n", "$1\r\n5\r\n", "$1\r\n5\r\n")))
+        },
+        testM("with negative offset and negative count") {
+          for {
+            result <- Task(LimitInput.encode(Limit(-5L, -5L)))
+          } yield assert(result)(equalTo(Chunk("$5\r\nLIMIT\r\n", "$2\r\n-5\r\n", "$2\r\n-5\r\n")))
+        },
+        testM("with zero offset and zero count") {
+          for {
+            result <- Task(LimitInput.encode(Limit(0L, 0L)))
+          } yield assert(result)(equalTo(Chunk("$5\r\nLIMIT\r\n", "$1\r\n0\r\n", "$1\r\n0\r\n")))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -672,6 +672,18 @@ object InputSpec extends BaseSpec {
             result <- Task(Tuple4(StringInput, LongInput, StringInput, LongInput).encode(("one", 2, "three", 4)))
           } yield assert(result)(equalTo(Chunk("$3\r\none\r\n", "$1\r\n2\r\n", "$5\r\nthree\r\n", "$1\r\n4\r\n")))
         }
+      ),
+      suite("Tuple5")(
+        testM("valid value") {
+          for {
+            result <- Task(
+                        Tuple5(StringInput, LongInput, StringInput, LongInput, StringInput)
+                          .encode(("one", 2, "three", 4, "five"))
+                      )
+          } yield assert(result)(
+            equalTo(Chunk("$3\r\none\r\n", "$1\r\n2\r\n", "$5\r\nthree\r\n", "$1\r\n4\r\n", "$4\r\nfive\r\n"))
+          )
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -603,6 +603,18 @@ object InputSpec extends BaseSpec {
             result <- Task(StringInput.encode(""))
           } yield assert(result)(equalTo(Chunk.single("$0\r\n\r\n")))
         }
+      ),
+      suite("Optional")(
+        testM("none") {
+          for {
+            result <- Task(OptionalInput(LongInput).encode(None))
+          } yield assert(result)(isEmpty)
+        },
+        testM("some") {
+          for {
+            result <- Task(OptionalInput(LongInput).encode(Some(2L)))
+          } yield assert(result)(equalTo(Chunk.single("$1\r\n2\r\n")))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -256,6 +256,18 @@ object InputSpec extends BaseSpec {
             result <- Task(DurationTtlInput.encode(100.millis))
           } yield assert(result)(equalTo(Chunk("$2\r\nPX\r\n", "$3\r\n100\r\n")))
         }
+      ),
+      suite("Freq")(
+        testM("empty string") {
+          for {
+            result <- Task(FreqInput.encode(Freq("")))
+          } yield assert(result)(equalTo(Chunk("$4\r\nFREQ\r\n", "$0\r\n\r\n")))
+        },
+        testM("non-empty string") {
+          for {
+            result <- Task(FreqInput.encode(Freq("frequency")))
+          } yield assert(result)(equalTo(Chunk("$4\r\nFREQ\r\n", "$9\r\nfrequency\r\n")))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -43,6 +43,18 @@ object InputSpec extends BaseSpec {
             result <- Task(AuthInput.encode(Auth("pass")))
           } yield assert(result)(equalTo(Chunk("$4\r\nAUTH\r\n", "$4\r\npass\r\n")))
         }
+      ),
+      suite("bool")(
+        testM("true") {
+          for {
+            result <- Task(BoolInput.encode(true))
+          } yield assert(result)(equalTo(Chunk.single("$1\r\n1\r\n")))
+        },
+        testM("false") {
+          for {
+            result <- Task(BoolInput.encode(false))
+          } yield assert(result)(equalTo(Chunk.single("$1\r\n0\r\n")))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -739,6 +739,43 @@ object InputSpec extends BaseSpec {
             )
           )
         }
+      ),
+      suite("Tuple11")(
+        testM("valid value") {
+          for {
+            result <- Task(
+                        Tuple11(
+                          StringInput,
+                          LongInput,
+                          StringInput,
+                          LongInput,
+                          StringInput,
+                          LongInput,
+                          StringInput,
+                          LongInput,
+                          StringInput,
+                          LongInput,
+                          StringInput
+                        ).encode(("one", 2, "three", 4, "five", 6, "seven", 8, "nine", 10, "eleven"))
+                      )
+          } yield assert(result)(
+            equalTo(
+              Chunk(
+                "$3\r\none\r\n",
+                "$1\r\n2\r\n",
+                "$5\r\nthree\r\n",
+                "$1\r\n4\r\n",
+                "$4\r\nfive\r\n",
+                "$1\r\n6\r\n",
+                "$5\r\nseven\r\n",
+                "$1\r\n8\r\n",
+                "$4\r\nnine\r\n",
+                "$2\r\n10\r\n",
+                "$6\r\neleven\r\n"
+              )
+            )
+          )
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -788,6 +788,18 @@ object InputSpec extends BaseSpec {
             result <- Task(UpdateInput.encode(Update.SetNew))
           } yield assert(result)(equalTo(Chunk.single("$2\r\nNX\r\n")))
         }
+      ),
+      suite("Varargs")(
+        testM("with multiple elements") {
+          for {
+            result <- Task(Varargs(LongInput).encode(List(1, 2, 3)))
+          } yield assert(result)(equalTo(Chunk("$1\r\n1\r\n", "$1\r\n2\r\n", "$1\r\n3\r\n")))
+        },
+        testM("with no elements") {
+          for {
+            result <- Task(Varargs(LongInput).encode(List.empty))
+          } yield assert(result)(isEmpty)
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -479,6 +479,28 @@ object InputSpec extends BaseSpec {
             result <- Task(RadiusUnitInput.encode(Miles))
           } yield assert(result)(equalTo(Chunk.single("$2\r\nmi\r\n")))
         }
+      ),
+      suite("Range")(
+        testM("with positive start and positive end") {
+          for {
+            result <- Task(RangeInput.encode(Range(1, 5)))
+          } yield assert(result)(equalTo(Chunk("$1\r\n1\r\n", "$1\r\n5\r\n")))
+        },
+        testM("with negative start and positive end") {
+          for {
+            result <- Task(RangeInput.encode(Range(-1, 5)))
+          } yield assert(result)(equalTo(Chunk("$2\r\n-1\r\n", "$1\r\n5\r\n")))
+        },
+        testM("with positive start and negative end") {
+          for {
+            result <- Task(RangeInput.encode(Range(1, -5)))
+          } yield assert(result)(equalTo(Chunk("$1\r\n1\r\n", "$2\r\n-5\r\n")))
+        },
+        testM("with negative start and negative end") {
+          for {
+            result <- Task(RangeInput.encode(Range(-1, -5)))
+          } yield assert(result)(equalTo(Chunk("$2\r\n-1\r\n", "$2\r\n-5\r\n")))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -424,6 +424,13 @@ object InputSpec extends BaseSpec {
             result <- Task(MemberScoreInput.encode(MemberScore(0d, "member")))
           } yield assert(result)(equalTo(Chunk("$3\r\n0.0\r\n", "$6\r\nmember\r\n")))
         }
+      ),
+      suite("NoInput")(
+        testM("valid value") {
+          for {
+            result <- Task(NoInput.encode(()))
+          } yield assert(result)(isEmpty)
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -657,6 +657,13 @@ object InputSpec extends BaseSpec {
             result <- Task(Tuple2(StringInput, LongInput).encode(("one", 2L)))
           } yield assert(result)(equalTo(Chunk("$3\r\none\r\n", "$1\r\n2\r\n")))
         }
+      ),
+      suite("Tuple3")(
+        testM("valid value") {
+          for {
+            result <- Task(Tuple3(StringInput, LongInput, StringInput).encode(("one", 2, "three")))
+          } yield assert(result)(equalTo(Chunk("$3\r\none\r\n", "$1\r\n2\r\n", "$5\r\nthree\r\n")))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -532,6 +532,18 @@ object InputSpec extends BaseSpec {
             result <- Task(StoreDistInput.encode(StoreDist("")))
           } yield assert(result)(equalTo(Chunk("$9\r\nSTOREDIST\r\n", "$0\r\n\r\n")))
         }
+      ),
+      suite("Store")(
+        testM("with non-empty string") {
+          for {
+            result <- Task(StoreInput.encode(Store("key")))
+          } yield assert(result)(equalTo(Chunk("$5\r\nSTORE\r\n", "$3\r\nkey\r\n")))
+        },
+        testM("with empty string") {
+          for {
+            result <- Task(StoreInput.encode(Store("")))
+          } yield assert(result)(equalTo(Chunk("$5\r\nSTORE\r\n", "$0\r\n\r\n")))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -1,0 +1,19 @@
+package zio.redis
+
+import zio.{ Chunk, Task }
+import zio.redis.Input._
+import zio.test._
+import zio.test.Assertion._
+
+object InputSpec extends BaseSpec {
+  def spec: ZSpec[environment.TestEnvironment, Any] =
+    suite("Input encoders")(
+      suite("abs ttl")(
+        testM("valid value") {
+          for {
+            result <- Task(AbsTtlInput.encode(AbsTtl))
+          } yield assert(result)(equalTo(Chunk.single("$6\r\nABSTTL\r\n")))
+        }
+      )
+    )
+}

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -155,6 +155,13 @@ object InputSpec extends BaseSpec {
             result <- Task(BitPosRangeInput.encode(BitPosRange(0.second.toMillis, Some(1.second.toMillis))))
           } yield assert(result)(equalTo(Chunk("$1\r\n0\r\n", "$4\r\n1000\r\n")))
         }
+      ),
+      suite("Changed")(
+        testM("valid value") {
+          for {
+            result <- Task(ChangedInput.encode(Changed))
+          } yield assert(result)(equalTo(Chunk("$2\r\nCH\r\n")))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -8,6 +8,8 @@ import BitFieldCommand._
 import BitFieldType._
 import BitOperation._
 import zio.duration._
+import Order._
+import RadiusUnit._
 
 object InputSpec extends BaseSpec {
   def spec: ZSpec[environment.TestEnvironment, Any] =
@@ -447,13 +449,35 @@ object InputSpec extends BaseSpec {
       suite("Order")(
         testM("ascending") {
           for {
-            result <- Task(OrderInput.encode(Order.Ascending))
+            result <- Task(OrderInput.encode(Ascending))
           } yield assert(result)(equalTo(Chunk.single("$3\r\nASC\r\n")))
         },
         testM("descending") {
           for {
-            result <- Task(OrderInput.encode(Order.Descending))
+            result <- Task(OrderInput.encode(Descending))
           } yield assert(result)(equalTo(Chunk.single("$4\r\nDESC\r\n")))
+        }
+      ),
+      suite("RadiusUnit")(
+        testM("meters") {
+          for {
+            result <- Task(RadiusUnitInput.encode(Meters))
+          } yield assert(result)(equalTo(Chunk.single("$1\r\nm\r\n")))
+        },
+        testM("kilometers") {
+          for {
+            result <- Task(RadiusUnitInput.encode(Kilometers))
+          } yield assert(result)(equalTo(Chunk.single("$2\r\nkm\r\n")))
+        },
+        testM("feet") {
+          for {
+            result <- Task(RadiusUnitInput.encode(Feet))
+          } yield assert(result)(equalTo(Chunk.single("$2\r\nft\r\n")))
+        },
+        testM("miles") {
+          for {
+            result <- Task(RadiusUnitInput.encode(Miles))
+          } yield assert(result)(equalTo(Chunk.single("$2\r\nmi\r\n")))
         }
       )
     )

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -800,6 +800,13 @@ object InputSpec extends BaseSpec {
             result <- Task(Varargs(LongInput).encode(List.empty))
           } yield assert(result)(isEmpty)
         }
+      ),
+      suite("WithScores")(
+        testM("valid value") {
+          for {
+            result <- Task(WithScoresInput.encode(WithScores))
+          } yield assert(result)(equalTo(Chunk("$10\r\nWITHSCORES\r\n")))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -169,6 +169,23 @@ object InputSpec extends BaseSpec {
             result <- Task(CopyInput.encode(Copy))
           } yield assert(result)(equalTo(Chunk("$4\r\nCOPY\r\n")))
         }
+      ),
+      suite("Count")(
+        testM("positive value") {
+          for {
+            result <- Task(CountInput.encode(Count(3L)))
+          } yield assert(result)(equalTo(Chunk("$5\r\nCOUNT\r\n", "$1\r\n3\r\n")))
+        },
+        testM("negative value") {
+          for {
+            result <- Task(CountInput.encode(Count(-3L)))
+          } yield assert(result)(equalTo(Chunk("$5\r\nCOUNT\r\n", "$2\r\n-3\r\n")))
+        },
+        testM("zero value") {
+          for {
+            result <- Task(CountInput.encode(Count(0L)))
+          } yield assert(result)(equalTo(Chunk("$5\r\nCOUNT\r\n", "$1\r\n0\r\n")))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -805,7 +805,14 @@ object InputSpec extends BaseSpec {
         testM("valid value") {
           for {
             result <- Task(WithScoresInput.encode(WithScores))
-          } yield assert(result)(equalTo(Chunk("$10\r\nWITHSCORES\r\n")))
+          } yield assert(result)(equalTo(Chunk.single("$10\r\nWITHSCORES\r\n")))
+        }
+      ),
+      suite("WithCoord")(
+        testM("valid value") {
+          for {
+            result <- Task(WithCoordInput.encode(WithCoord))
+          } yield assert(result)(equalTo(Chunk.single("$9\r\nWITHCOORD\r\n")))
         }
       )
     )

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -358,6 +358,23 @@ object InputSpec extends BaseSpec {
             result <- Task(LimitInput.encode(Limit(0L, 0L)))
           } yield assert(result)(equalTo(Chunk("$5\r\nLIMIT\r\n", "$1\r\n0\r\n", "$1\r\n0\r\n")))
         }
+      ),
+      suite("Long")(
+        testM("positive value") {
+          for {
+            result <- Task(LongInput.encode(4L))
+          } yield assert(result)(equalTo(Chunk.single("$1\r\n4\r\n")))
+        },
+        testM("negative value") {
+          for {
+            result <- Task(LongInput.encode(-4L))
+          } yield assert(result)(equalTo(Chunk.single("$2\r\n-4\r\n")))
+        },
+        testM("zero value") {
+          for {
+            result <- Task(LongInput.encode(0L))
+          } yield assert(result)(equalTo(Chunk.single("$1\r\n0\r\n")))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -294,6 +294,53 @@ object InputSpec extends BaseSpec {
             result <- Task(KeepTtlInput.encode(KeepTtl))
           } yield assert(result)(equalTo(Chunk.single("$7\r\nKEEPTTL\r\n")))
         }
+      ),
+      suite("LexRange")(
+        testM("with unbound min and unbound max") {
+          for {
+            result <- Task(LexRangeInput.encode(LexRange(LexMinimum.Unbounded, LexMaximum.Unbounded)))
+          } yield assert(result)(equalTo(Chunk("$1\r\n-\r\n", "$1\r\n+\r\n")))
+        },
+        testM("with open min and unbound max") {
+          for {
+            result <- Task(LexRangeInput.encode(LexRange(LexMinimum.Open("a"), LexMaximum.Unbounded)))
+          } yield assert(result)(equalTo(Chunk("$2\r\n(a\r\n", "$1\r\n+\r\n")))
+        },
+        testM("with closed min and unbound max") {
+          for {
+            result <- Task(LexRangeInput.encode(LexRange(LexMinimum.Closed("a"), LexMaximum.Unbounded)))
+          } yield assert(result)(equalTo(Chunk("$2\r\n[a\r\n", "$1\r\n+\r\n")))
+        },
+        testM("with unbound min and open max") {
+          for {
+            result <- Task(LexRangeInput.encode(LexRange(LexMinimum.Unbounded, LexMaximum.Open("z"))))
+          } yield assert(result)(equalTo(Chunk("$1\r\n-\r\n", "$2\r\n(z\r\n")))
+        },
+        testM("with open min and open max") {
+          for {
+            result <- Task(LexRangeInput.encode(LexRange(LexMinimum.Open("a"), LexMaximum.Open("z"))))
+          } yield assert(result)(equalTo(Chunk("$2\r\n(a\r\n", "$2\r\n(z\r\n")))
+        },
+        testM("with closed min and open max") {
+          for {
+            result <- Task(LexRangeInput.encode(LexRange(LexMinimum.Closed("a"), LexMaximum.Open("z"))))
+          } yield assert(result)(equalTo(Chunk("$2\r\n[a\r\n", "$2\r\n(z\r\n")))
+        },
+        testM("with unbound min and closed max") {
+          for {
+            result <- Task(LexRangeInput.encode(LexRange(LexMinimum.Unbounded, LexMaximum.Closed("z"))))
+          } yield assert(result)(equalTo(Chunk("$1\r\n-\r\n", "$2\r\n[z\r\n")))
+        },
+        testM("with open min and closed max") {
+          for {
+            result <- Task(LexRangeInput.encode(LexRange(LexMinimum.Open("a"), LexMaximum.Closed("z"))))
+          } yield assert(result)(equalTo(Chunk("$2\r\n(a\r\n", "$2\r\n[z\r\n")))
+        },
+        testM("with closed min and closed max") {
+          for {
+            result <- Task(LexRangeInput.encode(LexRange(LexMinimum.Closed("a"), LexMaximum.Closed("z"))))
+          } yield assert(result)(equalTo(Chunk("$2\r\n[a\r\n", "$2\r\n[z\r\n")))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -520,6 +520,18 @@ object InputSpec extends BaseSpec {
             result <- Task(ReplaceInput.encode(Replace))
           } yield assert(result)(equalTo(Chunk.single("$7\r\nREPLACE\r\n")))
         }
+      ),
+      suite("StoreDist")(
+        testM("with non-empty string") {
+          for {
+            result <- Task(StoreDistInput.encode(StoreDist("key")))
+          } yield assert(result)(equalTo(Chunk("$9\r\nSTOREDIST\r\n", "$3\r\nkey\r\n")))
+        },
+        testM("with empty string") {
+          for {
+            result <- Task(StoreDistInput.encode(StoreDist("")))
+          } yield assert(result)(equalTo(Chunk("$9\r\nSTOREDIST\r\n", "$0\r\n\r\n")))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -431,6 +431,18 @@ object InputSpec extends BaseSpec {
             result <- Task(NoInput.encode(()))
           } yield assert(result)(isEmpty)
         }
+      ),
+      suite("NonEmptyList")(
+        testM("with multiple elements") {
+          for {
+            result <- Task(NonEmptyList(StringInput).encode(("a", List("b", "c"))))
+          } yield assert(result)(equalTo(Chunk("$1\r\na\r\n", "$1\r\nb\r\n", "$1\r\nc\r\n")))
+        },
+        testM("with one element") {
+          for {
+            result <- Task(NonEmptyList(StringInput).encode(("a", List.empty)))
+          } yield assert(result)(equalTo(Chunk.single("$1\r\na\r\n")))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -392,6 +392,38 @@ object InputSpec extends BaseSpec {
             result <- Task(LongLatInput.encode(LongLat(0d, 0d)))
           } yield assert(result)(equalTo(Chunk("$3\r\n0.0\r\n", "$3\r\n0.0\r\n")))
         }
+      ),
+      suite("MemberScore")(
+        testM("with positive score and empty member") {
+          for {
+            result <- Task(MemberScoreInput.encode(MemberScore(4.2d, "")))
+          } yield assert(result)(equalTo(Chunk("$3\r\n4.2\r\n", "$0\r\n\r\n")))
+        },
+        testM("with negative score and empty member") {
+          for {
+            result <- Task(MemberScoreInput.encode(MemberScore(-4.2d, "")))
+          } yield assert(result)(equalTo(Chunk("$4\r\n-4.2\r\n", "$0\r\n\r\n")))
+        },
+        testM("with zero score and empty member") {
+          for {
+            result <- Task(MemberScoreInput.encode(MemberScore(0d, "")))
+          } yield assert(result)(equalTo(Chunk("$3\r\n0.0\r\n", "$0\r\n\r\n")))
+        },
+        testM("with positive score and non-empty member") {
+          for {
+            result <- Task(MemberScoreInput.encode(MemberScore(4.2d, "member")))
+          } yield assert(result)(equalTo(Chunk("$3\r\n4.2\r\n", "$6\r\nmember\r\n")))
+        },
+        testM("with negative score and non-empty member") {
+          for {
+            result <- Task(MemberScoreInput.encode(MemberScore(-4.2d, "member")))
+          } yield assert(result)(equalTo(Chunk("$4\r\n-4.2\r\n", "$6\r\nmember\r\n")))
+        },
+        testM("with zero score and non-empty member") {
+          for {
+            result <- Task(MemberScoreInput.encode(MemberScore(0d, "member")))
+          } yield assert(result)(equalTo(Chunk("$3\r\n0.0\r\n", "$6\r\nmember\r\n")))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -227,6 +227,23 @@ object InputSpec extends BaseSpec {
             result <- Task(DurationMillisecondsInput.encode(100.millis))
           } yield assert(result)(equalTo(Chunk("$3\r\n100\r\n")))
         }
+      ),
+      suite("DurationSeconds")(
+        testM("1 minute") {
+          for {
+            result <- Task(DurationSecondsInput.encode(1.minute))
+          } yield assert(result)(equalTo(Chunk.single("$2\r\n60\r\n")))
+        },
+        testM("1 second") {
+          for {
+            result <- Task(DurationSecondsInput.encode(1.second))
+          } yield assert(result)(equalTo(Chunk.single("$1\r\n1\r\n")))
+        },
+        testM("100 milliseconds") {
+          for {
+            result <- Task(DurationSecondsInput.encode(100.millis))
+          } yield assert(result)(equalTo(Chunk.single("$1\r\n0\r\n")))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -244,6 +244,18 @@ object InputSpec extends BaseSpec {
             result <- Task(DurationSecondsInput.encode(100.millis))
           } yield assert(result)(equalTo(Chunk.single("$1\r\n0\r\n")))
         }
+      ),
+      suite("DurationTtl")(
+        testM("1 second") {
+          for {
+            result <- Task(DurationTtlInput.encode(1.second))
+          } yield assert(result)(equalTo(Chunk("$2\r\nPX\r\n", "$4\r\n1000\r\n")))
+        },
+        testM("100 milliseconds") {
+          for {
+            result <- Task(DurationTtlInput.encode(100.millis))
+          } yield assert(result)(equalTo(Chunk("$2\r\nPX\r\n", "$3\r\n100\r\n")))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -776,6 +776,18 @@ object InputSpec extends BaseSpec {
             )
           )
         }
+      ),
+      suite("Update")(
+        testM("set existing") {
+          for {
+            result <- Task(UpdateInput.encode(Update.SetExisting))
+          } yield assert(result)(equalTo(Chunk.single("$2\r\nXX\r\n")))
+        },
+        testM("set new") {
+          for {
+            result <- Task(UpdateInput.encode(Update.SetNew))
+          } yield assert(result)(equalTo(Chunk.single("$2\r\nNX\r\n")))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -821,6 +821,13 @@ object InputSpec extends BaseSpec {
             result <- Task(WithDistInput.encode(WithDist))
           } yield assert(result)(equalTo(Chunk.single("$8\r\nWITHDIST\r\n")))
         }
+      ),
+      suite("WithHash")(
+        testM("valid value") {
+          for {
+            result <- Task(WithHashInput.encode(WithHash))
+          } yield assert(result)(equalTo(Chunk.single("$8\r\nWITHHASH\r\n")))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -280,6 +280,13 @@ object InputSpec extends BaseSpec {
             result <- Task(IdleTimeInput.encode(IdleTime(5)))
           } yield assert(result)(equalTo(Chunk("$8\r\nIDLETIME\r\n", "$1\r\n5\r\n")))
         }
+      ),
+      suite("Increment")(
+        testM("valid value") {
+          for {
+            result <- Task(IncrementInput.encode(Increment))
+          } yield assert(result)(equalTo(Chunk("$4\r\nINCR\r\n")))
+        }
       )
     )
 }


### PR DESCRIPTION
This PR resolves #69.

**Summary:**
1. Added tests for all of the input encodings.
2. Fixed `Tuple7` encoding.
3. Fixed `Tuple9` encoding.