### PR TITLE
Add connection pool support for streams

### DIFF
--- a/benchmarks/src/main/scala/zio/redis/BenchmarkRuntime.scala
+++ b/benchmarks/src/main/scala/zio/redis/BenchmarkRuntime.scala
@@ -7,6 +7,7 @@ import io.chrisdavenport.rediculous.Redis
 
 import zio.BootstrapRuntime
 import zio.internal.Platform
+import zio.duration._
 
 object BenchmarkRuntime extends BootstrapRuntime {
   implicit val cs: ContextShift[CatsIO] = CatsIO.contextShift(ExecutionContext.global)
@@ -16,6 +17,8 @@ object BenchmarkRuntime extends BootstrapRuntime {
 
   type RedisIO[A] = Redis[CatsIO, A]
 
-  final val RedisHost = "127.0.0.1"
-  final val RedisPort = 6379
+  final val RedisHost                    = "127.0.0.1"
+  final val RedisPort                    = 6379
+  final val ConnectionPoolMaxSize        = 1
+  final val ConnectionPoolMaxIdleTimeout = 10.seconds
 }

--- a/benchmarks/src/main/scala/zio/redis/PutBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/PutBenchmarks.scala
@@ -76,7 +76,20 @@ class PutBenchmarks {
   def zio(): Unit = {
     val effect = ZIO
       .foreach_(items)(i => set(i, i, None, None, None))
-      .provideLayer(RedisExecutor.live(RedisHost, RedisPort).orDie)
+      .provideLayer(
+        RedisExecutor.live(
+          PoolConfig(
+            RedisHost,
+            RedisPort,
+            ConnectionPoolMaxSize,
+            ConnectionPoolMaxIdleTimeout,
+            ConnectionPoolMaxSize,
+            ConnectionPoolMaxIdleTimeout,
+            ConnectionPoolMaxSize,
+            ConnectionPoolMaxIdleTimeout
+          )
+        )
+      )
 
     unsafeRun(effect)
   }

--- a/redis/src/main/scala/zio/redis/ConnectionType.scala
+++ b/redis/src/main/scala/zio/redis/ConnectionType.scala
@@ -1,0 +1,9 @@
+package zio.redis
+
+sealed trait ConnectionType
+
+object ConnectionType {
+  case object Base         extends ConnectionType
+  case object Streams      extends ConnectionType
+  case object Transactions extends ConnectionType
+}

--- a/redis/src/main/scala/zio/redis/Interpreter.scala
+++ b/redis/src/main/scala/zio/redis/Interpreter.scala
@@ -5,12 +5,15 @@ import java.net.{ InetSocketAddress, StandardSocketOptions }
 import java.nio.ByteBuffer
 import java.nio.channels.SocketChannel
 import java.nio.charset.StandardCharsets.UTF_8
-import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.TimeUnit
 
 import scala.collection.mutable.ArrayBuilder
 
 import zio._
-import zio.blocking._
+import zio.clock.{ currentTime, sleep, Clock }
+import zio.duration.{ durationInt, Duration }
+import zio.redis.ConnectionType._
+import zio.stm.{ STM, TQueue, TRef }
 
 trait Interpreter {
   type RedisExecutor = Has[RedisExecutor.Service]
@@ -20,66 +23,43 @@ trait Interpreter {
     val ResponseBufferSize = 1024
 
     trait Service {
-      def execute(command: Chunk[String]): IO[RedisError, String]
+      def execute(command: Chunk[String], connectionType: ConnectionType): Task[String]
     }
 
-    def live(host: String, port: Int): ZLayer[Blocking, IOException, RedisExecutor] =
-      ZLayer.fromServiceManaged { env =>
+    // TODO: parametrize time interval in which connections should be clean
+    def live(config: PoolConfig): URLayer[Clock, RedisExecutor] =
+      ZLayer.fromManaged {
         for {
-          connection <- connect(host, port)
-          _          <- env.blocking(connection.receive.forever).forkManaged
+          clock <- Managed.environment[Clock]
+          cps   <- ConnectionPools(config)
+          _     <- (cps.cleanIdle *> sleep(10.seconds)).forever.forkManaged
         } yield new Service {
-          def execute(command: Chunk[String]): IO[RedisError, String] = connection.send(command).flatMap(_.await)
+          def execute(command: Chunk[String], connectionType: ConnectionType): Task[String] =
+            cps.get(connectionType).provide(clock).use(_.send(command))
         }
       }
 
-    private[this] def connect(host: String, port: Int): Managed[IOException, Connection] = {
-      val makeChannel =
-        IO {
-          val channel = SocketChannel.open(new InetSocketAddress(host, port))
-          channel.configureBlocking(false)
-          channel.setOption(StandardSocketOptions.SO_KEEPALIVE, Boolean.box(true))
-          channel.setOption(StandardSocketOptions.TCP_NODELAY, Boolean.box(true))
-          channel
-        }
-
-      val connection =
-        for {
-          channel         <- Managed.fromAutoCloseable(makeChannel)
-          pendingRequests <- Queue.unbounded[Request].toManaged_
-          readinessFlag    = new AtomicBoolean(true)
-          response         = ByteBuffer.allocate(ResponseBufferSize)
-        } yield new Connection(channel, pendingRequests, readinessFlag, response)
-
-      connection.refineToOrDie[IOException]
-    }
-
     private[this] final class Connection(
       channel: SocketChannel,
-      pendingRequests: Queue[Request],
-      readinessFlag: AtomicBoolean,
-      response: ByteBuffer
+      response: ByteBuffer,
+      val idleTime: TRef[Long]
     ) {
-      val receive: UIO[Any] =
-        UIO.effectSuspendTotal(if (readinessFlag.compareAndSet(true, false)) executeNext else UIO.unit)
-
-      def send(command: Chunk[String]): UIO[Promise[RedisError, String]] =
-        Promise.make[RedisError, String].flatMap(p => pendingRequests.offer(Request(command, p)).as(p))
-
-      private val executeNext: UIO[Any] =
-        pendingRequests.take.map { request =>
-          val exchange =
-            IO.effect {
-              try {
-                unsafeSend(request.command)
-                unsafeReceive()
-              } catch {
-                case t: Throwable => throw RedisError.ProtocolError(t.getMessage)
-              } finally readinessFlag.set(true)
+      def send(command: Chunk[String]): IO[RedisError, String] = {
+        val exchange =
+          IO.effect {
+            try {
+              unsafeSend(command)
+              unsafeReceive()
+            } catch {
+              case t: Throwable => throw RedisError.ProtocolError(t.getMessage)
             }
+          }
 
-          request.result.unsafeDone(exchange.refineToOrDie[RedisError])
-        }
+        exchange.refineToOrDie[RedisError]
+      }
+
+      val close: UIO[Unit] =
+        IO.effect(channel.close()).orDie
 
       private def unsafeReceive(): String = {
         val builder      = ArrayBuilder.make[Array[Byte]]
@@ -129,7 +109,125 @@ trait Interpreter {
           channel.write(buffer)
       }
     }
+
+    private[this] final class ConnectionPools private (
+      basePool: ConnectionPool,
+      streamsPool: ConnectionPool,
+      transactionsPool: ConnectionPool
+    ) {
+      def get(connectionType: ConnectionType): RManaged[Clock, Connection] =
+        connectionType match {
+          case Base         => basePool.get
+          case Streams      => streamsPool.get
+          case Transactions => transactionsPool.get
+        }
+
+      val cleanIdle: URIO[Clock, Unit] =
+        for {
+          _ <- basePool.cleanIdle
+          _ <- streamsPool.cleanIdle
+          _ <- transactionsPool.cleanIdle
+        } yield ()
+    }
+
+    private[this] object ConnectionPools {
+      def apply(cfg: PoolConfig): UManaged[ConnectionPools] =
+        for {
+          basePool         <- ConnectionPool(cfg.host, cfg.port, cfg.baseMaxSize, cfg.baseMaxIdleTimeout)
+          streamsPool      <- ConnectionPool(cfg.host, cfg.port, cfg.streamsMaxSize, cfg.streamsMaxIdleTimeout)
+          transactionsPool <-
+            ConnectionPool(cfg.host, cfg.port, cfg.transactionsMaxSize, cfg.transactionsMaxIdleTimeout)
+        } yield new ConnectionPools(basePool, streamsPool, transactionsPool)
+    }
+
+    // Add timeout and then create ConnectionPools
+    private[this] final class ConnectionPool(
+      host: String,
+      port: Int,
+      conns: TQueue[Connection],
+      closed: TRef[Boolean],
+      maxSize: Int,
+      size: TRef[Int],
+      maxIdleTimeout: Long
+    ) {
+      def get: ZManaged[Clock, IOException, Connection] = {
+        val makeChannel =
+          IO {
+            val channel = SocketChannel.open(new InetSocketAddress(host, port))
+            channel.configureBlocking(false)
+            channel.setOption(StandardSocketOptions.SO_KEEPALIVE, Boolean.box(true))
+            channel.setOption(StandardSocketOptions.TCP_NODELAY, Boolean.box(true))
+            channel
+          }
+
+        val makeConnection =
+          for {
+            channel  <- makeChannel.refineToOrDie[IOException]
+            idleTime <- TRef.makeCommit(0L)
+            response  = ByteBuffer.allocate(ResponseBufferSize)
+          } yield new Connection(channel, response, idleTime)
+
+        val getConnection =
+          for {
+            createConn <- STM.atomically {
+                            for {
+                              connsEmpty <- conns.isEmpty
+                              numOfConns <- size.get
+                              create      = connsEmpty && numOfConns < maxSize
+                              _          <- size.update(_ + 1).when(create)
+                            } yield create
+                          }
+            conn       <- if (createConn) makeConnection.tapError(_ => size.update(_ - 1).commit)
+                    else conns.take.commit
+          } yield conn
+
+        getConnection.toManaged { c =>
+          for {
+            now     <- currentTime(TimeUnit.MILLISECONDS)
+            closing <- STM.atomically {
+                         for {
+                           closing <- closed.get
+                           _       <- c.idleTime.set(now).when(!closing)
+                           _       <- conns.offer(c).when(!closing)
+                         } yield closing
+                       }
+            _       <- c.close.when(closing)
+          } yield ()
+        }
+      }
+
+      val close: UIO[Unit] =
+        for {
+          _         <- closed.set(true).commit
+          idleConns <- conns.takeAll.commit
+          _         <- ZIO.foreachPar_(idleConns)(_.close)
+        } yield ()
+
+      val cleanIdle: URIO[Clock, Unit] =
+        for {
+          now       <- currentTime(TimeUnit.MILLISECONDS)
+          removeIdle = for {
+                         optionConn <- conns.peekOption
+                         conn       <- STM.fromOption(optionConn)
+                         idleTime   <- conn.idleTime.get
+                         timedout    = now - idleTime > maxIdleTimeout
+                         _          <- conns.take.when(timedout)
+                       } yield timedout
+          _         <- STM.iterate(true)(ZIO.identityFn)(_ => removeIdle).commit.ignore
+        } yield ()
+    }
+
+    private[this] object ConnectionPool {
+      def apply(host: String, port: Int, maxSize: Int, maxIdleTimeout: Duration): UManaged[ConnectionPool] = {
+        val makeCP = for {
+          queue  <- TQueue.bounded[Connection](maxSize).commit
+          size   <- TRef.makeCommit(0)
+          closed <- TRef.makeCommit(false)
+        } yield new ConnectionPool(host, port, queue, closed, maxSize, size, maxIdleTimeout.toMillis)
+
+        Managed.make(makeCP)(_.close)
+      }
+    }
   }
 
-  private[this] sealed case class Request(command: Chunk[String], result: Promise[RedisError, String])
 }

--- a/redis/src/main/scala/zio/redis/PoolConfig.scala
+++ b/redis/src/main/scala/zio/redis/PoolConfig.scala
@@ -1,0 +1,14 @@
+package zio.redis
+
+import zio.duration.Duration
+
+case class PoolConfig(
+  host: String,
+  port: Int,
+  baseMaxSize: Int,
+  baseMaxIdleTimeout: Duration,
+  streamsMaxSize: Int,
+  streamsMaxIdleTimeout: Duration,
+  transactionsMaxSize: Int,
+  transactionsMaxIdleTimeout: Duration
+)

--- a/redis/src/main/scala/zio/redis/api/Connection.scala
+++ b/redis/src/main/scala/zio/redis/api/Connection.scala
@@ -1,12 +1,13 @@
 package zio.redis.api
 
+import zio.redis.ConnectionType._
 import zio.redis.Input._
 import zio.redis.Output._
 import zio.redis.RedisCommand
 
 trait Connection {
-  final val auth   = RedisCommand("AUTH", StringInput, UnitOutput)
-  final val echo   = RedisCommand("ECHO", StringInput, MultiStringOutput)
-  final val ping   = RedisCommand("PING", Varargs(StringInput), MultiStringOutput)
-  final val select = RedisCommand("SELECT", LongInput, UnitOutput)
+  final val auth   = RedisCommand("AUTH", StringInput, UnitOutput, Base)
+  final val echo   = RedisCommand("ECHO", StringInput, MultiStringOutput, Base)
+  final val ping   = RedisCommand("PING", Varargs(StringInput), MultiStringOutput, Base)
+  final val select = RedisCommand("SELECT", LongInput, UnitOutput, Base)
 }

--- a/redis/src/main/scala/zio/redis/api/Geo.scala
+++ b/redis/src/main/scala/zio/redis/api/Geo.scala
@@ -1,22 +1,24 @@
 package zio.redis.api
 
+import zio.redis.ConnectionType._
 import zio.redis.Input._
 import zio.redis.Output._
 import zio.redis.RedisCommand
 
 trait Geo {
   final val geoAdd =
-    RedisCommand("GEOADD", Tuple2(StringInput, NonEmptyList(Tuple2(LongLatInput, StringInput))), LongOutput)
+    RedisCommand("GEOADD", Tuple2(StringInput, NonEmptyList(Tuple2(LongLatInput, StringInput))), LongOutput, Base)
 
   final val geoDist =
     RedisCommand(
       "GEODIST",
       Tuple4(StringInput, StringInput, StringInput, OptionalInput(RadiusUnitInput)),
-      OptionalOutput(DoubleOutput)
+      OptionalOutput(DoubleOutput),
+      Base
     )
 
-  final val geoHash = RedisCommand("GEOHASH", Tuple2(StringInput, NonEmptyList(StringInput)), ChunkOutput)
-  final val geoPos  = RedisCommand("GEOPOS", Tuple2(StringInput, NonEmptyList(StringInput)), GeoOutput)
+  final val geoHash = RedisCommand("GEOHASH", Tuple2(StringInput, NonEmptyList(StringInput)), ChunkOutput, Base)
+  final val geoPos  = RedisCommand("GEOPOS", Tuple2(StringInput, NonEmptyList(StringInput)), GeoOutput, Base)
 
   final val geoRadius =
     RedisCommand(
@@ -34,7 +36,8 @@ trait Geo {
         OptionalInput(StoreInput),
         OptionalInput(StoreDistInput)
       ),
-      GeoRadiusOutput
+      GeoRadiusOutput,
+      Base
     )
 
   final val geoRadiusByMember =
@@ -53,6 +56,7 @@ trait Geo {
         OptionalInput(StoreInput),
         OptionalInput(StoreDistInput)
       ),
-      GeoRadiusOutput
+      GeoRadiusOutput,
+      Base
     )
 }

--- a/redis/src/main/scala/zio/redis/api/Hashes.scala
+++ b/redis/src/main/scala/zio/redis/api/Hashes.scala
@@ -1,34 +1,37 @@
 package zio.redis.api
 
+import zio.redis.ConnectionType._
 import zio.redis.Input._
 import zio.redis.Output._
 import zio.redis.RedisCommand
 
 trait Hashes {
-  final val hDel         = RedisCommand("HDEL", Tuple2(StringInput, NonEmptyList(StringInput)), LongOutput)
-  final val hExists      = RedisCommand("HEXISTS", Tuple2(StringInput, StringInput), BoolOutput)
-  final val hGet         = RedisCommand("HGET", Tuple2(StringInput, StringInput), OptionalOutput(MultiStringOutput))
-  final val hGetAll      = RedisCommand("HGETALL", StringInput, KeyValueOutput)
-  final val hIncrBy      = RedisCommand("HINCRBY", Tuple3(StringInput, StringInput, LongInput), LongOutput)
+  final val hDel         = RedisCommand("HDEL", Tuple2(StringInput, NonEmptyList(StringInput)), LongOutput, Base)
+  final val hExists      = RedisCommand("HEXISTS", Tuple2(StringInput, StringInput), BoolOutput, Base)
+  final val hGet         = RedisCommand("HGET", Tuple2(StringInput, StringInput), OptionalOutput(MultiStringOutput), Base)
+  final val hGetAll      = RedisCommand("HGETALL", StringInput, KeyValueOutput, Base)
+  final val hIncrBy      = RedisCommand("HINCRBY", Tuple3(StringInput, StringInput, LongInput), LongOutput, Base)
   final val hIncrByFloat =
-    RedisCommand("HINCRBYFLOAT", Tuple3(StringInput, StringInput, DoubleInput), IncrementOutput)
-  final val hKeys        = RedisCommand("HKEYS", StringInput, ChunkOutput)
-  final val hLen         = RedisCommand("HLEN", StringInput, LongOutput)
-  final val hmGet        = RedisCommand("HMGET", Tuple2(StringInput, NonEmptyList(StringInput)), ChunkOutput)
+    RedisCommand("HINCRBYFLOAT", Tuple3(StringInput, StringInput, DoubleInput), IncrementOutput, Base)
+  final val hKeys        = RedisCommand("HKEYS", StringInput, ChunkOutput, Base)
+  final val hLen         = RedisCommand("HLEN", StringInput, LongOutput, Base)
+  final val hmGet        = RedisCommand("HMGET", Tuple2(StringInput, NonEmptyList(StringInput)), ChunkOutput, Base)
 
   final val hScan = RedisCommand(
     "HSCAN",
     Tuple4(LongInput, OptionalInput(RegexInput), OptionalInput(LongInput), OptionalInput(StringInput)),
-    ScanOutput
+    ScanOutput,
+    Base
   )
 
   final val hSet = RedisCommand(
     "HSET",
     Tuple2(StringInput, NonEmptyList(Tuple2(StringInput, StringInput))),
-    LongOutput
+    LongOutput,
+    Base
   )
 
-  final val hSetNx  = RedisCommand("HSETNX", Tuple3(StringInput, StringInput, StringInput), BoolOutput)
-  final val hStrLen = RedisCommand("HSTRLEN", Tuple2(StringInput, StringInput), LongOutput)
-  final val hVals   = RedisCommand("HVALS", StringInput, ChunkOutput)
+  final val hSetNx  = RedisCommand("HSETNX", Tuple3(StringInput, StringInput, StringInput), BoolOutput, Base)
+  final val hStrLen = RedisCommand("HSTRLEN", Tuple2(StringInput, StringInput), LongOutput, Base)
+  final val hVals   = RedisCommand("HVALS", StringInput, ChunkOutput, Base)
 }

--- a/redis/src/main/scala/zio/redis/api/HyperLogLog.scala
+++ b/redis/src/main/scala/zio/redis/api/HyperLogLog.scala
@@ -1,11 +1,12 @@
 package zio.redis.api
 
+import zio.redis.ConnectionType._
 import zio.redis.Input._
 import zio.redis.Output._
 import zio.redis.RedisCommand
 
 trait HyperLogLog {
-  final val pfAdd   = RedisCommand("PFADD", Tuple2(StringInput, NonEmptyList(StringInput)), BoolOutput)
-  final val pfCount = RedisCommand("PFCOUNT", NonEmptyList(StringInput), LongOutput)
-  final val pfMerge = RedisCommand("PFMERGE", Tuple2(StringInput, NonEmptyList(StringInput)), UnitOutput)
+  final val pfAdd   = RedisCommand("PFADD", Tuple2(StringInput, NonEmptyList(StringInput)), BoolOutput, Base)
+  final val pfCount = RedisCommand("PFCOUNT", NonEmptyList(StringInput), LongOutput, Base)
+  final val pfMerge = RedisCommand("PFMERGE", Tuple2(StringInput, NonEmptyList(StringInput)), UnitOutput, Base)
 }

--- a/redis/src/main/scala/zio/redis/api/Keys.scala
+++ b/redis/src/main/scala/zio/redis/api/Keys.scala
@@ -1,16 +1,17 @@
 package zio.redis.api
 
+import zio.redis.ConnectionType._
 import zio.redis.Input._
 import zio.redis.Output._
 import zio.redis.RedisCommand
 
 trait Keys {
-  final val del      = RedisCommand("DEL", NonEmptyList(StringInput), LongOutput)
-  final val dump     = RedisCommand("DUMP", StringInput, MultiStringOutput)
-  final val exists   = RedisCommand("EXISTS", NonEmptyList(StringInput), BoolOutput)
-  final val expire   = RedisCommand("EXPIRE", Tuple2(StringInput, DurationSecondsInput), BoolOutput)
-  final val expireAt = RedisCommand("EXPIREAT", Tuple2(StringInput, TimeSecondsInput), BoolOutput)
-  final val keys     = RedisCommand("KEYS", StringInput, ChunkOutput)
+  final val del      = RedisCommand("DEL", NonEmptyList(StringInput), LongOutput, Base)
+  final val dump     = RedisCommand("DUMP", StringInput, MultiStringOutput, Base)
+  final val exists   = RedisCommand("EXISTS", NonEmptyList(StringInput), BoolOutput, Base)
+  final val expire   = RedisCommand("EXPIRE", Tuple2(StringInput, DurationSecondsInput), BoolOutput, Base)
+  final val expireAt = RedisCommand("EXPIREAT", Tuple2(StringInput, TimeSecondsInput), BoolOutput, Base)
+  final val keys     = RedisCommand("KEYS", StringInput, ChunkOutput, Base)
 
   final val migrate = RedisCommand(
     "MIGRATE",
@@ -25,17 +26,18 @@ trait Keys {
       OptionalInput(AuthInput),
       OptionalInput(NonEmptyList(StringInput))
     ),
-    MultiStringOutput
+    MultiStringOutput,
+    Base
   )
 
-  final val move      = RedisCommand("MOVE", Tuple2(StringInput, LongInput), BoolOutput)
-  final val persist   = RedisCommand("PERSIST", StringInput, BoolOutput)
-  final val pExpire   = RedisCommand("PEXPIRE", Tuple2(StringInput, DurationMillisecondsInput), BoolOutput)
-  final val pExpireAt = RedisCommand("PEXPIREAT", Tuple2(StringInput, TimeMillisecondsInput), BoolOutput)
-  final val pTtl      = RedisCommand("PTTL", StringInput, DurationMillisecondsOutput)
-  final val randomKey = RedisCommand("RANDOMKEY", NoInput, OptionalOutput(MultiStringOutput))
-  final val rename    = RedisCommand("RENAME", Tuple2(StringInput, StringInput), UnitOutput)
-  final val renameNx  = RedisCommand("RENAMENX", Tuple2(StringInput, StringInput), BoolOutput)
+  final val move      = RedisCommand("MOVE", Tuple2(StringInput, LongInput), BoolOutput, Base)
+  final val persist   = RedisCommand("PERSIST", StringInput, BoolOutput, Base)
+  final val pExpire   = RedisCommand("PEXPIRE", Tuple2(StringInput, DurationMillisecondsInput), BoolOutput, Base)
+  final val pExpireAt = RedisCommand("PEXPIREAT", Tuple2(StringInput, TimeMillisecondsInput), BoolOutput, Base)
+  final val pTtl      = RedisCommand("PTTL", StringInput, DurationMillisecondsOutput, Base)
+  final val randomKey = RedisCommand("RANDOMKEY", NoInput, OptionalOutput(MultiStringOutput), Base)
+  final val rename    = RedisCommand("RENAME", Tuple2(StringInput, StringInput), UnitOutput, Base)
+  final val renameNx  = RedisCommand("RENAMENX", Tuple2(StringInput, StringInput), BoolOutput, Base)
 
   final val restore = RedisCommand(
     "RESTORE",
@@ -48,18 +50,20 @@ trait Keys {
       OptionalInput(IdleTimeInput),
       OptionalInput(FreqInput)
     ),
-    UnitOutput
+    UnitOutput,
+    Base
   )
 
   final val scan = RedisCommand(
     "SCAN",
     Tuple4(LongInput, OptionalInput(RegexInput), OptionalInput(LongInput), OptionalInput(StringInput)),
-    ScanOutput
+    ScanOutput,
+    Base
   )
 
-  final val touch  = RedisCommand("TOUCH", NonEmptyList(StringInput), LongOutput)
-  final val ttl    = RedisCommand("TTL", StringInput, DurationSecondsOutput)
-  final val typeOf = RedisCommand("TYPE", StringInput, TypeOutput)
-  final val unlink = RedisCommand("UNLINK", NonEmptyList(StringInput), LongOutput)
-  final val wait_  = RedisCommand("WAIT", Tuple2(LongInput, LongInput), LongOutput)
+  final val touch  = RedisCommand("TOUCH", NonEmptyList(StringInput), LongOutput, Base)
+  final val ttl    = RedisCommand("TTL", StringInput, DurationSecondsOutput, Base)
+  final val typeOf = RedisCommand("TYPE", StringInput, TypeOutput, Base)
+  final val unlink = RedisCommand("UNLINK", NonEmptyList(StringInput), LongOutput, Base)
+  final val wait_  = RedisCommand("WAIT", Tuple2(LongInput, LongInput), LongOutput, Base)
 }

--- a/redis/src/main/scala/zio/redis/api/Lists.scala
+++ b/redis/src/main/scala/zio/redis/api/Lists.scala
@@ -1,5 +1,6 @@
 package zio.redis.api
 
+import zio.redis.ConnectionType._
 import zio.redis.Input._
 import zio.redis.Output._
 import zio.redis.RedisCommand
@@ -9,26 +10,28 @@ trait Lists {
     RedisCommand(
       "BRPOPLPUSH",
       Tuple3(StringInput, StringInput, DurationSecondsInput),
-      OptionalOutput(MultiStringOutput)
+      OptionalOutput(MultiStringOutput),
+      Base
     )
 
-  final val lIndex    = RedisCommand("LINDEX", Tuple2(StringInput, LongInput), OptionalOutput(MultiStringOutput))
-  final val lLen      = RedisCommand("LLEN", StringInput, LongOutput)
-  final val lPop      = RedisCommand("LPOP", StringInput, OptionalOutput(MultiStringOutput))
-  final val lPush     = RedisCommand("LPUSH", Tuple2(StringInput, NonEmptyList(StringInput)), LongOutput)
-  final val lPushX    = RedisCommand("LPUSHX", Tuple2(StringInput, NonEmptyList(StringInput)), LongOutput)
-  final val lRange    = RedisCommand("LRANGE", Tuple2(StringInput, RangeInput), ChunkOutput)
-  final val lRem      = RedisCommand("LREM", Tuple3(StringInput, LongInput, StringInput), LongOutput)
-  final val lSet      = RedisCommand("LSET", Tuple3(StringInput, LongInput, StringInput), UnitOutput)
-  final val lTrim     = RedisCommand("LTRIM", Tuple2(StringInput, RangeInput), UnitOutput)
-  final val rPop      = RedisCommand("RPOP", StringInput, OptionalOutput(MultiStringOutput))
-  final val rPopLPush = RedisCommand("RPOPLPUSH", Tuple2(StringInput, StringInput), OptionalOutput(MultiStringOutput))
-  final val rPush     = RedisCommand("RPUSH", Tuple2(StringInput, NonEmptyList(StringInput)), LongOutput)
-  final val rPushX    = RedisCommand("RPUSHX", Tuple2(StringInput, NonEmptyList(StringInput)), LongOutput)
+  final val lIndex    = RedisCommand("LINDEX", Tuple2(StringInput, LongInput), OptionalOutput(MultiStringOutput), Base)
+  final val lLen      = RedisCommand("LLEN", StringInput, LongOutput, Base)
+  final val lPop      = RedisCommand("LPOP", StringInput, OptionalOutput(MultiStringOutput), Base)
+  final val lPush     = RedisCommand("LPUSH", Tuple2(StringInput, NonEmptyList(StringInput)), LongOutput, Base)
+  final val lPushX    = RedisCommand("LPUSHX", Tuple2(StringInput, NonEmptyList(StringInput)), LongOutput, Base)
+  final val lRange    = RedisCommand("LRANGE", Tuple2(StringInput, RangeInput), ChunkOutput, Base)
+  final val lRem      = RedisCommand("LREM", Tuple3(StringInput, LongInput, StringInput), LongOutput, Base)
+  final val lSet      = RedisCommand("LSET", Tuple3(StringInput, LongInput, StringInput), UnitOutput, Base)
+  final val lTrim     = RedisCommand("LTRIM", Tuple2(StringInput, RangeInput), UnitOutput, Base)
+  final val rPop      = RedisCommand("RPOP", StringInput, OptionalOutput(MultiStringOutput), Base)
+  final val rPopLPush =
+    RedisCommand("RPOPLPUSH", Tuple2(StringInput, StringInput), OptionalOutput(MultiStringOutput), Base)
+  final val rPush     = RedisCommand("RPUSH", Tuple2(StringInput, NonEmptyList(StringInput)), LongOutput, Base)
+  final val rPushX    = RedisCommand("RPUSHX", Tuple2(StringInput, NonEmptyList(StringInput)), LongOutput, Base)
   final val blPop     =
-    RedisCommand("BLPOP", Tuple2(NonEmptyList(StringInput), DurationSecondsInput), KeyElemOutput)
+    RedisCommand("BLPOP", Tuple2(NonEmptyList(StringInput), DurationSecondsInput), KeyElemOutput, Base)
   final val brPop     =
-    RedisCommand("BRPOP", Tuple2(NonEmptyList(StringInput), DurationSecondsInput), KeyElemOutput)
+    RedisCommand("BRPOP", Tuple2(NonEmptyList(StringInput), DurationSecondsInput), KeyElemOutput, Base)
   final val lInsert   =
-    RedisCommand("LINSERT", Tuple4(StringInput, PositionInput, StringInput, StringInput), LongOutput)
+    RedisCommand("LINSERT", Tuple4(StringInput, PositionInput, StringInput, StringInput), LongOutput, Base)
 }

--- a/redis/src/main/scala/zio/redis/api/Sets.scala
+++ b/redis/src/main/scala/zio/redis/api/Sets.scala
@@ -1,33 +1,35 @@
 package zio.redis.api
 
+import zio.redis.ConnectionType._
 import zio.redis.Input._
 import zio.redis.Output._
 import zio.redis.RedisCommand
 
 trait Sets {
-  final val sAdd        = RedisCommand("SADD", Tuple2(StringInput, NonEmptyList(StringInput)), LongOutput)
-  final val sCard       = RedisCommand("SCARD", StringInput, LongOutput)
-  final val sDiff       = RedisCommand("SDIFF", NonEmptyList(StringInput), ChunkOutput)
-  final val sDiffStore  = RedisCommand("SDIFFSTORE", Tuple2(StringInput, NonEmptyList(StringInput)), LongOutput)
-  final val sInter      = RedisCommand("SINTER", NonEmptyList(StringInput), ChunkOutput)
-  final val sInterStore = RedisCommand("SINTERSTORE", Tuple2(StringInput, NonEmptyList(StringInput)), LongOutput)
-  final val sIsMember   = RedisCommand("SISMEMBER", Tuple2(StringInput, StringInput), BoolOutput)
-  final val sMembers    = RedisCommand("SMEMBERS", StringInput, ChunkOutput)
-  final val sMove       = RedisCommand("SMOVE", Tuple3(StringInput, StringInput, StringInput), BoolOutput)
+  final val sAdd        = RedisCommand("SADD", Tuple2(StringInput, NonEmptyList(StringInput)), LongOutput, Base)
+  final val sCard       = RedisCommand("SCARD", StringInput, LongOutput, Base)
+  final val sDiff       = RedisCommand("SDIFF", NonEmptyList(StringInput), ChunkOutput, Base)
+  final val sDiffStore  = RedisCommand("SDIFFSTORE", Tuple2(StringInput, NonEmptyList(StringInput)), LongOutput, Base)
+  final val sInter      = RedisCommand("SINTER", NonEmptyList(StringInput), ChunkOutput, Base)
+  final val sInterStore = RedisCommand("SINTERSTORE", Tuple2(StringInput, NonEmptyList(StringInput)), LongOutput, Base)
+  final val sIsMember   = RedisCommand("SISMEMBER", Tuple2(StringInput, StringInput), BoolOutput, Base)
+  final val sMembers    = RedisCommand("SMEMBERS", StringInput, ChunkOutput, Base)
+  final val sMove       = RedisCommand("SMOVE", Tuple3(StringInput, StringInput, StringInput), BoolOutput, Base)
   final val sPop        =
-    RedisCommand("SPOP", Tuple2(StringInput, OptionalInput(LongInput)), MultiStringChunkOutput)
+    RedisCommand("SPOP", Tuple2(StringInput, OptionalInput(LongInput)), MultiStringChunkOutput, Base)
 
   final val sRandMember =
-    RedisCommand("SRANDMEMBER", Tuple2(StringInput, OptionalInput(LongInput)), MultiStringChunkOutput)
+    RedisCommand("SRANDMEMBER", Tuple2(StringInput, OptionalInput(LongInput)), MultiStringChunkOutput, Base)
 
-  final val sRem = RedisCommand("SREM", Tuple2(StringInput, NonEmptyList(StringInput)), LongOutput)
+  final val sRem = RedisCommand("SREM", Tuple2(StringInput, NonEmptyList(StringInput)), LongOutput, Base)
 
   final val sScan = RedisCommand(
     "SSCAN",
     Tuple4(StringInput, LongInput, OptionalInput(RegexInput), OptionalInput(CountInput)),
-    ScanOutput
+    ScanOutput,
+    Base
   )
 
-  final val sUnion      = RedisCommand("SUNION", NonEmptyList(StringInput), ChunkOutput)
-  final val sUnionStore = RedisCommand("SUNIONSTORE", Tuple2(StringInput, NonEmptyList(StringInput)), LongOutput)
+  final val sUnion      = RedisCommand("SUNION", NonEmptyList(StringInput), ChunkOutput, Base)
+  final val sUnionStore = RedisCommand("SUNIONSTORE", Tuple2(StringInput, NonEmptyList(StringInput)), LongOutput, Base)
 }

--- a/redis/src/main/scala/zio/redis/api/SortedSets.scala
+++ b/redis/src/main/scala/zio/redis/api/SortedSets.scala
@@ -1,12 +1,15 @@
 package zio.redis.api
 
+import zio.redis.ConnectionType._
 import zio.redis.Input._
 import zio.redis.Output._
 import zio.redis.RedisCommand
 
 trait SortedSets {
-  final val bzPopMax = RedisCommand("BZPOPMAX", Tuple2(DurationSecondsInput, NonEmptyList(StringInput)), ChunkOutput)
-  final val bzPopMin = RedisCommand("BZPOPMIN", Tuple2(DurationSecondsInput, NonEmptyList(StringInput)), ChunkOutput)
+  final val bzPopMax =
+    RedisCommand("BZPOPMAX", Tuple2(DurationSecondsInput, NonEmptyList(StringInput)), ChunkOutput, Base)
+  final val bzPopMin =
+    RedisCommand("BZPOPMIN", Tuple2(DurationSecondsInput, NonEmptyList(StringInput)), ChunkOutput, Base)
 
   final def zAdd =
     RedisCommand(
@@ -17,7 +20,8 @@ trait SortedSets {
         OptionalInput(ChangedInput),
         NonEmptyList(MemberScoreInput)
       ),
-      LongOutput
+      LongOutput,
+      Base
     )
 
   final def zAddWithIncr =
@@ -30,12 +34,13 @@ trait SortedSets {
         IncrementInput,
         NonEmptyList(MemberScoreInput)
       ),
-      OptionalOutput(DoubleOutput)
+      OptionalOutput(DoubleOutput),
+      Base
     )
 
-  final val zCard   = RedisCommand("ZCARD", StringInput, LongOutput)
-  final val zCount  = RedisCommand("ZCOUNT", Tuple2(StringInput, RangeInput), LongOutput)
-  final val zIncrBy = RedisCommand("ZINCRBY", Tuple3(StringInput, LongInput, StringInput), DoubleOutput)
+  final val zCard   = RedisCommand("ZCARD", StringInput, LongOutput, Base)
+  final val zCount  = RedisCommand("ZCOUNT", Tuple2(StringInput, RangeInput), LongOutput, Base)
+  final val zIncrBy = RedisCommand("ZINCRBY", Tuple3(StringInput, LongInput, StringInput), DoubleOutput, Base)
 
   final val zInterStore = RedisCommand(
     "ZINTERSTORE",
@@ -46,52 +51,56 @@ trait SortedSets {
       OptionalInput(AggregateInput),
       OptionalInput(WeightsInput)
     ),
-    LongOutput
+    LongOutput,
+    Base
   )
 
-  final val zLexCount = RedisCommand("ZLEXCOUNT", Tuple2(StringInput, LexRangeInput), LongOutput)
-  final val zPopMax   = RedisCommand("ZPOPMAX", Tuple2(StringInput, OptionalInput(LongInput)), ChunkOutput)
-  final val zPopMin   = RedisCommand("ZPOPMIN", Tuple2(StringInput, OptionalInput(LongInput)), ChunkOutput)
+  final val zLexCount = RedisCommand("ZLEXCOUNT", Tuple2(StringInput, LexRangeInput), LongOutput, Base)
+  final val zPopMax   = RedisCommand("ZPOPMAX", Tuple2(StringInput, OptionalInput(LongInput)), ChunkOutput, Base)
+  final val zPopMin   = RedisCommand("ZPOPMIN", Tuple2(StringInput, OptionalInput(LongInput)), ChunkOutput, Base)
 
   final val zRange =
-    RedisCommand("ZRANGE", Tuple3(StringInput, RangeInput, OptionalInput(WithScoresInput)), ChunkOutput)
+    RedisCommand("ZRANGE", Tuple3(StringInput, RangeInput, OptionalInput(WithScoresInput)), ChunkOutput, Base)
 
   final val zRangeByLex =
-    RedisCommand("ZRANGEBYLEX", Tuple3(StringInput, LexRangeInput, OptionalInput(LimitInput)), ChunkOutput)
+    RedisCommand("ZRANGEBYLEX", Tuple3(StringInput, LexRangeInput, OptionalInput(LimitInput)), ChunkOutput, Base)
 
   final val zRangeByScore = RedisCommand(
     "ZRANGEBYSCORE",
     Tuple4(StringInput, ScoreRangeInput, OptionalInput(WithScoresInput), OptionalInput(LimitInput)),
-    ChunkOutput
+    ChunkOutput,
+    Base
   )
 
-  final val zRank            = RedisCommand("ZRANK", Tuple2(StringInput, StringInput), OptionalOutput(LongOutput))
-  final val zRem             = RedisCommand("ZREM", Tuple2(StringInput, NonEmptyList(StringInput)), LongOutput)
-  final val zRemRangeByLex   = RedisCommand("ZREMRANGEBYLEX", Tuple2(StringInput, LexRangeInput), LongOutput)
-  final val zRemRangeByRank  = RedisCommand("ZREMRANGEBYRANK", Tuple2(StringInput, RangeInput), LongOutput)
-  final val zRemRangeByScore = RedisCommand("ZREMRANGEBYSCORE", Tuple2(StringInput, ScoreRangeInput), LongOutput)
+  final val zRank            = RedisCommand("ZRANK", Tuple2(StringInput, StringInput), OptionalOutput(LongOutput), Base)
+  final val zRem             = RedisCommand("ZREM", Tuple2(StringInput, NonEmptyList(StringInput)), LongOutput, Base)
+  final val zRemRangeByLex   = RedisCommand("ZREMRANGEBYLEX", Tuple2(StringInput, LexRangeInput), LongOutput, Base)
+  final val zRemRangeByRank  = RedisCommand("ZREMRANGEBYRANK", Tuple2(StringInput, RangeInput), LongOutput, Base)
+  final val zRemRangeByScore = RedisCommand("ZREMRANGEBYSCORE", Tuple2(StringInput, ScoreRangeInput), LongOutput, Base)
 
   final val zRevRange =
-    RedisCommand("ZREVRANGE", Tuple3(StringInput, RangeInput, OptionalInput(WithScoresInput)), ChunkOutput)
+    RedisCommand("ZREVRANGE", Tuple3(StringInput, RangeInput, OptionalInput(WithScoresInput)), ChunkOutput, Base)
 
   final val zRevRangeByLex =
-    RedisCommand("ZREVRANGEBYLEX", Tuple3(StringInput, LexRangeInput, OptionalInput(LimitInput)), ChunkOutput)
+    RedisCommand("ZREVRANGEBYLEX", Tuple3(StringInput, LexRangeInput, OptionalInput(LimitInput)), ChunkOutput, Base)
 
   final val zRevRangeByScore = RedisCommand(
     "ZREVRANGEBYSCORE",
     Tuple4(StringInput, ScoreRangeInput, OptionalInput(WithScoresInput), OptionalInput(LimitInput)),
-    ChunkOutput
+    ChunkOutput,
+    Base
   )
 
-  final val zRevRank = RedisCommand("ZREVRANK", Tuple2(StringInput, StringInput), OptionalOutput(LongOutput))
+  final val zRevRank = RedisCommand("ZREVRANK", Tuple2(StringInput, StringInput), OptionalOutput(LongOutput), Base)
 
   final val zScan = RedisCommand(
     "ZSCAN",
     Tuple4(StringInput, LongInput, OptionalInput(RegexInput), OptionalInput(CountInput)),
-    ScanOutput
+    ScanOutput,
+    Base
   )
 
-  final val zScore = RedisCommand("ZSCORE", Tuple2(StringInput, StringInput), OptionalOutput(DoubleOutput))
+  final val zScore = RedisCommand("ZSCORE", Tuple2(StringInput, StringInput), OptionalOutput(DoubleOutput), Base)
 
   final val zUnionStore = RedisCommand(
     "ZUNIONSTORE",
@@ -102,6 +111,7 @@ trait SortedSets {
       OptionalInput(WeightsInput),
       OptionalInput(AggregateInput)
     ),
-    LongOutput
+    LongOutput,
+    Base
   )
 }

--- a/redis/src/main/scala/zio/redis/api/Streams.scala
+++ b/redis/src/main/scala/zio/redis/api/Streams.scala
@@ -1,0 +1,11 @@
+package zio.redis.api
+
+import zio.redis.ConnectionType._
+import zio.redis.Input._
+import zio.redis.Output._
+import zio.redis.RedisCommand
+
+trait Streams {
+  final val xAck =
+    RedisCommand("XACK", Tuple3(StringInput, StringInput, NonEmptyList(StringInput)), LongOutput, Streams)
+}

--- a/redis/src/main/scala/zio/redis/api/Strings.scala
+++ b/redis/src/main/scala/zio/redis/api/Strings.scala
@@ -1,12 +1,13 @@
 package zio.redis.api
 
+import zio.redis.ConnectionType._
 import zio.redis.Input._
 import zio.redis.Output._
 import zio.redis.RedisCommand
 
 trait Strings {
-  final val append   = RedisCommand("APPEND", Tuple2(StringInput, StringInput), LongOutput)
-  final val bitCount = RedisCommand("BITCOUNT", Tuple2(StringInput, OptionalInput(RangeInput)), LongOutput)
+  final val append   = RedisCommand("APPEND", Tuple2(StringInput, StringInput), LongOutput, Base)
+  final val bitCount = RedisCommand("BITCOUNT", Tuple2(StringInput, OptionalInput(RangeInput)), LongOutput, Base)
 
   final val bitField = RedisCommand(
     "BITFIELD",
@@ -14,28 +15,30 @@ trait Strings {
       StringInput,
       NonEmptyList(BitFieldCommandInput)
     ),
-    ChunkOptionalLongOutput
+    ChunkOptionalLongOutput,
+    Base
   )
 
   final val bitOp =
-    RedisCommand("BITOP", Tuple3(BitOperationInput, StringInput, NonEmptyList(StringInput)), LongOutput)
+    RedisCommand("BITOP", Tuple3(BitOperationInput, StringInput, NonEmptyList(StringInput)), LongOutput, Base)
 
   final val bitPos =
-    RedisCommand("BITPOS", Tuple3(StringInput, BoolInput, OptionalInput(BitPosRangeInput)), LongOutput)
+    RedisCommand("BITPOS", Tuple3(StringInput, BoolInput, OptionalInput(BitPosRangeInput)), LongOutput, Base)
 
-  final val decr        = RedisCommand("DECR", StringInput, LongOutput)
-  final val decrBy      = RedisCommand("DECRBY", Tuple2(StringInput, LongInput), LongOutput)
-  final val get         = RedisCommand("GET", StringInput, OptionalOutput(MultiStringOutput))
-  final val getBit      = RedisCommand("GETBIT", Tuple2(StringInput, LongInput), LongOutput)
-  final val getRange    = RedisCommand("GETRANGE", Tuple2(StringInput, RangeInput), MultiStringOutput)
-  final val getSet      = RedisCommand("GETSET", Tuple2(StringInput, StringInput), OptionalOutput(MultiStringOutput))
-  final val incr        = RedisCommand("INCR", StringInput, LongOutput)
-  final val incrBy      = RedisCommand("INCRBY", Tuple2(StringInput, LongInput), LongOutput)
-  final val incrByFloat = RedisCommand("INCRBYFLOAT", Tuple2(StringInput, DoubleInput), MultiStringOutput)
-  final val mGet        = RedisCommand("MGET", NonEmptyList(StringInput), ChunkOptionalMultiStringOutput)
-  final val mSet        = RedisCommand("MSET", NonEmptyList(Tuple2(StringInput, StringInput)), UnitOutput)
-  final val mSetNx      = RedisCommand("MSETNX", NonEmptyList(Tuple2(StringInput, StringInput)), BoolOutput)
-  final val pSetEx      = RedisCommand("PSETEX", Tuple3(StringInput, DurationMillisecondsInput, StringInput), UnitOutput)
+  final val decr        = RedisCommand("DECR", StringInput, LongOutput, Base)
+  final val decrBy      = RedisCommand("DECRBY", Tuple2(StringInput, LongInput), LongOutput, Base)
+  final val get         = RedisCommand("GET", StringInput, OptionalOutput(MultiStringOutput), Base)
+  final val getBit      = RedisCommand("GETBIT", Tuple2(StringInput, LongInput), LongOutput, Base)
+  final val getRange    = RedisCommand("GETRANGE", Tuple2(StringInput, RangeInput), MultiStringOutput, Base)
+  final val getSet      = RedisCommand("GETSET", Tuple2(StringInput, StringInput), OptionalOutput(MultiStringOutput), Base)
+  final val incr        = RedisCommand("INCR", StringInput, LongOutput, Base)
+  final val incrBy      = RedisCommand("INCRBY", Tuple2(StringInput, LongInput), LongOutput, Base)
+  final val incrByFloat = RedisCommand("INCRBYFLOAT", Tuple2(StringInput, DoubleInput), MultiStringOutput, Base)
+  final val mGet        = RedisCommand("MGET", NonEmptyList(StringInput), ChunkOptionalMultiStringOutput, Base)
+  final val mSet        = RedisCommand("MSET", NonEmptyList(Tuple2(StringInput, StringInput)), UnitOutput, Base)
+  final val mSetNx      = RedisCommand("MSETNX", NonEmptyList(Tuple2(StringInput, StringInput)), BoolOutput, Base)
+  final val pSetEx      =
+    RedisCommand("PSETEX", Tuple3(StringInput, DurationMillisecondsInput, StringInput), UnitOutput, Base)
 
   final val set = RedisCommand(
     "SET",
@@ -46,12 +49,13 @@ trait Strings {
       OptionalInput(UpdateInput),
       OptionalInput(KeepTtlInput)
     ),
-    OptionalOutput(UnitOutput)
+    OptionalOutput(UnitOutput),
+    Base
   )
 
-  final val setBit   = RedisCommand("SETBIT", Tuple3(StringInput, LongInput, BoolInput), BoolOutput)
-  final val setEx    = RedisCommand("SETEX", Tuple3(StringInput, DurationSecondsInput, StringInput), UnitOutput)
-  final val setNx    = RedisCommand("SETNX", Tuple2(StringInput, StringInput), BoolOutput)
-  final val setRange = RedisCommand("SETRANGE", Tuple3(StringInput, LongInput, StringInput), LongOutput)
-  final val strLen   = RedisCommand("STRLEN", StringInput, LongOutput)
+  final val setBit   = RedisCommand("SETBIT", Tuple3(StringInput, LongInput, BoolInput), BoolOutput, Base)
+  final val setEx    = RedisCommand("SETEX", Tuple3(StringInput, DurationSecondsInput, StringInput), UnitOutput, Base)
+  final val setNx    = RedisCommand("SETNX", Tuple2(StringInput, StringInput), BoolOutput, Base)
+  final val setRange = RedisCommand("SETRANGE", Tuple3(StringInput, LongInput, StringInput), LongOutput, Base)
+  final val strLen   = RedisCommand("STRLEN", StringInput, LongOutput, Base)
 }

--- a/redis/src/main/scala/zio/redis/api/Transactions.scala
+++ b/redis/src/main/scala/zio/redis/api/Transactions.scala
@@ -6,9 +6,9 @@ import zio.redis.Output.{ ChunkOutput, UnitOutput }
 import zio.redis.RedisCommand
 
 trait Transactions {
-  final val discard = RedisCommand("DISCARD", NoInput, UnitOutput, Base)
-  final val exec    = RedisCommand("EXEC", NoInput, ChunkOutput, Base)
-  final val multi   = RedisCommand("MULTI", NoInput, UnitOutput, Base)
-  final val unwatch = RedisCommand("UNWATCH", NoInput, UnitOutput, Base)
-  final val watch   = RedisCommand("WATCH", NonEmptyList(StringInput), UnitOutput, Base)
+  final val discard = RedisCommand("DISCARD", NoInput, UnitOutput, Transactions)
+  final val exec    = RedisCommand("EXEC", NoInput, ChunkOutput, Transactions)
+  final val multi   = RedisCommand("MULTI", NoInput, UnitOutput, Transactions)
+  final val unwatch = RedisCommand("UNWATCH", NoInput, UnitOutput, Transactions)
+  final val watch   = RedisCommand("WATCH", NonEmptyList(StringInput), UnitOutput, Transactions)
 }

--- a/redis/src/main/scala/zio/redis/api/Transactions.scala
+++ b/redis/src/main/scala/zio/redis/api/Transactions.scala
@@ -1,13 +1,14 @@
 package zio.redis.api
 
+import zio.redis.ConnectionType._
 import zio.redis.Input.{ NoInput, NonEmptyList, StringInput }
 import zio.redis.Output.{ ChunkOutput, UnitOutput }
 import zio.redis.RedisCommand
 
 trait Transactions {
-  final val discard = RedisCommand("DISCARD", NoInput, UnitOutput)
-  final val exec    = RedisCommand("EXEC", NoInput, ChunkOutput)
-  final val multi   = RedisCommand("MULTI", NoInput, UnitOutput)
-  final val unwatch = RedisCommand("UNWATCH", NoInput, UnitOutput)
-  final val watch   = RedisCommand("WATCH", NonEmptyList(StringInput), UnitOutput)
+  final val discard = RedisCommand("DISCARD", NoInput, UnitOutput, Base)
+  final val exec    = RedisCommand("EXEC", NoInput, ChunkOutput, Base)
+  final val multi   = RedisCommand("MULTI", NoInput, UnitOutput, Base)
+  final val unwatch = RedisCommand("UNWATCH", NoInput, UnitOutput, Base)
+  final val watch   = RedisCommand("WATCH", NonEmptyList(StringInput), UnitOutput, Base)
 }

--- a/redis/src/test/scala/zio/redis/ApiSpec.scala
+++ b/redis/src/test/scala/zio/redis/ApiSpec.scala
@@ -2,6 +2,7 @@ package zio.redis
 
 import zio.clock.Clock
 import zio.test._
+import zio.duration._
 
 object ApiSpec
     extends KeysSpec
@@ -25,5 +26,5 @@ object ApiSpec
       hashSuite
     ).provideCustomLayerShared(Executor ++ Clock.live)
 
-  private val Executor = RedisExecutor.live("127.0.0.1", 6379).orDie
+  private val Executor = RedisExecutor.live(PoolConfig("127.0.0.1", 6379, 1, 10.seconds, 1, 10.seconds, 1, 10.seconds))
 }


### PR DESCRIPTION
This PR adds a basic queued connection pool in order to support blocking streaming commands (related to #68).