### PR TITLE
Rework serialisation and interpreter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,10 +4,10 @@ scala_211: &scala_211
   SCALA_VERSION: 2.11.12
 
 scala_212: &scala_212
-  SCALA_VERSION: 2.12.10
+  SCALA_VERSION: 2.12.11
 
 scala_213: &scala_213
-  SCALA_VERSION: 2.13.1
+  SCALA_VERSION: 2.13.3
 
 jdk_8: &jdk_8
   JDK_VERSION: 8

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /.idea/
 /.bloop
 target/
-
+/.bsp

--- a/benchmarks/src/main/scala/zio/redis/PutBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/PutBenchmarks.scala
@@ -76,7 +76,7 @@ class PutBenchmarks {
   def zio(): Unit = {
     val effect = ZIO
       .foreach_(items)(i => set(i, i, None, None, None))
-      .provideLayer(RedisExecutor.live(RedisHost, RedisPort).orDie)
+      .provideLayer(RedisExecutor.liveServer(RedisHost, RedisPort).orDie)
 
     unsafeRun(effect)
   }

--- a/benchmarks/src/main/scala/zio/redis/PutBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/PutBenchmarks.scala
@@ -76,7 +76,7 @@ class PutBenchmarks {
   def zio(): Unit = {
     val effect = ZIO
       .foreach_(items)(i => set(i, i, None, None, None))
-      .provideLayer(RedisExecutor.liveServer(RedisHost, RedisPort).orDie)
+      .provideLayer(RedisExecutor.live(RedisHost, RedisPort).orDie)
 
     unsafeRun(effect)
   }

--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ lazy val redis =
     .settings(buildInfoSettings("zio.redis"))
     .settings(
       libraryDependencies ++= Seq(
-        "dev.zio" %% "zio"          % "1.0.3",
+        "dev.zio" %% "zio-streams"  % "1.0.3",
         "dev.zio" %% "zio-test"     % "1.0.3" % Test,
         "dev.zio" %% "zio-test-sbt" % "1.0.3" % Test
       ),

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -28,10 +28,10 @@ object BuildHelper {
     )
 
   val Scala211 = "2.11.12"
-  val Scala212 = "2.12.10"
-  val Scala213 = "2.13.1"
+  val Scala212 = "2.12.11"
+  val Scala213 = "2.13.3"
 
-  private val SilencerVersion = "1.4.4"
+  private val SilencerVersion = "1.7.1"
 
   private val StdOpts =
     Seq(

--- a/redis/src/main/scala/zio/redis/Input.scala
+++ b/redis/src/main/scala/zio/redis/Input.scala
@@ -4,6 +4,7 @@ import java.time.Instant
 import java.util.concurrent.TimeUnit
 
 import scala.util.matching.Regex
+
 import zio.Chunk
 import zio.duration.Duration
 

--- a/redis/src/main/scala/zio/redis/Input.scala
+++ b/redis/src/main/scala/zio/redis/Input.scala
@@ -14,6 +14,7 @@ sealed trait Input[-A] {
 
 object Input {
 
+  @inline
   private[this] def stringEncode(s: String) = RespValue.bulkString(s)
 
   case object AbsTtlInput extends Input[AbsTtl] {

--- a/redis/src/main/scala/zio/redis/Input.scala
+++ b/redis/src/main/scala/zio/redis/Input.scala
@@ -4,211 +4,225 @@ import java.time.Instant
 import java.util.concurrent.TimeUnit
 
 import scala.util.matching.Regex
-
 import zio.Chunk
 import zio.duration.Duration
 
 sealed trait Input[-A] {
-  private[redis] def encode(data: A): Chunk[String]
+  private[redis] def encode(data: A): Chunk[RespValue.BulkString]
 }
 
 object Input {
-  private[this] def wrap(text: String): String = s"$$${text.length}\r\n$text\r\n"
+
+  private[this] def stringEncode(s: String) = RespValue.bulkString(s)
 
   case object AbsTtlInput extends Input[AbsTtl] {
-    def encode(data: AbsTtl): Chunk[String] = Chunk.single(wrap(data.stringify))
+    def encode(data: AbsTtl): Chunk[RespValue.BulkString] = Chunk.single(stringEncode(data.stringify))
   }
 
   case object AggregateInput extends Input[Aggregate] {
-    def encode(data: Aggregate): Chunk[String] = Chunk(wrap("AGGREGATE"), wrap(data.stringify))
+    def encode(data: Aggregate): Chunk[RespValue.BulkString] =
+      Chunk(stringEncode("AGGREGATE"), stringEncode(data.stringify))
   }
 
   case object AuthInput extends Input[Auth] {
-    def encode(data: Auth): Chunk[String] = Chunk(wrap("AUTH"), wrap(data.password))
+    def encode(data: Auth): Chunk[RespValue.BulkString] = Chunk(stringEncode("AUTH"), stringEncode(data.password))
   }
 
   case object BoolInput extends Input[Boolean] {
-    def encode(data: Boolean): Chunk[String] = Chunk.single(wrap(if (data) "1" else "0"))
+    def encode(data: Boolean): Chunk[RespValue.BulkString] = Chunk.single(stringEncode(if (data) "1" else "0"))
   }
 
   case object BitFieldCommandInput extends Input[BitFieldCommand] {
-    def encode(data: BitFieldCommand): Chunk[String] = {
+    def encode(data: BitFieldCommand): Chunk[RespValue.BulkString] = {
       import BitFieldCommand._
 
       data match {
-        case BitFieldGet(t, o)     => Chunk(wrap("GET"), wrap(t.stringify), wrap(o.toString))
-        case BitFieldSet(t, o, v)  => Chunk(wrap("SET"), wrap(t.stringify), wrap(o.toString), wrap(v.toString))
-        case BitFieldIncr(t, o, i) => Chunk(wrap("INCRBY"), wrap(t.stringify), wrap(o.toString), wrap(i.toString))
-        case bfo: BitFieldOverflow => Chunk(wrap("OVERFLOW"), wrap(bfo.stringify))
+        case BitFieldGet(t, o)     => Chunk(stringEncode("GET"), stringEncode(t.stringify), stringEncode(o.toString))
+        case BitFieldSet(t, o, v)  =>
+          Chunk(stringEncode("SET"), stringEncode(t.stringify), stringEncode(o.toString), stringEncode(v.toString))
+        case BitFieldIncr(t, o, i) =>
+          Chunk(stringEncode("INCRBY"), stringEncode(t.stringify), stringEncode(o.toString), stringEncode(i.toString))
+        case bfo: BitFieldOverflow => Chunk(stringEncode("OVERFLOW"), stringEncode(bfo.stringify))
       }
     }
   }
 
   case object BitOperationInput extends Input[BitOperation] {
-    def encode(data: BitOperation): Chunk[String] = Chunk.single(wrap(data.stringify))
+    def encode(data: BitOperation): Chunk[RespValue.BulkString] = Chunk.single(stringEncode(data.stringify))
   }
 
   case object BitPosRangeInput extends Input[BitPosRange] {
-    def encode(data: BitPosRange): Chunk[String] = {
-      val start = wrap(data.start.toString)
-      data.end.fold(Chunk.single(start))(end => Chunk(start, wrap(end.toString)))
+    def encode(data: BitPosRange): Chunk[RespValue.BulkString] = {
+      val start = stringEncode(data.start.toString)
+      data.end.fold(Chunk.single(start))(end => Chunk(start, stringEncode(end.toString)))
     }
   }
 
   case object ChangedInput extends Input[Changed] {
-    def encode(data: Changed): Chunk[String] = Chunk.single(wrap(data.stringify))
+    def encode(data: Changed): Chunk[RespValue.BulkString] = Chunk.single(stringEncode(data.stringify))
   }
 
   case object CopyInput extends Input[Copy] {
-    def encode(data: Copy): Chunk[String] = Chunk.single(wrap(data.stringify))
+    def encode(data: Copy): Chunk[RespValue.BulkString] = Chunk.single(stringEncode(data.stringify))
   }
 
   case object CountInput extends Input[Count] {
-    def encode(data: Count): Chunk[String] = Chunk(wrap("COUNT"), wrap(data.count.toString))
+    def encode(data: Count): Chunk[RespValue.BulkString] =
+      Chunk(stringEncode("COUNT"), stringEncode(data.count.toString))
   }
 
   case object PositionInput extends Input[Position] {
-    def encode(data: Position): Chunk[String] = Chunk.single(wrap(data.stringify))
+    def encode(data: Position): Chunk[RespValue.BulkString] = Chunk.single(stringEncode(data.stringify))
   }
 
   case object DoubleInput extends Input[Double] {
-    def encode(data: Double): Chunk[String] = Chunk.single(wrap(data.toString))
+    def encode(data: Double): Chunk[RespValue.BulkString] = Chunk.single(stringEncode(data.toString))
   }
 
   case object DurationMillisecondsInput extends Input[Duration] {
-    def encode(data: Duration): Chunk[String] = Chunk.single(wrap(data.toMillis.toString))
+    def encode(data: Duration): Chunk[RespValue.BulkString] = Chunk.single(stringEncode(data.toMillis.toString))
   }
 
   case object DurationSecondsInput extends Input[Duration] {
-    def encode(data: Duration): Chunk[String] = {
+    def encode(data: Duration): Chunk[RespValue.BulkString] = {
       val seconds = TimeUnit.MILLISECONDS.toSeconds(data.toMillis)
-      Chunk.single(wrap(seconds.toString))
+      Chunk.single(stringEncode(seconds.toString))
     }
   }
 
   case object DurationTtlInput extends Input[Duration] {
-    def encode(data: Duration): Chunk[String] = {
+    def encode(data: Duration): Chunk[RespValue.BulkString] = {
       val milliseconds = data.toMillis
-      Chunk(wrap("PX"), wrap(milliseconds.toString))
+      Chunk(stringEncode("PX"), stringEncode(milliseconds.toString))
     }
   }
 
   case object FreqInput extends Input[Freq] {
-    def encode(data: Freq): Chunk[String] = Chunk(wrap("FREQ"), wrap(data.frequency))
+    def encode(data: Freq): Chunk[RespValue.BulkString] = Chunk(stringEncode("FREQ"), stringEncode(data.frequency))
   }
 
   case object IdleTimeInput extends Input[IdleTime] {
-    def encode(data: IdleTime): Chunk[String] = Chunk(wrap("IDLETIME"), wrap(data.seconds.toString))
+    def encode(data: IdleTime): Chunk[RespValue.BulkString] =
+      Chunk(stringEncode("IDLETIME"), stringEncode(data.seconds.toString))
   }
 
   case object IncrementInput extends Input[Increment] {
-    def encode(data: Increment): Chunk[String] = Chunk.single(wrap(data.stringify))
+    def encode(data: Increment): Chunk[RespValue.BulkString] = Chunk.single(stringEncode(data.stringify))
   }
 
   case object KeepTtlInput extends Input[KeepTtl] {
-    def encode(data: KeepTtl): Chunk[String] = Chunk.single(wrap(data.stringify))
+    def encode(data: KeepTtl): Chunk[RespValue.BulkString] = Chunk.single(stringEncode(data.stringify))
   }
 
   case object LexRangeInput extends Input[LexRange] {
-    def encode(data: LexRange): Chunk[String] = Chunk(wrap(data.min.stringify), wrap(data.max.stringify))
+    def encode(data: LexRange): Chunk[RespValue.BulkString] =
+      Chunk(stringEncode(data.min.stringify), stringEncode(data.max.stringify))
   }
 
   case object LimitInput extends Input[Limit] {
-    def encode(data: Limit): Chunk[String] =
-      Chunk(wrap("LIMIT"), wrap(data.offset.toString), wrap(data.count.toString))
+    def encode(data: Limit): Chunk[RespValue.BulkString] =
+      Chunk(stringEncode("LIMIT"), stringEncode(data.offset.toString), stringEncode(data.count.toString))
   }
 
   case object LongInput extends Input[Long] {
-    def encode(data: Long): Chunk[String] = Chunk.single(wrap(data.toString))
+    def encode(data: Long): Chunk[RespValue.BulkString] = Chunk.single(stringEncode(data.toString))
   }
 
   case object LongLatInput extends Input[LongLat] {
-    def encode(data: LongLat): Chunk[String] = Chunk(wrap(data.longitude.toString), wrap(data.latitude.toString))
+    def encode(data: LongLat): Chunk[RespValue.BulkString] =
+      Chunk(stringEncode(data.longitude.toString), stringEncode(data.latitude.toString))
   }
 
   case object MemberScoreInput extends Input[MemberScore] {
-    def encode(data: MemberScore): Chunk[String] = Chunk(wrap(data.score.toString), wrap(data.member))
+    def encode(data: MemberScore): Chunk[RespValue.BulkString] =
+      Chunk(stringEncode(data.score.toString), stringEncode(data.member))
   }
 
   case object NoInput extends Input[Unit] {
-    def encode(data: Unit): Chunk[String] = Chunk.empty
+    def encode(data: Unit): Chunk[RespValue.BulkString] = Chunk.empty
   }
 
   final case class NonEmptyList[-A](input: Input[A]) extends Input[(A, List[A])] {
-    def encode(data: (A, List[A])): Chunk[String] =
-      (data._1 :: data._2).foldLeft(Chunk.empty: Chunk[String])((acc, a) => acc ++ input.encode(a))
+    def encode(data: (A, List[A])): Chunk[RespValue.BulkString] =
+      (data._1 :: data._2).foldLeft(Chunk.empty: Chunk[RespValue.BulkString])((acc, a) => acc ++ input.encode(a))
   }
 
   case object OrderInput extends Input[Order] {
-    def encode(data: Order): Chunk[String] = Chunk.single(wrap(data.stringify))
+    def encode(data: Order): Chunk[RespValue.BulkString] = Chunk.single(stringEncode(data.stringify))
   }
 
   case object RadiusUnitInput extends Input[RadiusUnit] {
-    def encode(data: RadiusUnit): Chunk[String] = Chunk.single(wrap(data.stringify))
+    def encode(data: RadiusUnit): Chunk[RespValue.BulkString] = Chunk.single(stringEncode(data.stringify))
   }
 
   case object RangeInput extends Input[Range] {
-    def encode(data: Range): Chunk[String] = Chunk(wrap(data.start.toString), wrap(data.end.toString))
+    def encode(data: Range): Chunk[RespValue.BulkString] =
+      Chunk(stringEncode(data.start.toString), stringEncode(data.end.toString))
   }
 
   case object RegexInput extends Input[Regex] {
-    def encode(data: Regex): Chunk[String] = Chunk(wrap("MATCH"), wrap(data.regex))
+    def encode(data: Regex): Chunk[RespValue.BulkString] = Chunk(stringEncode("MATCH"), stringEncode(data.regex))
   }
 
   case object ReplaceInput extends Input[Replace] {
-    def encode(data: Replace): Chunk[String] = Chunk.single(wrap(data.stringify))
+    def encode(data: Replace): Chunk[RespValue.BulkString] = Chunk.single(stringEncode(data.stringify))
   }
 
   case object StoreDistInput extends Input[StoreDist] {
-    def encode(data: StoreDist): Chunk[String] = Chunk(wrap("STOREDIST"), wrap(data.key))
+    def encode(data: StoreDist): Chunk[RespValue.BulkString] = Chunk(stringEncode("STOREDIST"), stringEncode(data.key))
   }
 
   case object StoreInput extends Input[Store] {
-    def encode(data: Store): Chunk[String] = Chunk(wrap("STORE"), wrap(data.key))
+    def encode(data: Store): Chunk[RespValue.BulkString] = Chunk(stringEncode("STORE"), stringEncode(data.key))
   }
 
   case object ScoreRangeInput extends Input[ScoreRange] {
-    def encode(data: ScoreRange): Chunk[String] = Chunk(wrap(data.min.stringify), wrap(data.max.stringify))
+    def encode(data: ScoreRange): Chunk[RespValue.BulkString] =
+      Chunk(stringEncode(data.min.stringify), stringEncode(data.max.stringify))
   }
 
   case object StringInput extends Input[String] {
-    def encode(data: String): Chunk[String] = Chunk.single(wrap(data))
+    def encode(data: String): Chunk[RespValue.BulkString] = Chunk.single(stringEncode(data))
   }
 
   final case class OptionalInput[-A](a: Input[A]) extends Input[Option[A]] {
-    def encode(data: Option[A]): Chunk[String] = data.fold(Chunk.empty: Chunk[String])(a.encode)
+    def encode(data: Option[A]): Chunk[RespValue.BulkString] =
+      data.fold(Chunk.empty: Chunk[RespValue.BulkString])(a.encode)
   }
 
   case object TimeSecondsInput extends Input[Instant] {
-    def encode(data: Instant): Chunk[String] = Chunk.single(wrap(data.getEpochSecond.toString))
+    def encode(data: Instant): Chunk[RespValue.BulkString] = Chunk.single(stringEncode(data.getEpochSecond.toString))
   }
 
   case object TimeMillisecondsInput extends Input[Instant] {
-    def encode(data: Instant): Chunk[String] = Chunk.single(wrap(data.toEpochMilli.toString))
+    def encode(data: Instant): Chunk[RespValue.BulkString] = Chunk.single(stringEncode(data.toEpochMilli.toString))
   }
 
   case object WeightsInput extends Input[::[Double]] {
-    def encode(data: ::[Double]): Chunk[String] =
-      data.foldLeft(Chunk.single(wrap("WEIGHTS")): Chunk[String])((acc, a) => acc ++ Chunk.single(wrap(a.toString)))
+    def encode(data: ::[Double]): Chunk[RespValue.BulkString] =
+      data.foldLeft(Chunk.single(stringEncode("WEIGHTS")): Chunk[RespValue.BulkString])((acc, a) =>
+        acc ++ Chunk.single(stringEncode(a.toString))
+      )
   }
 
   final case class Tuple2[-A, -B](_1: Input[A], _2: Input[B]) extends Input[(A, B)] {
-    def encode(data: (A, B)): Chunk[String] = _1.encode(data._1) ++ _2.encode(data._2)
+    def encode(data: (A, B)): Chunk[RespValue.BulkString] = _1.encode(data._1) ++ _2.encode(data._2)
   }
 
   final case class Tuple3[-A, -B, -C](_1: Input[A], _2: Input[B], _3: Input[C]) extends Input[(A, B, C)] {
-    def encode(data: (A, B, C)): Chunk[String] = _1.encode(data._1) ++ _2.encode(data._2) ++ _3.encode(data._3)
+    def encode(data: (A, B, C)): Chunk[RespValue.BulkString] =
+      _1.encode(data._1) ++ _2.encode(data._2) ++ _3.encode(data._3)
   }
 
   final case class Tuple4[-A, -B, -C, -D](_1: Input[A], _2: Input[B], _3: Input[C], _4: Input[D])
       extends Input[(A, B, C, D)] {
-    def encode(data: (A, B, C, D)): Chunk[String] =
+    def encode(data: (A, B, C, D)): Chunk[RespValue.BulkString] =
       _1.encode(data._1) ++ _2.encode(data._2) ++ _3.encode(data._3) ++ _4.encode(data._4)
   }
 
   final case class Tuple5[-A, -B, -C, -D, -E](_1: Input[A], _2: Input[B], _3: Input[C], _4: Input[D], _5: Input[E])
       extends Input[(A, B, C, D, E)] {
-    def encode(data: (A, B, C, D, E)): Chunk[String] =
+    def encode(data: (A, B, C, D, E)): Chunk[RespValue.BulkString] =
       _1.encode(data._1) ++ _2.encode(data._2) ++ _3.encode(data._3) ++ _4.encode(data._4) ++ _5.encode(data._5)
   }
 
@@ -221,7 +235,7 @@ object Input {
     _6: Input[F],
     _7: Input[G]
   ) extends Input[(A, B, C, D, E, F, G)] {
-    def encode(data: (A, B, C, D, E, F, G)): Chunk[String] =
+    def encode(data: (A, B, C, D, E, F, G)): Chunk[RespValue.BulkString] =
       _1.encode(data._1) ++ _2.encode(data._2) ++ _3.encode(data._3) ++ _4.encode(data._4) ++ _5.encode(data._5) ++
         _6.encode(data._6) ++ _7.encode(data._7)
   }
@@ -237,7 +251,7 @@ object Input {
     _8: Input[H],
     _9: Input[I]
   ) extends Input[(A, B, C, D, E, F, G, H, I)] {
-    def encode(data: (A, B, C, D, E, F, G, H, I)): Chunk[String] =
+    def encode(data: (A, B, C, D, E, F, G, H, I)): Chunk[RespValue.BulkString] =
       _1.encode(data._1) ++ _2.encode(data._2) ++ _3.encode(data._3) ++ _4.encode(data._4) ++ _5.encode(data._5) ++
         _6.encode(data._6) ++ _7.encode(data._7) ++ _8.encode(data._8) ++ _9.encode(data._9)
   }
@@ -255,34 +269,34 @@ object Input {
     _10: Input[J],
     _11: Input[K]
   ) extends Input[(A, B, C, D, E, F, G, H, I, J, K)] {
-    def encode(data: (A, B, C, D, E, F, G, H, I, J, K)): Chunk[String] =
+    def encode(data: (A, B, C, D, E, F, G, H, I, J, K)): Chunk[RespValue.BulkString] =
       _1.encode(data._1) ++ _2.encode(data._2) ++ _3.encode(data._3) ++ _4.encode(data._4) ++
         _5.encode(data._5) ++ _6.encode(data._6) ++ _7.encode(data._7) ++ _8.encode(data._8) ++
         _9.encode(data._9) ++ _10.encode(data._10) ++ _11.encode(data._11)
   }
 
   case object UpdateInput extends Input[Update] {
-    def encode(data: Update): Chunk[String] = Chunk.single(wrap(data.stringify))
+    def encode(data: Update): Chunk[RespValue.BulkString] = Chunk.single(stringEncode(data.stringify))
   }
 
   final case class Varargs[-A](input: Input[A]) extends Input[Iterable[A]] {
-    def encode(data: Iterable[A]): Chunk[String] =
-      data.foldLeft(Chunk.empty: Chunk[String])((acc, a) => acc ++ input.encode(a))
+    def encode(data: Iterable[A]): Chunk[RespValue.BulkString] =
+      data.foldLeft(Chunk.empty: Chunk[RespValue.BulkString])((acc, a) => acc ++ input.encode(a))
   }
 
   case object WithScoresInput extends Input[WithScores] {
-    def encode(data: WithScores): Chunk[String] = Chunk.single(wrap(data.stringify))
+    def encode(data: WithScores): Chunk[RespValue.BulkString] = Chunk.single(stringEncode(data.stringify))
   }
 
   case object WithCoordInput extends Input[WithCoord] {
-    def encode(data: WithCoord): Chunk[String] = Chunk.single(wrap(data.stringify))
+    def encode(data: WithCoord): Chunk[RespValue.BulkString] = Chunk.single(stringEncode(data.stringify))
   }
 
   case object WithDistInput extends Input[WithDist] {
-    def encode(data: WithDist): Chunk[String] = Chunk.single(wrap(data.stringify))
+    def encode(data: WithDist): Chunk[RespValue.BulkString] = Chunk.single(stringEncode(data.stringify))
   }
 
   case object WithHashInput extends Input[WithHash] {
-    def encode(data: WithHash): Chunk[String] = Chunk.single(wrap(data.stringify))
+    def encode(data: WithHash): Chunk[RespValue.BulkString] = Chunk.single(stringEncode(data.stringify))
   }
 }

--- a/redis/src/main/scala/zio/redis/Interpreter.scala
+++ b/redis/src/main/scala/zio/redis/Interpreter.scala
@@ -1,135 +1,236 @@
 package zio.redis
 
-import java.io.IOException
-import java.net.{ InetSocketAddress, StandardSocketOptions }
+import java.io.{ EOFException, IOException }
+import java.net.{ InetAddress, InetSocketAddress, SocketAddress, StandardSocketOptions }
 import java.nio.ByteBuffer
-import java.nio.channels.SocketChannel
-import java.nio.charset.StandardCharsets.UTF_8
-import java.util.concurrent.atomic.AtomicBoolean
-
-import scala.collection.mutable.ArrayBuilder
+import java.nio.channels.{ AsynchronousByteChannel, AsynchronousSocketChannel, Channel, CompletionHandler }
 
 import zio._
-import zio.blocking._
+import zio.stream.Stream
 
 trait Interpreter {
+
+  import Interpreter._
+
   type RedisExecutor = Has[RedisExecutor.Service]
 
   object RedisExecutor {
 
-    val ResponseBufferSize = 1024
+    val defaultPort = 6379
 
     trait Service {
-      def execute(command: Chunk[String]): IO[RedisError, String]
+
+      def execute(command: Chunk[RespValue.BulkString]): IO[RedisError, RespValue]
+
     }
 
-    def live(host: String, port: Int): ZLayer[Blocking, IOException, RedisExecutor] =
+    /**
+     * This is to make better use of pipelining by writing requests to the socket in batches.
+     * Ideally this*(average RESP serialized message size) should equal the buffer size used by `ByteStream`,
+     * but we can only guesstimate.
+     */
+    private val requestQueueSize = 20
+
+    private final class Live(
+      reqQueue: Queue[Request],
+      resQueue: Queue[Promise[RedisError, RespValue]],
+      byteStream: Managed[IOException, ByteStream.ReadWriteBytes]
+    ) extends Service {
+
+      override def execute(command: Chunk[RespValue.BulkString]): IO[RedisError, RespValue] =
+        Promise
+          .make[RedisError, RespValue]
+          .flatMap(promise => reqQueue.offer(Request(command, promise)) *> promise.await)
+
+      private def sendNext(out: Chunk[Byte] => IO[IOException, Unit]): IO[RedisError, Unit] =
+        reqQueue.takeBetween(1, Int.MaxValue).flatMap { reqs =>
+          val bytes = Chunk.fromIterable(reqs).flatMap(req => RespValue.Array(req.command).serialize)
+          out(bytes)
+            .mapError(RedisError.IOError)
+            .tapError(e => IO.foreach(reqs)(_.promise.fail(e)))
+            .zipLeft(IO.foreach(reqs)(req => resQueue.offer(req.promise)))
+        }
+
+      private def runReceive(inStream: Stream[IOException, Byte]): IO[RedisError, Unit] =
+        inStream
+          .mapError(RedisError.IOError)
+          .transduce(RespValue.deserialize.toTransducer)
+          .foreach(response => resQueue.take.flatMap(_.succeed(response)))
+
+      /**
+       * Opens a connection to the server and launches send and receive operations.
+       * All failures are retried by opening a new connection.
+       * Only exits by interruption or defect.
+       */
+      def run: IO[RedisError, Unit] =
+        byteStream
+          .mapError(RedisError.IOError)
+          .use { rwBytes =>
+            sendNext(rwBytes.write).forever race runReceive(rwBytes.read)
+          }
+          .tapError { e =>
+            IO.effectTotal(println(s"Reconnecting due to error: $e")) *>
+              resQueue.takeAll.flatMap(IO.foreach(_)(_.fail(e)))
+          }
+          .retryWhile(Function.const(true))
+          .tapCause(c => IO.effectTotal(Console.err.println(s"Executor exiting: $c")))
+
+    }
+
+    def live: ZLayer[ByteStream, RedisError.IOError, RedisExecutor] =
       ZLayer.fromServiceManaged { env =>
         for {
-          connection <- connect(host, port)
-          _          <- env.blocking(connection.receive.forever).forkManaged
-        } yield new Service {
-          def execute(command: Chunk[String]): IO[RedisError, String] = connection.send(command).flatMap(_.await)
-        }
+          reqQueue <- Queue.bounded[Request](requestQueueSize).toManaged_
+          resQueue <- Queue.unbounded[Promise[RedisError, RespValue]].toManaged_
+          live      = new Live(reqQueue, resQueue, env.connect)
+          _        <- live.run.forkManaged
+        } yield live
       }
 
-    private[this] def connect(host: String, port: Int): Managed[IOException, Connection] = {
-      val makeChannel =
-        IO {
-          val channel = SocketChannel.open(new InetSocketAddress(host, port))
-          channel.configureBlocking(false)
-          channel.setOption(StandardSocketOptions.SO_KEEPALIVE, Boolean.box(true))
-          channel.setOption(StandardSocketOptions.TCP_NODELAY, Boolean.box(true))
-          channel
-        }
+    def liveServer(address: SocketAddress): Layer[RedisError.IOError, RedisExecutor] =
+      ByteStream.socket(address).mapError(RedisError.IOError) >>> live
 
-      val connection =
-        for {
-          channel         <- Managed.fromAutoCloseable(makeChannel)
-          pendingRequests <- Queue.unbounded[Request].toManaged_
-          readinessFlag    = new AtomicBoolean(true)
-          response         = ByteBuffer.allocate(ResponseBufferSize)
-        } yield new Connection(channel, pendingRequests, readinessFlag, response)
+    def liveServer(host: String, port: Int = defaultPort): Layer[RedisError.IOError, RedisExecutor] =
+      ByteStream.socket(host, port).mapError(RedisError.IOError) >>> live
 
-      connection.refineToOrDie[IOException]
-    }
+    def liveLoopback(port: Int = defaultPort): Layer[RedisError.IOError, RedisExecutor] =
+      ByteStream.socketLoopback(port).mapError(RedisError.IOError) >>> live
 
-    private[this] final class Connection(
-      channel: SocketChannel,
-      pendingRequests: Queue[Request],
-      readinessFlag: AtomicBoolean,
-      response: ByteBuffer
-    ) {
-      val receive: UIO[Any] =
-        UIO.effectSuspendTotal(if (readinessFlag.compareAndSet(true, false)) executeNext else UIO.unit)
-
-      def send(command: Chunk[String]): UIO[Promise[RedisError, String]] =
-        Promise.make[RedisError, String].flatMap(p => pendingRequests.offer(Request(command, p)).as(p))
-
-      private val executeNext: UIO[Any] =
-        pendingRequests.take.map { request =>
-          val exchange =
-            IO.effect {
-              try {
-                unsafeSend(request.command)
-                unsafeReceive()
-              } catch {
-                case t: Throwable => throw RedisError.ProtocolError(t.getMessage)
-              } finally readinessFlag.set(true)
-            }
-
-          request.result.unsafeDone(exchange.refineToOrDie[RedisError])
-        }
-
-      private def unsafeReceive(): String = {
-        val builder      = ArrayBuilder.make[Array[Byte]]
-        var readBytes    = 0
-        var responseSize = 0
-
-        // TODO: handle -1
-        while (readBytes == 0 || readBytes == ResponseBufferSize) {
-          channel.read(response)
-          response.flip()
-
-          readBytes = response.remaining()
-          responseSize += readBytes
-
-          val chunk = Array.ofDim[Byte](readBytes)
-
-          response.get(chunk)
-
-          builder += chunk
-
-          response.clear()
-        }
-
-        val chunks = builder.result()
-        val data   = Array.ofDim[Byte](responseSize)
-        var i      = 0
-        var j      = 0
-
-        while (i < chunks.length) {
-          val chunk = chunks(i)
-
-          System.arraycopy(chunk, 0, data, j, chunk.length)
-
-          i += 1
-          j += chunk.length
-        }
-
-        new String(data, UTF_8)
-      }
-
-      private def unsafeSend(command: Chunk[String]): Unit = {
-        val data     = command.mkString
-        val envelope = s"*${command.length}\r\n$data"
-        val buffer   = ByteBuffer.wrap(envelope.getBytes(UTF_8))
-
-        while (buffer.hasRemaining())
-          channel.write(buffer)
-      }
-    }
   }
 
-  private[this] sealed case class Request(command: Chunk[String], result: Promise[RedisError, String])
+  type ByteStream = Has[ByteStream.Service]
+
+  object ByteStream {
+
+    val ResponseBufferSize = 1024
+
+    def connect: ZManaged[ByteStream, IOException, ReadWriteBytes] = ZManaged.accessManaged(_.get.connect)
+
+    trait Service {
+
+      def connect: Managed[IOException, ReadWriteBytes]
+
+    }
+
+    trait ReadWriteBytes {
+
+      def read: Stream[IOException, Byte]
+
+      def write(chunk: Chunk[Byte]): IO[IOException, Unit]
+
+    }
+
+    /**
+     * Adapts `ComplectionHandler` async channel operations with interruption support.
+     */
+    private def effectAsyncChannel[C <: Channel, T](
+      channel: C
+    )(op: C => CompletionHandler[T, Any] => Any): IO[IOException, T] =
+      IO.effectAsyncInterrupt { k =>
+        val handler = new CompletionHandler[T, Any] {
+          def completed(result: T, u: Any): Unit = k(IO.succeedNow(result))
+
+          def failed(t: Throwable, u: Any): Unit =
+            t match {
+              case e: IOException => k(IO.fail(e))
+              case _              => k(IO.die(t))
+            }
+        }
+
+        op(channel)(handler)
+        Left(IO.effect(channel.close()).ignore)
+      }
+
+    def socket(host: String, port: Int): Layer[IOException, ByteStream] =
+      socket(IO.effectTotal(new InetSocketAddress(host, port)))
+
+    def socket(address: SocketAddress): Layer[IOException, ByteStream] = socket(UIO.succeed(address))
+
+    def socketLoopback(port: Int): Layer[IOException, ByteStream] =
+      socket(IO.effectTotal(new InetSocketAddress(InetAddress.getLoopbackAddress, port)))
+
+    private def socket(getAddress: UIO[SocketAddress]): Layer[IOException, ByteStream] = {
+      val makeBuffer = IO.effectTotal(ByteBuffer.allocateDirect(ResponseBufferSize))
+      ZLayer.fromEffect {
+        for {
+          address     <- getAddress
+          readBuffer  <- makeBuffer
+          writeBuffer <- makeBuffer
+        } yield new Connection(address, readBuffer, writeBuffer)
+      }
+    }
+
+    private final class Connection(
+      address: SocketAddress,
+      readBuffer: ByteBuffer,
+      writeBuffer: ByteBuffer
+    ) extends Service {
+
+      private def openChannel: Managed[IOException, AsynchronousSocketChannel] = {
+        val make = for {
+          channel <- IO.effect {
+                       val channel = AsynchronousSocketChannel.open()
+                       channel.setOption(StandardSocketOptions.SO_KEEPALIVE, Boolean.box(true))
+                       channel.setOption(StandardSocketOptions.TCP_NODELAY, Boolean.box(true))
+                       channel
+                     }
+          _       <- effectAsyncChannel[AsynchronousSocketChannel, Void](channel)(c => c.connect(address, null, _))
+        } yield channel
+        Managed.fromAutoCloseable(make).refineToOrDie[IOException]
+      }
+
+      override def connect: Managed[IOException, ReadWriteBytes] =
+        openChannel.map { channel =>
+          val readChunk: IO[Option[IOException], Chunk[Byte]] =
+            (for {
+              _     <- IO.effectTotal(readBuffer.clear())
+              _     <- effectAsyncChannel[AsynchronousByteChannel, Integer](channel)(c => c.read(readBuffer, null, _))
+                     .filterOrFail(_ >= 0)(new EOFException())
+              chunk <- IO.effectTotal {
+                         readBuffer.flip()
+                         val count = readBuffer.remaining()
+                         val array = Array.ofDim[Byte](count)
+                         readBuffer.get(array)
+                         Chunk.fromArray(array)
+                       }
+            } yield chunk).mapError {
+              case _: EOFException => None
+              case e: IOException  => Some(e)
+            }
+
+          def writeChunk(chunk: Chunk[Byte]): IO[IOException, Unit] =
+            IO.when(chunk.nonEmpty) {
+              IO.effectTotal {
+                writeBuffer.clear()
+                val (c, remainder) = chunk.splitAt(writeBuffer.capacity())
+                writeBuffer.put(c.toArray)
+                writeBuffer.flip()
+                remainder
+              }.flatMap { remainder =>
+                effectAsyncChannel[AsynchronousByteChannel, Integer](channel)(c => c.write(writeBuffer, null, _))
+                  .repeatWhileM(_ => IO.effectTotal(writeBuffer.hasRemaining))
+                  .zipRight(writeChunk(remainder))
+              }
+            }
+
+          new ReadWriteBytes {
+            override def read = Stream.repeatEffectChunkOption(readChunk)
+
+            override def write(chunk: Chunk[Byte]) = writeChunk(chunk)
+          }
+        }
+
+    }
+
+  }
+
+}
+
+object Interpreter {
+
+  private final case class Request(
+    command: Chunk[RespValue.BulkString],
+    promise: Promise[RedisError, RespValue]
+  )
+
 }

--- a/redis/src/main/scala/zio/redis/Output.scala
+++ b/redis/src/main/scala/zio/redis/Output.scala
@@ -23,7 +23,7 @@ sealed trait Output[+A] {
 
   final def map[B](f: A => B): Output[B] =
     new Output[B] {
-      override protected def tryDecode(respValue: RespValue): B = f(self.tryDecode(respValue))
+      protected def tryDecode(respValue: RespValue): B = f(self.tryDecode(respValue))
     }
 
 }

--- a/redis/src/main/scala/zio/redis/Output.scala
+++ b/redis/src/main/scala/zio/redis/Output.scala
@@ -4,685 +4,290 @@ import zio.Chunk
 import zio.duration._
 
 sealed trait Output[+A] {
-  private[redis] final def unsafeDecode(text: String): A = {
-    val error = decodeError(text)
 
-    if (error eq null) tryDecode(text) else throw error
-  }
+  self =>
 
-  private[this] def decodeError(text: String): RedisError =
-    if (text.startsWith("-ERR"))
-      RedisError.ProtocolError(text.drop(4).trim())
-    else if (text.startsWith("-WRONGTYPE"))
-      RedisError.WrongType(text.drop(10).trim())
-    else
-      null
+  private[redis] final def unsafeDecode(respValue: RespValue): A =
+    respValue match {
+      case RespValue.Error(msg) if msg.startsWith("ERR")       =>
+        throw RedisError.ProtocolError(msg.drop(3).trim())
+      case RespValue.Error(msg) if msg.startsWith("WRONGTYPE") =>
+        throw RedisError.WrongType(msg.drop(9).trim())
+      case RespValue.Error(msg)                                =>
+        throw RedisError.ProtocolError(msg.trim)
+      case success                                             =>
+        tryDecode(success)
+    }
 
-  protected def tryDecode(text: String): A
+  protected def tryDecode(respValue: RespValue): A
+
+  final def map[B](f: A => B): Output[B] =
+    new Output[B] {
+      override protected def tryDecode(respValue: RespValue): B = f(self.tryDecode(respValue))
+    }
+
 }
 
 object Output {
 
   import RedisError._
 
+  private def decodeDouble(bytes: Chunk[Byte]): Double = {
+    val text = RespValue.decodeString(bytes)
+    try text.toDouble
+    catch {
+      case _: NumberFormatException => throw ProtocolError(s"'$text' isn't a double.")
+    }
+  }
+
   case object BoolOutput extends Output[Boolean] {
-    protected def tryDecode(text: String): Boolean =
-      if (text == ":1\r\n")
-        true
-      else if (text == ":0\r\n")
-        false
-      else
-        throw ProtocolError(s"$text isn't a boolean.")
+
+    override protected def tryDecode(respValue: RespValue): Boolean =
+      respValue match {
+        case RespValue.Integer(0) => false
+        case RespValue.Integer(1) => true
+        case other                => throw ProtocolError(s"$other isn't a boolean")
+      }
+
   }
 
   case object ChunkOutput extends Output[Chunk[String]] {
-    protected def tryDecode(text: String): Chunk[String] =
-      if (text.startsWith("*"))
-        unsafeReadChunk(text, 0)
-      else
-        throw ProtocolError(s"$text isn't an array.")
+
+    override protected def tryDecode(respValue: RespValue): Chunk[String] =
+      respValue match {
+        case RespValue.Array(values) =>
+          values.map {
+            case s @ RespValue.BulkString(_) => s.asString
+            case other                       => throw ProtocolError(s"$other is not a bulk string")
+          }
+        case other                   =>
+          throw ProtocolError(s"$other isn't an array")
+      }
+
   }
 
   case object DoubleOutput extends Output[Double] {
-    protected def tryDecode(text: String): Double =
-      if (text.startsWith("$"))
-        parse(text)
-      else
-        throw ProtocolError(s"$text isn't a double.")
 
-    private[this] def parse(text: String): Double = {
-      var pos = 1
-      var len = 0
-
-      while (text.charAt(pos) != '\r') {
-        len = len * 10 + text.charAt(pos) - '0'
-        pos += 1
+    override protected def tryDecode(respValue: RespValue): Double =
+      respValue match {
+        case RespValue.BulkString(bytes) => decodeDouble(bytes)
+        case other                       => throw ProtocolError(s"$other isn't a double.")
       }
 
-      // skip to the first payload char
-      pos += 2
+  }
 
-      try text.substring(pos, pos + len).toDouble
-      catch {
-        case _: Throwable => throw ProtocolError(s"$text isn't a double.")
+  private object DurationOutput extends Output[Long] {
+    override protected def tryDecode(respValue: RespValue): Long =
+      respValue match {
+        case RespValue.Integer(-2L) => throw ProtocolError("Key not found.")
+        case RespValue.Integer(-1L) => throw ProtocolError("Key has no expire.")
+        case RespValue.Integer(n)   => n
+        case other                  => throw ProtocolError(s"$other isn't a duration.")
       }
-    }
   }
 
-  case object DurationMillisecondsOutput extends Output[Duration] {
-    protected def tryDecode(text: String): Duration =
-      if (text.startsWith(":"))
-        parse(text)
-      else
-        throw ProtocolError(s"$text isn't a duration.")
+  val DurationMillisecondsOutput: Output[Duration] = DurationOutput.map(_.milliseconds)
 
-    private[this] def parse(text: String): Duration = {
-      val value = unsafeReadNumber(text)
-
-      if (value == -2)
-        throw ProtocolError("Key not found.")
-      else if (value == -1)
-        throw ProtocolError("Key has no expire.")
-      else
-        value.millis
-    }
-  }
-
-  case object DurationSecondsOutput extends Output[Duration] {
-    protected def tryDecode(text: String): Duration =
-      if (text.startsWith(":"))
-        parse(text)
-      else
-        throw ProtocolError(s"$text isn't a duration.")
-
-    private[this] def parse(text: String): Duration = {
-      val value = unsafeReadNumber(text)
-
-      if (value == -2)
-        throw ProtocolError("Key not found.")
-      else if (value == -1)
-        throw ProtocolError("Key has no expire.")
-      else
-        value.seconds
-    }
-  }
+  val DurationSecondsOutput: Output[Duration] = DurationOutput.map(_.seconds)
 
   case object LongOutput extends Output[Long] {
-    protected def tryDecode(text: String): Long =
-      if (text.startsWith(":"))
-        unsafeReadNumber(text)
-      else
-        throw ProtocolError(s"$text isn't a number.")
+
+    override protected def tryDecode(respValue: RespValue): Long =
+      respValue match {
+        case RespValue.Integer(v) => v
+        case other                => throw ProtocolError(s"$other isn't an integer")
+      }
+
   }
 
   final case class OptionalOutput[+A](output: Output[A]) extends Output[Option[A]] {
-    protected def tryDecode(text: String): Option[A] =
-      if (text.startsWith("$-1")) None else Some(output.tryDecode(text))
+
+    override protected def tryDecode(respValue: RespValue): Option[A] =
+      respValue match {
+        case RespValue.NullValue => None
+        case other               => Some(output.tryDecode(other))
+      }
+
   }
 
   case object ScanOutput extends Output[(String, Chunk[String])] {
-    protected def tryDecode(text: String): (String, Chunk[String]) =
-      if (text.startsWith("*2\r\n"))
-        parse(text)
-      else
-        throw ProtocolError(s"$text isn't scan output.")
 
-    private[this] def parse(text: String): (String, Chunk[String]) = {
-      var pos = 5
-      var len = 0
-
-      while (text.charAt(pos) != '\r') {
-        len = len * 10 + text.charAt(pos) - '0'
-        pos += 1
+    override protected def tryDecode(respValue: RespValue): (String, Chunk[String]) =
+      respValue match {
+        case RespValue.ArrayValues(cursor @ RespValue.BulkString(_), RespValue.Array(items)) =>
+          val strings = items.map {
+            case s @ RespValue.BulkString(_) => s.asString
+            case other                       => s"$other is not a bulk string"
+          }
+          (cursor.asString, strings)
+        case other                                                                           =>
+          throw ProtocolError(s"$other isn't scan output")
       }
 
-      // skip to the first payload char
-      pos += 2
-
-      val cursor = text.substring(pos, pos + len)
-      val items  = unsafeReadChunk(text, pos + len + 2)
-
-      (cursor, items)
-    }
   }
 
   case object KeyElemOutput extends Output[Option[(String, String)]] {
-    protected def tryDecode(text: String): Option[(String, String)] =
-      if (text.startsWith("*-1\r\n"))
-        None
-      else if (text.startsWith("*2\r\n"))
-        Some(parse(text))
-      else
-        throw ProtocolError(s"$text isn't blPop output.")
 
-    private[this] def parse(text: String): (String, String) = {
-      val items = unsafeReadChunk(text, 0)
-      (items(0), items(1))
-    }
+    override protected def tryDecode(respValue: RespValue): Option[(String, String)] =
+      respValue match {
+        case RespValue.NullValue                                                             =>
+          None
+        case RespValue.ArrayValues(a @ RespValue.BulkString(_), b @ RespValue.BulkString(_)) =>
+          Some((a.asString, b.asString))
+        case other                                                                           => throw ProtocolError(s"$other isn't blPop output")
+      }
+
   }
 
   case object StringOutput extends Output[String] {
-    protected def tryDecode(text: String): String =
-      if (text.startsWith("+"))
-        parse(text)
-      else
-        throw ProtocolError(s"$text isn't a simple string.")
 
-    private[this] def parse(text: String): String =
-      text.substring(1, text.length - 2)
+    override protected def tryDecode(respValue: RespValue): String =
+      respValue match {
+        case RespValue.SimpleString(s) => s
+        case other                     => throw ProtocolError(s"$other isn't a simple string")
+      }
+
   }
 
   case object MultiStringOutput extends Output[String] {
-    protected def tryDecode(text: String): String =
-      if (text.startsWith("$"))
-        unsafeReadMultiString(text)
-      else
-        throw ProtocolError(s"$text isn't a string.")
+
+    override protected def tryDecode(respValue: RespValue): String =
+      respValue match {
+        case s @ RespValue.BulkString(_) => s.asString
+        case other                       => throw ProtocolError(s"$other isn't a bulk string")
+      }
+
   }
 
   case object MultiStringChunkOutput extends Output[Chunk[String]] {
-    protected def tryDecode(text: String): Chunk[String] =
-      if (text.startsWith("$-1"))
-        Chunk.empty
-      else if (text.startsWith("$"))
-        Chunk(unsafeReadMultiString(text))
-      else if (text.startsWith("*"))
-        unsafeReadChunk(text, 0)
-      else
-        throw ProtocolError(s"$text isn't a string nor an array.")
+
+    override protected def tryDecode(respValue: RespValue): Chunk[String] =
+      respValue match {
+        case RespValue.NullValue         =>
+          Chunk.empty
+        case s @ RespValue.BulkString(_) =>
+          Chunk.single(s.asString)
+        case RespValue.Array(elements)   =>
+          elements.map {
+            case s @ RespValue.BulkString(_) => s.asString
+            case other                       => throw ProtocolError(s"$other isn't a bulk string")
+          }
+        case other                       => throw ProtocolError(s"$other isn't a string nor an array")
+      }
+
   }
 
   case object ChunkOptionalMultiStringOutput extends Output[Chunk[Option[String]]] {
-    protected def tryDecode(text: String): Chunk[Option[String]] =
-      if (text.startsWith("*-1\r\n"))
-        Chunk.empty
-      else if (text.startsWith("*"))
-        unsafeReadChunkOptionalString(text, 0)
-      else
-        throw ProtocolError(s"$text isn't an array.")
+    protected def tryDecode(respValue: RespValue): Chunk[Option[String]] =
+      respValue match {
+        case RespValue.NullValue       => Chunk.empty
+        case RespValue.Array(elements) =>
+          elements.map {
+            case s @ RespValue.BulkString(_) => Some(s.asString)
+            case RespValue.NullValue         => None
+            case other                       => throw ProtocolError(s"$other isn't null or a bulk string")
+          }
+        case other                     => throw ProtocolError(s"$other isn't an array")
+      }
   }
 
   case object ChunkOptionalLongOutput extends Output[Chunk[Option[Long]]] {
-    protected def tryDecode(text: String): Chunk[Option[Long]] =
-      if (text.startsWith("*"))
-        unsafeReadChunkOptionalLong(text, 0)
-      else
-        throw ProtocolError("$text isn't an array")
+    protected def tryDecode(respValue: RespValue): Chunk[Option[Long]] =
+      respValue match {
+        case RespValue.Array(elements) =>
+          elements.map {
+            case RespValue.Integer(element) => Some(element)
+            case RespValue.NullValue        => None
+            case other                      => throw ProtocolError(s"$other isn't an integer")
+          }
+        case other                     => throw ProtocolError(s"$other isn't an array")
+      }
   }
 
   case object TypeOutput extends Output[RedisType] {
-    protected def tryDecode(text: String): RedisType =
-      text match {
-        case "+string\r\n" => RedisType.String
-        case "+list\r\n"   => RedisType.List
-        case "+set\r\n"    => RedisType.Set
-        case "+zset\r\n"   => RedisType.SortedSet
-        case "+hash\r\n"   => RedisType.Hash
-        case _             => throw ProtocolError(s"$text isn't redis type.")
+    protected def tryDecode(respValue: RespValue): RedisType =
+      respValue match {
+        case RespValue.SimpleString("string") => RedisType.String
+        case RespValue.SimpleString("list")   => RedisType.List
+        case RespValue.SimpleString("set")    => RedisType.Set
+        case RespValue.SimpleString("zset")   => RedisType.SortedSet
+        case RespValue.SimpleString("hash")   => RedisType.Hash
+        case other                            => throw ProtocolError(s"$other isn't redis type.")
       }
   }
 
   case object UnitOutput extends Output[Unit] {
-    protected def tryDecode(text: String): Unit =
-      if (text == "+OK\r\n")
-        ()
-      else
-        throw ProtocolError(s"$text isn't unit.")
+    protected def tryDecode(respValue: RespValue): Unit =
+      respValue match {
+        case RespValue.SimpleString("OK") => ()
+        case other                        => throw ProtocolError(s"$other isn't unit.")
+      }
   }
 
   case object GeoOutput extends Output[Chunk[LongLat]] {
-    protected def tryDecode(text: String) =
-      if (text.startsWith("*"))
-        parse(text)
-      else
-        throw ProtocolError(s"$text isn't scan output.")
-
-    private[this] def parse(text: String): Chunk[LongLat] =
-      unsafeReadCoordinates(text)
+    protected def tryDecode(respValue: RespValue): Chunk[LongLat] =
+      respValue match {
+        case RespValue.Array(elements) =>
+          elements.map {
+            case RespValue.ArrayValues(RespValue.BulkString(long), RespValue.BulkString(lat)) =>
+              LongLat(decodeDouble(long), decodeDouble(lat))
+            case other                                                                        =>
+              throw ProtocolError(s"$other was not a longitude,latitude pair")
+          }
+        case RespValue.NullValue       =>
+          Chunk.empty
+        case other                     =>
+          throw ProtocolError(s"$other isn't geo output")
+      }
   }
 
   case object GeoRadiusOutput extends Output[Chunk[GeoView]] {
-    protected def tryDecode(text: String) =
-      if (text.startsWith("*"))
-        parse(text)
-      else
-        throw ProtocolError(s"$text isn't scan output.")
-
-    private[this] def parse(text: String): Chunk[GeoView] = {
-      val len = unsafeReadNumber(text).toInt
-
-      if (containsInnerArray(text)) {
-        val pos          = skipToNext(text, 0)
-        var output       = Array.ofDim[GeoView](len)
-        val coordinates  = unsafeReadCoordinates(text)
-        val containsHash = containsGeoHash(text)
-
-        output =
-          if (containsHash)
-            viewWithDetails(text, pos, len, coordinates)
-          else if (coordinates.isEmpty)
-            viewWithDistance(text, pos, len)
-          else
-            view(text, pos, len, coordinates)
-
-        Chunk.fromArray(output)
-      } else unsafeReadMembers(text, len)
-    }
-
-    private[this] def viewWithDistance(text: String, start: Int, len: Int): Array[GeoView] = {
-      var idx    = 0
-      var pos    = start
-      val output = Array.ofDim[GeoView](len)
-
-      while (idx < len) {
-        val member = unsafeReadString(text, pos)
-
-        pos = skipToNext(text, pos)
-
-        output(idx) = GeoView(member, Some(unsafeReadString(text, pos).toDouble), None, None)
-        idx += 1
-
-        if (idx < len)
-          pos = skipToNext(text, pos)
-      }
-
-      output
-    }
-
-    private[this] def viewWithDetails(
-      text: String,
-      start: Int,
-      len: Int,
-      coordinates: Chunk[LongLat]
-    ): Array[GeoView] = {
-      var idx    = 0
-      var pos    = start
-      val output = Array.ofDim[GeoView](len)
-
-      while (idx < len) {
-        val member = unsafeReadString(text, pos)
-
-        while (text.charAt(pos) != '\n') pos += 1
-        pos += 1
-
-        val longLat = if (coordinates.isEmpty) None else Some(coordinates(idx))
-
-        output(idx) = if (text.charAt(pos) == ':') {
-          pos += 1
-          GeoView(member, None, Some(unsafeReadString(text, pos).toLong), longLat)
-        } else {
-          while (text.charAt(pos) != '\n') pos += 1
-          pos += 1
-
-          val distance = unsafeReadString(text, pos).toDouble
-
-          while (text.charAt(pos) != ':') pos += 1
-          pos += 1
-
-          GeoView(member, Some(distance), Some(unsafeReadString(text, pos).toLong), longLat)
-        }
-
-        idx += 1
-        if (idx < len)
-          while (!text.charAt(pos).isLetter) pos += 1
-      }
-
-      output
-    }
-
-    private[this] def view(
-      text: String,
-      start: Int,
-      len: Int,
-      coordinates: Chunk[LongLat]
-    ): Array[GeoView] = {
-      var idx    = 0
-      var pos    = start
-      val output = Array.ofDim[GeoView](len)
-
-      while (idx < len) {
-        val member = unsafeReadString(text, pos)
-
-        while (text.charAt(pos) != '\n') pos += 1
-        pos += 1
-
-        output(idx) =
-          if (text.charAt(pos) != '$')
-            GeoView(member, None, None, Some(coordinates(idx)))
-          else {
-            while (text.charAt(pos) != '\n') pos += 1
-            pos += 1
-            GeoView(member, Some(unsafeReadString(text, pos).toDouble), None, Some(coordinates(idx)))
+    protected def tryDecode(respValue: RespValue): Chunk[GeoView] =
+      respValue match {
+        case RespValue.Array(elements) =>
+          elements.map {
+            case s @ RespValue.BulkString(_)                                       =>
+              GeoView(s.asString, None, None, None)
+            case RespValue.ArrayValues(name @ RespValue.BulkString(_), infos @ _*) =>
+              val distance = infos.collectFirst {
+                case RespValue.BulkString(bytes) => decodeDouble(bytes)
+              }
+              val hash     = infos.collectFirst {
+                case RespValue.Integer(i) => i
+              }
+              val position = infos.collectFirst {
+                case RespValue.ArrayValues(RespValue.BulkString(long), RespValue.BulkString(lat)) =>
+                  LongLat(decodeDouble(long), decodeDouble(lat))
+              }
+              GeoView(name.asString, distance, hash, position)
+            case other                                                             =>
+              throw ProtocolError(s"$other is not a geo radious output")
           }
-
-        idx += 1
-        if (idx < len)
-          while (!text.charAt(pos).isLetter) pos += 1
+        case other                     => throw ProtocolError(s"$other is not an array")
       }
-
-      output
-    }
-
-    private[this] def unsafeReadMembers(text: String, len: Int): Chunk[GeoView] = {
-      var idx    = 0
-      var pos    = 0
-      val output = Array.ofDim[GeoView](len)
-
-      while (idx < len) {
-        if (text.charAt(pos) == '$') {
-          while (text.charAt(pos) != '\n') pos += 1
-          pos += 1
-
-          output(idx) = GeoView(unsafeReadString(text, pos), None, None, None)
-          idx += 1
-        }
-        pos += 1
-      }
-
-      Chunk.fromArray(output)
-    }
-
-    private[this] def unsafeReadString(text: String, start: Int): String = {
-      var pos = start + 1
-
-      while (text.charAt(pos) != '\r') pos += 1
-
-      text.substring(start, pos)
-    }
-
-    private[this] def skipToNext(text: String, start: Int): Int = {
-      var pos = start
-
-      while (text.charAt(pos) != '$') pos += 1
-      while (text.charAt(pos) != '\n') pos += 1
-      pos += 1
-
-      pos
-    }
   }
 
   case object KeyValueOutput extends Output[Map[String, String]] {
-    protected def tryDecode(text: String) =
-      if (text.startsWith("*"))
-        parse(text)
-      else
-        throw ProtocolError(s"$text isn't a string.")
-
-    private[this] def parse(text: String): Map[String, String] = {
-      val data   = unsafeReadChunk(text, 0)
-      val output = collection.mutable.Map.empty[String, String]
-      val len    = data.length
-      var pos    = 0
-
-      while (pos < len) {
-        output += data(pos) -> data(pos + 1)
-        pos += 2
-      }
-
-      output.toMap
-    }
-  }
-
-  case object IncrementOutput extends Output[Double] {
-    protected def tryDecode(text: String) =
-      if (text.startsWith("$"))
-        parse(text)
-      else
-        throw ProtocolError(s"$text isn't a string.")
-
-    private[this] def parse(text: String): Double = {
-      var pos = 1
-
-      while (text.charAt(pos) != '\n') pos += 1
-      pos += 1
-
-      var end = pos + 1
-      while (text.charAt(end) != '\r') end += 1
-
-      text.substring(pos, end).toDouble
-    }
-  }
-
-  private[this] def unsafeReadCoordinates(text: String): Chunk[LongLat] = {
-    var pos       = 1
-    var idx       = 0
-    val len       = text.length
-    val outputLen = countCoordinates(text, len)
-
-    if (outputLen == 0) Chunk.empty
-    else {
-      val output = Array.ofDim[LongLat](outputLen)
-      while (pos < len) {
-        if (coordinatesArrayStarts(text, pos)) {
-          // skip to payload
-          pos += 9
-
-          output(idx) = unsafeReadLongLat(text, pos)
-          idx += 1
-        }
-        pos += 1
-      }
-
-      Chunk.fromArray(output)
-    }
-  }
-
-  private[this] def countCoordinates(text: String, len: Int): Int = {
-    var cnt = 0
-    var pos = 1
-
-    while (pos < len)
-      if (!coordinatesArrayStarts(text, pos))
-        pos += 1
-      else {
-        cnt += 1
-        pos += 9
-      }
-
-    cnt
-  }
-
-  private[this] def unsafeReadLongLat(text: String, start: Int): LongLat = {
-    // longitude start
-    var pos = start
-
-    while (text.charAt(pos) != '\r') pos += 1
-    val long = text.substring(start, pos).toDouble
-
-    // skip to latitude
-    pos += 7
-    val latStart = pos
-
-    while (text.charAt(pos) != '\r') pos += 1
-
-    val lat = text.substring(latStart, pos).toDouble
-
-    LongLat(long, lat)
-  }
-
-  private[this] def coordinatesArrayStarts(text: String, pos: Int): Boolean =
-    text.startsWith("*2\r\n$", pos) && text.charAt(pos + 5).isDigit &&
-      text.charAt(pos + 6).isDigit && text.charAt(pos + 7) == '\r'
-
-  private[this] def containsGeoHash(text: String): Boolean = {
-    var pos    = 1
-    var isHash = false
-    val len    = text.length
-
-    while (pos < len && !isHash) {
-      isHash = text.charAt(pos) == ':'
-      pos += 1
-    }
-
-    isHash
-  }
-
-  private[this] def containsInnerArray(text: String): Boolean = {
-    // skip outer array length
-    var pos      = 1
-    var innerLen = 0
-
-    while (text.charAt(pos) != '$') {
-      if (text.charAt(pos) == '*') innerLen += 1
-      pos += 1
-    }
-
-    innerLen == 1
-  }
-
-  private[this] def unsafeReadChunk(text: String, start: Int): Chunk[String] = {
-    var pos = start + 1
-    var len = 0
-    while (text.charAt(pos) != '\r') {
-      len = len * 10 + text.charAt(pos) - '0'
-      pos += 1
-    }
-
-    if (len == 0) Chunk.empty
-    else {
-      val data = Array.ofDim[String](len)
-      var idx  = 0
-
-      while (idx < len) {
-        // skip to the first size character
-        pos += 3
-
-        var itemLen = 0
-
-        while (text.charAt(pos) != '\r') {
-          itemLen = itemLen * 10 + text.charAt(pos) - '0'
-          pos += 1
-        }
-
-        // skip to the first payload char
-        pos += 2
-
-        data(idx) = text.substring(pos, pos + itemLen)
-        idx += 1
-        pos += itemLen
-      }
-
-      Chunk.fromArray(data)
-    }
-  }
-
-  private[this] def unsafeReadChunkOptionalString(text: String, start: Int): Chunk[Option[String]] = {
-    var pos = start + 1
-    var len = 0
-
-    while (text.charAt(pos) != '\r') {
-      len = len * 10 + text.charAt(pos) - '0'
-      pos += 1
-    }
-
-    pos += 3
-
-    if (len == 0) Chunk.empty
-    else {
-      val data = Array.ofDim[Option[String]](len)
-      var idx  = 0
-
-      while (idx < len) {
-        var itemLen = 0
-
-        // if first char is '-', then it's NULL value
-        if (text.charAt(pos) == '-') {
-          data(idx) = None
-          itemLen = 2
-        } else {
-          while (text.charAt(pos) != '\r') {
-            itemLen = itemLen * 10 + text.charAt(pos) - '0'
-            pos += 1
+    protected def tryDecode(respValue: RespValue): Map[String, String] =
+      respValue match {
+        case RespValue.Array(elements) if elements.length % 2 == 0 =>
+          val output = collection.mutable.Map.empty[String, String]
+          val len    = elements.length
+          var pos    = 0
+          while (pos < len) {
+            (elements(pos), elements(pos + 1)) match {
+              case (key @ RespValue.BulkString(_), value @ RespValue.BulkString(_)) =>
+                output += key.asString -> value.asString
+              case _                                                                =>
+            }
+            pos += 2
           }
-
-          // skip to the first payload char
-          pos += 2
-
-          data(idx) = Some(text.substring(pos, pos + itemLen))
-        }
-
-        pos += itemLen + 3
-        idx += 1
+          output.toMap
+        case array @ RespValue.Array(_) =>
+          throw ProtocolError(s"$array doesn't have an even number of elements")
+        case other =>
+          throw ProtocolError(s"$other isn't an array")
       }
-
-      Chunk.fromArray(data)
-    }
   }
 
-  private[this] def unsafeReadChunkOptionalLong(text: String, start: Int): Chunk[Option[Long]] = {
-    var pos = start + 1
-    var len = 0
-
-    while (text.charAt(pos) != '\r') {
-      len = len * 10 + text.charAt(pos) - '0'
-      pos += 1
-    }
-
-    pos += 2
-
-    if (len == 0) Chunk.empty
-    else {
-      val data = Array.ofDim[Option[Long]](len)
-      var idx  = 0
-
-      while (idx < len) {
-        var itemLen = 0
-
-        // if element is multistring, it is null value
-        if (text.charAt(pos) == '$') {
-          data(idx) = None
-          itemLen = 3
-        } else {
-          // skip ':' char
-          pos += 1
-
-          var value = 0L
-          while (text.charAt(pos) != '\r') {
-            value = value * 10 + text.charAt(pos) - '0'
-            pos += 1
-          }
-
-          data(idx) = Some(value)
-        }
-
-        pos += itemLen + 2
-        idx += 1
-      }
-
-      Chunk.fromArray(data)
-    }
-  }
-
-  private[this] def unsafeReadNumber(text: String): Long = {
-    var pos  = 1
-    var res  = 0L
-    var sign = 1
-
-    if (text.charAt(pos) == '-') {
-      sign = -1
-      pos += 1
-    }
-
-    while (text.charAt(pos) != '\r') {
-      res = res * 10 + text.charAt(pos) - '0'
-      pos += 1
-    }
-
-    sign * res
-  }
-
-  private[this] def unsafeReadMultiString(text: String): String = {
-    var pos = 1
-    var len = 0
-
-    while (text.charAt(pos) != '\r') {
-      len = len * 10 + text.charAt(pos) - '0'
-      pos += 1
-    }
-
-    // skip to the first payload char
-    pos += 2
-
-    text.substring(pos, pos + len)
-  }
 }

--- a/redis/src/main/scala/zio/redis/RedisError.scala
+++ b/redis/src/main/scala/zio/redis/RedisError.scala
@@ -1,14 +1,14 @@
 package zio.redis
 
-import scala.util.control.NoStackTrace
+import java.io.IOException
 
-import zio.IO
+import scala.util.control.NoStackTrace
 
 sealed trait RedisError extends NoStackTrace
 
 object RedisError {
-  final case class ProtocolError(message: String) extends RedisError
-  final case class WrongType(message: String)     extends RedisError
+  final case class ProtocolError(message: String)  extends RedisError
+  final case class WrongType(message: String)      extends RedisError
+  final case class IOError(exception: IOException) extends RedisError
 
-  private[redis] def make(t: Throwable): IO[RedisError, Nothing] = IO.fail(ProtocolError(t.getMessage))
 }

--- a/redis/src/main/scala/zio/redis/RespValue.scala
+++ b/redis/src/main/scala/zio/redis/RespValue.scala
@@ -2,8 +2,8 @@ package zio.redis
 
 import java.nio.charset.StandardCharsets
 
-import zio.{ Chunk, IO, Ref }
 import zio.stream.{ Sink, ZSink }
+import zio.{ Chunk, IO, Ref }
 
 sealed trait RespValue extends Any {
 

--- a/redis/src/main/scala/zio/redis/RespValue.scala
+++ b/redis/src/main/scala/zio/redis/RespValue.scala
@@ -1,0 +1,197 @@
+package zio.redis
+
+import java.nio.charset.StandardCharsets
+
+import zio.{ Chunk, IO, Ref }
+import zio.stream.{ Sink, ZSink }
+
+sealed trait RespValue extends Any {
+
+  import RespValue._
+
+  final def serialize: Chunk[Byte] = {
+    def simpleString(s: String) = Chunk.fromArray(s.getBytes(StandardCharsets.US_ASCII)) ++ crLf
+
+    this match {
+      case SimpleString(s)   =>
+        Header.simpleString +: simpleString(s)
+      case Error(s)          =>
+        Header.error +: simpleString(s)
+      case Integer(i)        =>
+        Header.integer +: simpleString(i.toString)
+      case BulkString(bytes) =>
+        Header.bulkString +: (simpleString(bytes.length.toString) ++ bytes ++ crLf)
+      case Array(elements)   =>
+        Header.array +: (simpleString(elements.size.toString) ++ elements.foldLeft[Chunk[Byte]](Chunk.empty)(
+          (acc, elem) => acc ++ elem.serialize
+        ))
+      case NullValue         =>
+        nullString
+    }
+  }
+
+}
+
+object RespValue {
+
+  private object Header {
+    val simpleString = '+'.toByte
+    val error        = '-'.toByte
+    val integer      = ':'.toByte
+    val bulkString   = '$'.toByte
+    val array        = '*'.toByte
+  }
+
+  private[redis] val cr = '\r'.toByte
+
+  private[redis] val lf = '\n'.toByte
+
+  private val crLf = Chunk(cr, lf)
+
+  private val nullString = Chunk.fromArray("$-1\r\n".getBytes(StandardCharsets.US_ASCII))
+
+  final case class SimpleString(value: String) extends AnyVal with RespValue
+
+  final case class Error(value: String) extends AnyVal with RespValue
+
+  final case class Integer(value: Long) extends AnyVal with RespValue
+
+  final case class BulkString(value: Chunk[Byte]) extends AnyVal with RespValue {
+
+    def asString: String = decodeString(value)
+
+  }
+
+  final case class Array(values: Chunk[RespValue]) extends AnyVal with RespValue
+
+  case object NullValue extends RespValue
+
+  def array(values: RespValue*): Array = Array(Chunk.fromIterable(values))
+
+  def bulkString(s: String): BulkString = BulkString(Chunk.fromArray(s.getBytes(StandardCharsets.UTF_8)))
+
+  def decodeString(bytes: Chunk[Byte]): String = new String(bytes.toArray, StandardCharsets.UTF_8)
+
+  sealed trait State {
+    import State._
+    final def continue: Boolean =
+      this match {
+        case InProgress(_) | CrSeen(_) => true
+        case Complete(_) | Failed      => false
+      }
+  }
+
+  object State {
+
+    final case class InProgress(chunk: Chunk[Char]) extends State
+
+    final case class CrSeen(chunk: Chunk[Char]) extends State
+
+    final case class Complete(chunk: Chunk[Char]) extends State
+
+    case object Failed extends State
+
+  }
+
+  def simpleStringDeserialize: Sink[RedisError.ProtocolError, Byte, Byte, String] = {
+    import State._
+    Sink
+      .fold[Byte, State](InProgress(Chunk.empty))(_.continue) { (acc, b) =>
+        acc match {
+          case InProgress(chunk) if b == cr => CrSeen(chunk)
+          case InProgress(_) if b == lf     => Failed
+          case InProgress(chunk)            => InProgress(chunk :+ b.toChar)
+          case CrSeen(chunk) if b == lf     => Complete(chunk)
+          case _                            => Failed
+        }
+      }
+      .mapM {
+        case Complete(chunk)                    => IO.succeed(chunk.mkString)
+        case Failed                             => IO.fail(RedisError.ProtocolError("Invalid data string"))
+        case InProgress(chunk) if chunk.isEmpty => IO.fail(RedisError.ProtocolError("Expected data missing"))
+        case other                              => IO.dieMessage(s"Bug in deserialization, should not get: $other")
+      }
+  }
+
+  def intDeserialize: Sink[RedisError.ProtocolError, Byte, Byte, Long] =
+    simpleStringDeserialize.mapM { s =>
+      IO.effect(s.toLong).refineOrDie {
+        case _: NumberFormatException => RedisError.ProtocolError(s"'$s' is not a valid integer")
+      }
+    }
+
+  def bulkStringDeserialize: Sink[RedisError.ProtocolError, Byte, Byte, RespValue] =
+    intDeserialize.flatMap {
+      case size if size >= 0 =>
+        for {
+          bytes <- sinkTake[Byte](size.toInt)
+          _     <- sinkTake[Byte](2) // crlf terminator
+        } yield BulkString(bytes)
+      case -1                =>
+        Sink.succeed(NullValue)
+      case other             =>
+        Sink.fail(RedisError.ProtocolError(s"Invalid bulk string length: $other"))
+    }
+
+  def arrayDeserialize: Sink[RedisError.ProtocolError, Byte, Byte, RespValue] = {
+    def help(
+      count: Int,
+      elements: Chunk[RespValue]
+    ): Sink[RedisError.ProtocolError, Byte, Byte, Chunk[RespValue]] =
+      if (count > 0) deserialize.flatMap(element => help(count - 1, elements :+ element)) else Sink.succeed(elements)
+
+    intDeserialize.flatMap {
+      case -1   => Sink.succeed(NullValue)
+      case size => help(size.toInt, Chunk.empty).map(Array)
+    }
+  }
+
+  def deserialize: Sink[RedisError.ProtocolError, Byte, Byte, RespValue] =
+    sinkTake[Byte](1).flatMap { header =>
+      header.head match {
+        case Header.simpleString => simpleStringDeserialize.map(SimpleString)
+        case Header.error        => simpleStringDeserialize.map(Error)
+        case Header.integer      => intDeserialize.map(Integer)
+        case Header.bulkString   => bulkStringDeserialize
+        case Header.array        => arrayDeserialize
+        case other               =>
+          Sink.fail[RedisError.ProtocolError, Byte](RedisError.ProtocolError(s"Invalid initial byte: $other"))
+      }
+    }
+
+  object ArrayValues {
+    def unapplySeq(v: RespValue): Option[Seq[RespValue]] =
+      v match {
+        case Array(values) => Some(values)
+        case _             => None
+      }
+  }
+
+  /**
+   * Fixed version of `ZSink.take`.
+   *
+   * This will be removed once https://github.com/zio/zio/pull/4342 is available.
+   */
+  private def sinkTake[I](n: Int): ZSink[Any, Nothing, I, I, Chunk[I]] =
+    ZSink {
+      for {
+        state <- Ref.make[Chunk[I]](Chunk.empty).toManaged_
+        push   = (is: Option[Chunk[I]]) =>
+                 state.get.flatMap { take =>
+                   is match {
+                     case Some(ch) =>
+                       val idx = n - take.length
+                       if (idx <= ch.length) {
+                         val (chunk, leftover) = ch.splitAt(idx)
+                         state.set(Chunk.empty) *> ZSink.Push.emit(take ++ chunk, leftover)
+                       } else
+                         state.set(take ++ ch) *> ZSink.Push.more
+                     case None     =>
+                       if (n >= 0) ZSink.Push.emit(take, Chunk.empty)
+                       else ZSink.Push.emit(Chunk.empty, take)
+                   }
+                 }
+      } yield push
+    }
+
+}

--- a/redis/src/main/scala/zio/redis/api/Hashes.scala
+++ b/redis/src/main/scala/zio/redis/api/Hashes.scala
@@ -57,7 +57,7 @@ private object Hashes {
   final val HIncrBy = RedisCommand("HINCRBY", Tuple3(StringInput, StringInput, LongInput), LongOutput)
 
   final val HIncrByFloat =
-    RedisCommand("HINCRBYFLOAT", Tuple3(StringInput, StringInput, DoubleInput), IncrementOutput)
+    RedisCommand("HINCRBYFLOAT", Tuple3(StringInput, StringInput, DoubleInput), DoubleOutput)
 
   final val HKeys = RedisCommand("HKEYS", StringInput, ChunkOutput)
   final val HLen  = RedisCommand("HLEN", StringInput, LongOutput)

--- a/redis/src/test/scala/zio/redis/ApiSpec.scala
+++ b/redis/src/test/scala/zio/redis/ApiSpec.scala
@@ -25,5 +25,5 @@ object ApiSpec
       hashSuite
     ).provideCustomLayerShared(Executor ++ Clock.live)
 
-  private val Executor = RedisExecutor.liveLoopback().orDie
+  private val Executor = RedisExecutor.loopback().orDie
 }

--- a/redis/src/test/scala/zio/redis/ApiSpec.scala
+++ b/redis/src/test/scala/zio/redis/ApiSpec.scala
@@ -25,5 +25,5 @@ object ApiSpec
       hashSuite
     ).provideCustomLayerShared(Executor ++ Clock.live)
 
-  private val Executor = RedisExecutor.live("127.0.0.1", 6379).orDie
+  private val Executor = RedisExecutor.liveLoopback().orDie
 }

--- a/redis/src/test/scala/zio/redis/ByteStreamSpec.scala
+++ b/redis/src/test/scala/zio/redis/ByteStreamSpec.scala
@@ -2,8 +2,8 @@ package zio.redis
 import java.nio.charset.StandardCharsets
 
 import zio.Chunk
-import zio.test._
 import zio.test.Assertion._
+import zio.test._
 
 object ByteStreamSpec extends BaseSpec {
   override def spec: ZSpec[Environment, Failure] =

--- a/redis/src/test/scala/zio/redis/ByteStreamSpec.scala
+++ b/redis/src/test/scala/zio/redis/ByteStreamSpec.scala
@@ -1,0 +1,22 @@
+package zio.redis
+import java.nio.charset.StandardCharsets
+
+import zio.Chunk
+import zio.test._
+import zio.test.Assertion._
+
+object ByteStreamSpec extends BaseSpec {
+  override def spec: ZSpec[Environment, Failure] =
+    suite("Byte stream")(
+      testM("can write and read") {
+        ByteStream.connect.use { rw =>
+          rw.write(
+            Chunk.fromArray("*2\r\n$7\r\nCOMMAND\r\n$4\r\nINFO\r\n$3\r\nGET\r\n".getBytes(StandardCharsets.UTF_8))
+          ) *>
+            rw.read.runHead
+              .map(result => assert(result)(isSome(equalTo('*'.toByte))))
+
+        }
+      }
+    ).provideCustomLayerShared(ByteStream.socketLoopback(RedisExecutor.defaultPort).orDie)
+}

--- a/redis/src/test/scala/zio/redis/ByteStreamSpec.scala
+++ b/redis/src/test/scala/zio/redis/ByteStreamSpec.scala
@@ -18,5 +18,5 @@ object ByteStreamSpec extends BaseSpec {
 
         }
       }
-    ).provideCustomLayerShared(ByteStream.socketLoopback(RedisExecutor.defaultPort).orDie)
+    ).provideCustomLayerShared(ByteStream.socketLoopback(RedisExecutor.DefaultPort).orDie)
 }

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -7,6 +7,7 @@ import BitFieldType._
 import BitOperation._
 import Order._
 import RadiusUnit._
+
 import zio.duration._
 import zio.redis.Input._
 import zio.test.Assertion._

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -7,7 +7,6 @@ import BitFieldType._
 import BitOperation._
 import Order._
 import RadiusUnit._
-
 import zio.duration._
 import zio.redis.Input._
 import zio.test.Assertion._
@@ -15,419 +14,423 @@ import zio.test._
 import zio.{ Chunk, Task }
 
 object InputSpec extends BaseSpec {
+
+  private def respArgs(xs: String*) =
+    Chunk.fromIterable(xs.map(RespValue.bulkString))
+
   def spec: ZSpec[environment.TestEnvironment, Any] =
     suite("Input encoders")(
       suite("AbsTtl")(
         testM("valid value") {
           for {
             result <- Task(AbsTtlInput.encode(AbsTtl))
-          } yield assert(result)(equalTo(Chunk.single("$6\r\nABSTTL\r\n")))
+          } yield assert(result)(equalTo(respArgs("ABSTTL")))
         }
       ),
       suite("Aggregate")(
         testM("max") {
           for {
             result <- Task(AggregateInput.encode(Aggregate.Max))
-          } yield assert(result)(equalTo(Chunk("$9\r\nAGGREGATE\r\n", "$3\r\nMAX\r\n")))
+          } yield assert(result)(equalTo(respArgs("AGGREGATE", "MAX")))
         },
         testM("min") {
           for {
             result <- Task(AggregateInput.encode(Aggregate.Min))
-          } yield assert(result)(equalTo(Chunk("$9\r\nAGGREGATE\r\n", "$3\r\nMIN\r\n")))
+          } yield assert(result)(equalTo(respArgs("AGGREGATE", "MIN")))
         },
         testM("sum") {
           for {
             result <- Task(AggregateInput.encode(Aggregate.Sum))
-          } yield assert(result)(equalTo(Chunk("$9\r\nAGGREGATE\r\n", "$3\r\nSUM\r\n")))
+          } yield assert(result)(equalTo(respArgs("AGGREGATE", "SUM")))
         }
       ),
       suite("Auth")(
         testM("with empty password") {
           for {
             result <- Task(AuthInput.encode(Auth("")))
-          } yield assert(result)(equalTo(Chunk("$4\r\nAUTH\r\n", "$0\r\n\r\n")))
+          } yield assert(result)(equalTo(respArgs("AUTH", "")))
         },
         testM("with non-empty password") {
           for {
             result <- Task(AuthInput.encode(Auth("pass")))
-          } yield assert(result)(equalTo(Chunk("$4\r\nAUTH\r\n", "$4\r\npass\r\n")))
+          } yield assert(result)(equalTo(respArgs("AUTH", "pass")))
         }
       ),
       suite("Bool")(
         testM("true") {
           for {
             result <- Task(BoolInput.encode(true))
-          } yield assert(result)(equalTo(Chunk.single("$1\r\n1\r\n")))
+          } yield assert(result)(equalTo(respArgs("1")))
         },
         testM("false") {
           for {
             result <- Task(BoolInput.encode(false))
-          } yield assert(result)(equalTo(Chunk.single("$1\r\n0\r\n")))
+          } yield assert(result)(equalTo(respArgs("0")))
         }
       ),
       suite("BitFieldCommand")(
         testM("get with unsigned type and positive offset") {
           for {
             result <- Task(BitFieldCommandInput.encode(BitFieldGet(UnsignedInt(3), 2)))
-          } yield assert(result)(equalTo(Chunk("$3\r\nGET\r\n", "$2\r\nu3\r\n", "$1\r\n2\r\n")))
+          } yield assert(result)(equalTo(respArgs("GET", "u3", "2")))
         },
         testM("get with signed type and negative offset") {
           for {
             result <- Task(BitFieldCommandInput.encode(BitFieldGet(SignedInt(3), -2)))
-          } yield assert(result)(equalTo(Chunk("$3\r\nGET\r\n", "$2\r\ni3\r\n", "$2\r\n-2\r\n")))
+          } yield assert(result)(equalTo(respArgs("GET", "i3", "-2")))
         },
         testM("get with unsigned type and zero offset") {
           for {
             result <- Task(BitFieldCommandInput.encode(BitFieldGet(UnsignedInt(3), 0)))
-          } yield assert(result)(equalTo(Chunk("$3\r\nGET\r\n", "$2\r\nu3\r\n", "$1\r\n0\r\n")))
+          } yield assert(result)(equalTo(respArgs("GET", "u3", "0")))
         },
         testM("set with unsigned type, positive offset and positive value") {
           for {
             result <- Task(BitFieldCommandInput.encode(BitFieldSet(UnsignedInt(3), 2, 100L)))
-          } yield assert(result)(equalTo(Chunk("$3\r\nSET\r\n", "$2\r\nu3\r\n", "$1\r\n2\r\n", "$3\r\n100\r\n")))
+          } yield assert(result)(equalTo(respArgs("SET", "u3", "2", "100")))
         },
         testM("set with signed type, negative offset and negative value") {
           for {
             result <- Task(BitFieldCommandInput.encode(BitFieldSet(SignedInt(3), -2, -100L)))
-          } yield assert(result)(equalTo(Chunk("$3\r\nSET\r\n", "$2\r\ni3\r\n", "$2\r\n-2\r\n", "$4\r\n-100\r\n")))
+          } yield assert(result)(equalTo(respArgs("SET", "i3", "-2", "-100")))
         },
         testM("set with unsigned type, zero offset and zero value") {
           for {
             result <- Task(BitFieldCommandInput.encode(BitFieldSet(UnsignedInt(3), 0, 0L)))
-          } yield assert(result)(equalTo(Chunk("$3\r\nSET\r\n", "$2\r\nu3\r\n", "$1\r\n0\r\n", "$1\r\n0\r\n")))
+          } yield assert(result)(equalTo(respArgs("SET", "u3", "0", "0")))
         },
         testM("incr with unsigned type, positive offset and positive value") {
           for {
             result <- Task(BitFieldCommandInput.encode(BitFieldIncr(UnsignedInt(3), 2, 100L)))
-          } yield assert(result)(equalTo(Chunk("$6\r\nINCRBY\r\n", "$2\r\nu3\r\n", "$1\r\n2\r\n", "$3\r\n100\r\n")))
+          } yield assert(result)(equalTo(respArgs("INCRBY", "u3", "2", "100")))
         },
         testM("incr with signed type, negative offset and negative value") {
           for {
             result <- Task(BitFieldCommandInput.encode(BitFieldIncr(SignedInt(3), -2, -100L)))
-          } yield assert(result)(equalTo(Chunk("$6\r\nINCRBY\r\n", "$2\r\ni3\r\n", "$2\r\n-2\r\n", "$4\r\n-100\r\n")))
+          } yield assert(result)(equalTo(respArgs("INCRBY", "i3", "-2", "-100")))
         },
         testM("incr with unsigned type, zero offset and zero value") {
           for {
             result <- Task(BitFieldCommandInput.encode(BitFieldIncr(UnsignedInt(3), 0, 0L)))
-          } yield assert(result)(equalTo(Chunk("$6\r\nINCRBY\r\n", "$2\r\nu3\r\n", "$1\r\n0\r\n", "$1\r\n0\r\n")))
+          } yield assert(result)(equalTo(respArgs("INCRBY", "u3", "0", "0")))
         },
         testM("overflow sat") {
           for {
             result <- Task(BitFieldCommandInput.encode(BitFieldOverflow.Sat))
-          } yield assert(result)(equalTo(Chunk("$8\r\nOVERFLOW\r\n", "$3\r\nSAT\r\n")))
+          } yield assert(result)(equalTo(respArgs("OVERFLOW", "SAT")))
         },
         testM("overflow fail") {
           for {
             result <- Task(BitFieldCommandInput.encode(BitFieldOverflow.Fail))
-          } yield assert(result)(equalTo(Chunk("$8\r\nOVERFLOW\r\n", "$4\r\nFAIL\r\n")))
+          } yield assert(result)(equalTo(respArgs("OVERFLOW", "FAIL")))
         },
         testM("overflow warp") {
           for {
             result <- Task(BitFieldCommandInput.encode(BitFieldOverflow.Wrap))
-          } yield assert(result)(equalTo(Chunk("$8\r\nOVERFLOW\r\n", "$4\r\nWRAP\r\n")))
+          } yield assert(result)(equalTo(respArgs("OVERFLOW", "WRAP")))
         }
       ),
       suite("BitOperation")(
         testM("and") {
           for {
             result <- Task(BitOperationInput.encode(AND))
-          } yield assert(result)(equalTo(Chunk.single("$3\r\nAND\r\n")))
+          } yield assert(result)(equalTo(respArgs("AND")))
         },
         testM("or") {
           for {
             result <- Task(BitOperationInput.encode(OR))
-          } yield assert(result)(equalTo(Chunk.single("$2\r\nOR\r\n")))
+          } yield assert(result)(equalTo(respArgs("OR")))
         },
         testM("xor") {
           for {
             result <- Task(BitOperationInput.encode(XOR))
-          } yield assert(result)(equalTo(Chunk.single("$3\r\nXOR\r\n")))
+          } yield assert(result)(equalTo(respArgs("XOR")))
         },
         testM("not") {
           for {
             result <- Task(BitOperationInput.encode(NOT))
-          } yield assert(result)(equalTo(Chunk.single("$3\r\nNOT\r\n")))
+          } yield assert(result)(equalTo(respArgs("NOT")))
         }
       ),
       suite("BitPosRange")(
         testM("with only start") {
           for {
             result <- Task(BitPosRangeInput.encode(BitPosRange(1.second.toMillis, None)))
-          } yield assert(result)(equalTo(Chunk.single("$4\r\n1000\r\n")))
+          } yield assert(result)(equalTo(respArgs("1000")))
         },
         testM("with start and the end") {
           for {
             result <- Task(BitPosRangeInput.encode(BitPosRange(0.second.toMillis, Some(1.second.toMillis))))
-          } yield assert(result)(equalTo(Chunk("$1\r\n0\r\n", "$4\r\n1000\r\n")))
+          } yield assert(result)(equalTo(respArgs("0", "1000")))
         }
       ),
       suite("Changed")(
         testM("valid value") {
           for {
             result <- Task(ChangedInput.encode(Changed))
-          } yield assert(result)(equalTo(Chunk("$2\r\nCH\r\n")))
+          } yield assert(result)(equalTo(respArgs("CH")))
         }
       ),
       suite("Copy")(
         testM("valid value") {
           for {
             result <- Task(CopyInput.encode(Copy))
-          } yield assert(result)(equalTo(Chunk("$4\r\nCOPY\r\n")))
+          } yield assert(result)(equalTo(respArgs("COPY")))
         }
       ),
       suite("Count")(
         testM("positive value") {
           for {
             result <- Task(CountInput.encode(Count(3L)))
-          } yield assert(result)(equalTo(Chunk("$5\r\nCOUNT\r\n", "$1\r\n3\r\n")))
+          } yield assert(result)(equalTo(respArgs("COUNT", "3")))
         },
         testM("negative value") {
           for {
             result <- Task(CountInput.encode(Count(-3L)))
-          } yield assert(result)(equalTo(Chunk("$5\r\nCOUNT\r\n", "$2\r\n-3\r\n")))
+          } yield assert(result)(equalTo(respArgs("COUNT", "-3")))
         },
         testM("zero value") {
           for {
             result <- Task(CountInput.encode(Count(0L)))
-          } yield assert(result)(equalTo(Chunk("$5\r\nCOUNT\r\n", "$1\r\n0\r\n")))
+          } yield assert(result)(equalTo(respArgs("COUNT", "0")))
         }
       ),
       suite("Position")(
         testM("before") {
           for {
             result <- Task(PositionInput.encode(Position.Before))
-          } yield assert(result)(equalTo(Chunk.single("$6\r\nBEFORE\r\n")))
+          } yield assert(result)(equalTo(respArgs("BEFORE")))
         },
         testM("after") {
           for {
             result <- Task(PositionInput.encode(Position.After))
-          } yield assert(result)(equalTo(Chunk.single("$5\r\nAFTER\r\n")))
+          } yield assert(result)(equalTo(respArgs("AFTER")))
         }
       ),
       suite("Double")(
         testM("positive value") {
           for {
             result <- Task(DoubleInput.encode(4.2d))
-          } yield assert(result)(equalTo(Chunk.single("$3\r\n4.2\r\n")))
+          } yield assert(result)(equalTo(respArgs("4.2")))
         },
         testM("negative value") {
           for {
             result <- Task(DoubleInput.encode(-4.2d))
-          } yield assert(result)(equalTo(Chunk.single("$4\r\n-4.2\r\n")))
+          } yield assert(result)(equalTo(respArgs("-4.2")))
         },
         testM("zero value") {
           for {
             result <- Task(DoubleInput.encode(0d))
-          } yield assert(result)(equalTo(Chunk.single("$3\r\n0.0\r\n")))
+          } yield assert(result)(equalTo(respArgs("0.0")))
         }
       ),
       suite("DurationMilliseconds")(
         testM("1 second") {
           for {
             result <- Task(DurationMillisecondsInput.encode(1.second))
-          } yield assert(result)(equalTo(Chunk("$4\r\n1000\r\n")))
+          } yield assert(result)(equalTo(respArgs("1000")))
         },
         testM("100 milliseconds") {
           for {
             result <- Task(DurationMillisecondsInput.encode(100.millis))
-          } yield assert(result)(equalTo(Chunk("$3\r\n100\r\n")))
+          } yield assert(result)(equalTo(respArgs("100")))
         }
       ),
       suite("DurationSeconds")(
         testM("1 minute") {
           for {
             result <- Task(DurationSecondsInput.encode(1.minute))
-          } yield assert(result)(equalTo(Chunk.single("$2\r\n60\r\n")))
+          } yield assert(result)(equalTo(respArgs("60")))
         },
         testM("1 second") {
           for {
             result <- Task(DurationSecondsInput.encode(1.second))
-          } yield assert(result)(equalTo(Chunk.single("$1\r\n1\r\n")))
+          } yield assert(result)(equalTo(respArgs("1")))
         },
         testM("100 milliseconds") {
           for {
             result <- Task(DurationSecondsInput.encode(100.millis))
-          } yield assert(result)(equalTo(Chunk.single("$1\r\n0\r\n")))
+          } yield assert(result)(equalTo(respArgs("0")))
         }
       ),
       suite("DurationTtl")(
         testM("1 second") {
           for {
             result <- Task(DurationTtlInput.encode(1.second))
-          } yield assert(result)(equalTo(Chunk("$2\r\nPX\r\n", "$4\r\n1000\r\n")))
+          } yield assert(result)(equalTo(respArgs("PX", "1000")))
         },
         testM("100 milliseconds") {
           for {
             result <- Task(DurationTtlInput.encode(100.millis))
-          } yield assert(result)(equalTo(Chunk("$2\r\nPX\r\n", "$3\r\n100\r\n")))
+          } yield assert(result)(equalTo(respArgs("PX", "100")))
         }
       ),
       suite("Freq")(
         testM("empty string") {
           for {
             result <- Task(FreqInput.encode(Freq("")))
-          } yield assert(result)(equalTo(Chunk("$4\r\nFREQ\r\n", "$0\r\n\r\n")))
+          } yield assert(result)(equalTo(respArgs("FREQ", "")))
         },
         testM("non-empty string") {
           for {
             result <- Task(FreqInput.encode(Freq("frequency")))
-          } yield assert(result)(equalTo(Chunk("$4\r\nFREQ\r\n", "$9\r\nfrequency\r\n")))
+          } yield assert(result)(equalTo(respArgs("FREQ", "frequency")))
         }
       ),
       suite("IdleTime")(
         testM("0 seconds") {
           for {
             result <- Task(IdleTimeInput.encode(IdleTime(0)))
-          } yield assert(result)(equalTo(Chunk("$8\r\nIDLETIME\r\n", "$1\r\n0\r\n")))
+          } yield assert(result)(equalTo(respArgs("IDLETIME", "0")))
         },
         testM("5 seconds") {
           for {
             result <- Task(IdleTimeInput.encode(IdleTime(5)))
-          } yield assert(result)(equalTo(Chunk("$8\r\nIDLETIME\r\n", "$1\r\n5\r\n")))
+          } yield assert(result)(equalTo(respArgs("IDLETIME", "5")))
         }
       ),
       suite("Increment")(
         testM("valid value") {
           for {
             result <- Task(IncrementInput.encode(Increment))
-          } yield assert(result)(equalTo(Chunk.single("$4\r\nINCR\r\n")))
+          } yield assert(result)(equalTo(respArgs("INCR")))
         }
       ),
       suite("KeepTtl")(
         testM("valid value") {
           for {
             result <- Task(KeepTtlInput.encode(KeepTtl))
-          } yield assert(result)(equalTo(Chunk.single("$7\r\nKEEPTTL\r\n")))
+          } yield assert(result)(equalTo(respArgs("KEEPTTL")))
         }
       ),
       suite("LexRange")(
         testM("with unbound min and unbound max") {
           for {
             result <- Task(LexRangeInput.encode(LexRange(LexMinimum.Unbounded, LexMaximum.Unbounded)))
-          } yield assert(result)(equalTo(Chunk("$1\r\n-\r\n", "$1\r\n+\r\n")))
+          } yield assert(result)(equalTo(respArgs("-", "+")))
         },
         testM("with open min and unbound max") {
           for {
             result <- Task(LexRangeInput.encode(LexRange(LexMinimum.Open("a"), LexMaximum.Unbounded)))
-          } yield assert(result)(equalTo(Chunk("$2\r\n(a\r\n", "$1\r\n+\r\n")))
+          } yield assert(result)(equalTo(respArgs("(a", "+")))
         },
         testM("with closed min and unbound max") {
           for {
             result <- Task(LexRangeInput.encode(LexRange(LexMinimum.Closed("a"), LexMaximum.Unbounded)))
-          } yield assert(result)(equalTo(Chunk("$2\r\n[a\r\n", "$1\r\n+\r\n")))
+          } yield assert(result)(equalTo(respArgs("[a", "+")))
         },
         testM("with unbound min and open max") {
           for {
             result <- Task(LexRangeInput.encode(LexRange(LexMinimum.Unbounded, LexMaximum.Open("z"))))
-          } yield assert(result)(equalTo(Chunk("$1\r\n-\r\n", "$2\r\n(z\r\n")))
+          } yield assert(result)(equalTo(respArgs("-", "(z")))
         },
         testM("with open min and open max") {
           for {
             result <- Task(LexRangeInput.encode(LexRange(LexMinimum.Open("a"), LexMaximum.Open("z"))))
-          } yield assert(result)(equalTo(Chunk("$2\r\n(a\r\n", "$2\r\n(z\r\n")))
+          } yield assert(result)(equalTo(respArgs("(a", "(z")))
         },
         testM("with closed min and open max") {
           for {
             result <- Task(LexRangeInput.encode(LexRange(LexMinimum.Closed("a"), LexMaximum.Open("z"))))
-          } yield assert(result)(equalTo(Chunk("$2\r\n[a\r\n", "$2\r\n(z\r\n")))
+          } yield assert(result)(equalTo(respArgs("[a", "(z")))
         },
         testM("with unbound min and closed max") {
           for {
             result <- Task(LexRangeInput.encode(LexRange(LexMinimum.Unbounded, LexMaximum.Closed("z"))))
-          } yield assert(result)(equalTo(Chunk("$1\r\n-\r\n", "$2\r\n[z\r\n")))
+          } yield assert(result)(equalTo(respArgs("-", "[z")))
         },
         testM("with open min and closed max") {
           for {
             result <- Task(LexRangeInput.encode(LexRange(LexMinimum.Open("a"), LexMaximum.Closed("z"))))
-          } yield assert(result)(equalTo(Chunk("$2\r\n(a\r\n", "$2\r\n[z\r\n")))
+          } yield assert(result)(equalTo(respArgs("(a", "[z")))
         },
         testM("with closed min and closed max") {
           for {
             result <- Task(LexRangeInput.encode(LexRange(LexMinimum.Closed("a"), LexMaximum.Closed("z"))))
-          } yield assert(result)(equalTo(Chunk("$2\r\n[a\r\n", "$2\r\n[z\r\n")))
+          } yield assert(result)(equalTo(respArgs("[a", "[z")))
         }
       ),
       suite("Limit")(
         testM("with positive offset and positive count") {
           for {
             result <- Task(LimitInput.encode(Limit(4L, 5L)))
-          } yield assert(result)(equalTo(Chunk("$5\r\nLIMIT\r\n", "$1\r\n4\r\n", "$1\r\n5\r\n")))
+          } yield assert(result)(equalTo(respArgs("LIMIT", "4", "5")))
         },
         testM("with negative offset and negative count") {
           for {
             result <- Task(LimitInput.encode(Limit(-4L, -5L)))
-          } yield assert(result)(equalTo(Chunk("$5\r\nLIMIT\r\n", "$2\r\n-4\r\n", "$2\r\n-5\r\n")))
+          } yield assert(result)(equalTo(respArgs("LIMIT", "-4", "-5")))
         },
         testM("with zero offset and zero count") {
           for {
             result <- Task(LimitInput.encode(Limit(0L, 0L)))
-          } yield assert(result)(equalTo(Chunk("$5\r\nLIMIT\r\n", "$1\r\n0\r\n", "$1\r\n0\r\n")))
+          } yield assert(result)(equalTo(respArgs("LIMIT", "0", "0")))
         }
       ),
       suite("Long")(
         testM("positive value") {
           for {
             result <- Task(LongInput.encode(4L))
-          } yield assert(result)(equalTo(Chunk.single("$1\r\n4\r\n")))
+          } yield assert(result)(equalTo(respArgs("4")))
         },
         testM("negative value") {
           for {
             result <- Task(LongInput.encode(-4L))
-          } yield assert(result)(equalTo(Chunk.single("$2\r\n-4\r\n")))
+          } yield assert(result)(equalTo(respArgs("-4")))
         },
         testM("zero value") {
           for {
             result <- Task(LongInput.encode(0L))
-          } yield assert(result)(equalTo(Chunk.single("$1\r\n0\r\n")))
+          } yield assert(result)(equalTo(respArgs("0")))
         }
       ),
       suite("LongLat")(
         testM("positive longitude and latitude") {
           for {
             result <- Task(LongLatInput.encode(LongLat(4.2d, 5.2d)))
-          } yield assert(result)(equalTo(Chunk("$3\r\n4.2\r\n", "$3\r\n5.2\r\n")))
+          } yield assert(result)(equalTo(respArgs("4.2", "5.2")))
         },
         testM("negative longitude and latitude") {
           for {
             result <- Task(LongLatInput.encode(LongLat(-4.2d, -5.2d)))
-          } yield assert(result)(equalTo(Chunk("$4\r\n-4.2\r\n", "$4\r\n-5.2\r\n")))
+          } yield assert(result)(equalTo(respArgs("-4.2", "-5.2")))
         },
         testM("zero longitude and latitude") {
           for {
             result <- Task(LongLatInput.encode(LongLat(0d, 0d)))
-          } yield assert(result)(equalTo(Chunk("$3\r\n0.0\r\n", "$3\r\n0.0\r\n")))
+          } yield assert(result)(equalTo(respArgs("0.0", "0.0")))
         }
       ),
       suite("MemberScore")(
         testM("with positive score and empty member") {
           for {
             result <- Task(MemberScoreInput.encode(MemberScore(4.2d, "")))
-          } yield assert(result)(equalTo(Chunk("$3\r\n4.2\r\n", "$0\r\n\r\n")))
+          } yield assert(result)(equalTo(respArgs("4.2", "")))
         },
         testM("with negative score and empty member") {
           for {
             result <- Task(MemberScoreInput.encode(MemberScore(-4.2d, "")))
-          } yield assert(result)(equalTo(Chunk("$4\r\n-4.2\r\n", "$0\r\n\r\n")))
+          } yield assert(result)(equalTo(respArgs("-4.2", "")))
         },
         testM("with zero score and empty member") {
           for {
             result <- Task(MemberScoreInput.encode(MemberScore(0d, "")))
-          } yield assert(result)(equalTo(Chunk("$3\r\n0.0\r\n", "$0\r\n\r\n")))
+          } yield assert(result)(equalTo(respArgs("0.0", "")))
         },
         testM("with positive score and non-empty member") {
           for {
             result <- Task(MemberScoreInput.encode(MemberScore(4.2d, "member")))
-          } yield assert(result)(equalTo(Chunk("$3\r\n4.2\r\n", "$6\r\nmember\r\n")))
+          } yield assert(result)(equalTo(respArgs("4.2", "member")))
         },
         testM("with negative score and non-empty member") {
           for {
             result <- Task(MemberScoreInput.encode(MemberScore(-4.2d, "member")))
-          } yield assert(result)(equalTo(Chunk("$4\r\n-4.2\r\n", "$6\r\nmember\r\n")))
+          } yield assert(result)(equalTo(respArgs("-4.2", "member")))
         },
         testM("with zero score and non-empty member") {
           for {
             result <- Task(MemberScoreInput.encode(MemberScore(0d, "member")))
-          } yield assert(result)(equalTo(Chunk("$3\r\n0.0\r\n", "$6\r\nmember\r\n")))
+          } yield assert(result)(equalTo(respArgs("0.0", "member")))
         }
       ),
       suite("NoInput")(
@@ -441,170 +444,170 @@ object InputSpec extends BaseSpec {
         testM("with multiple elements") {
           for {
             result <- Task(NonEmptyList(StringInput).encode(("a", List("b", "c"))))
-          } yield assert(result)(equalTo(Chunk("$1\r\na\r\n", "$1\r\nb\r\n", "$1\r\nc\r\n")))
+          } yield assert(result)(equalTo(respArgs("a", "b", "c")))
         },
         testM("with one element") {
           for {
             result <- Task(NonEmptyList(StringInput).encode(("a", List.empty)))
-          } yield assert(result)(equalTo(Chunk.single("$1\r\na\r\n")))
+          } yield assert(result)(equalTo(respArgs("a")))
         }
       ),
       suite("Order")(
         testM("ascending") {
           for {
             result <- Task(OrderInput.encode(Ascending))
-          } yield assert(result)(equalTo(Chunk.single("$3\r\nASC\r\n")))
+          } yield assert(result)(equalTo(respArgs("ASC")))
         },
         testM("descending") {
           for {
             result <- Task(OrderInput.encode(Descending))
-          } yield assert(result)(equalTo(Chunk.single("$4\r\nDESC\r\n")))
+          } yield assert(result)(equalTo(respArgs("DESC")))
         }
       ),
       suite("RadiusUnit")(
         testM("meters") {
           for {
             result <- Task(RadiusUnitInput.encode(Meters))
-          } yield assert(result)(equalTo(Chunk.single("$1\r\nm\r\n")))
+          } yield assert(result)(equalTo(respArgs("m")))
         },
         testM("kilometers") {
           for {
             result <- Task(RadiusUnitInput.encode(Kilometers))
-          } yield assert(result)(equalTo(Chunk.single("$2\r\nkm\r\n")))
+          } yield assert(result)(equalTo(respArgs("km")))
         },
         testM("feet") {
           for {
             result <- Task(RadiusUnitInput.encode(Feet))
-          } yield assert(result)(equalTo(Chunk.single("$2\r\nft\r\n")))
+          } yield assert(result)(equalTo(respArgs("ft")))
         },
         testM("miles") {
           for {
             result <- Task(RadiusUnitInput.encode(Miles))
-          } yield assert(result)(equalTo(Chunk.single("$2\r\nmi\r\n")))
+          } yield assert(result)(equalTo(respArgs("mi")))
         }
       ),
       suite("Range")(
         testM("with positive start and positive end") {
           for {
             result <- Task(RangeInput.encode(Range(1, 5)))
-          } yield assert(result)(equalTo(Chunk("$1\r\n1\r\n", "$1\r\n5\r\n")))
+          } yield assert(result)(equalTo(respArgs("1", "5")))
         },
         testM("with negative start and positive end") {
           for {
             result <- Task(RangeInput.encode(Range(-1, 5)))
-          } yield assert(result)(equalTo(Chunk("$2\r\n-1\r\n", "$1\r\n5\r\n")))
+          } yield assert(result)(equalTo(respArgs("-1", "5")))
         },
         testM("with positive start and negative end") {
           for {
             result <- Task(RangeInput.encode(Range(1, -5)))
-          } yield assert(result)(equalTo(Chunk("$1\r\n1\r\n", "$2\r\n-5\r\n")))
+          } yield assert(result)(equalTo(respArgs("1", "-5")))
         },
         testM("with negative start and negative end") {
           for {
             result <- Task(RangeInput.encode(Range(-1, -5)))
-          } yield assert(result)(equalTo(Chunk("$2\r\n-1\r\n", "$2\r\n-5\r\n")))
+          } yield assert(result)(equalTo(respArgs("-1", "-5")))
         }
       ),
       suite("Regex")(
         testM("with valid pattern") {
           for {
             result <- Task(RegexInput.encode("\\d{3}".r))
-          } yield assert(result)(equalTo(Chunk("$5\r\nMATCH\r\n", "$5\r\n\\d{3}\r\n")))
+          } yield assert(result)(equalTo(respArgs("MATCH", "\\d{3}")))
         },
         testM("with empty pattern") {
           for {
             result <- Task(RegexInput.encode("".r))
-          } yield assert(result)(equalTo(Chunk("$5\r\nMATCH\r\n", "$0\r\n\r\n")))
+          } yield assert(result)(equalTo(respArgs("MATCH", "")))
         }
       ),
       suite("Replace")(
         testM("valid value") {
           for {
             result <- Task(ReplaceInput.encode(Replace))
-          } yield assert(result)(equalTo(Chunk.single("$7\r\nREPLACE\r\n")))
+          } yield assert(result)(equalTo(respArgs("REPLACE")))
         }
       ),
       suite("StoreDist")(
         testM("with non-empty string") {
           for {
             result <- Task(StoreDistInput.encode(StoreDist("key")))
-          } yield assert(result)(equalTo(Chunk("$9\r\nSTOREDIST\r\n", "$3\r\nkey\r\n")))
+          } yield assert(result)(equalTo(respArgs("STOREDIST", "key")))
         },
         testM("with empty string") {
           for {
             result <- Task(StoreDistInput.encode(StoreDist("")))
-          } yield assert(result)(equalTo(Chunk("$9\r\nSTOREDIST\r\n", "$0\r\n\r\n")))
+          } yield assert(result)(equalTo(respArgs("STOREDIST", "")))
         }
       ),
       suite("Store")(
         testM("with non-empty string") {
           for {
             result <- Task(StoreInput.encode(Store("key")))
-          } yield assert(result)(equalTo(Chunk("$5\r\nSTORE\r\n", "$3\r\nkey\r\n")))
+          } yield assert(result)(equalTo(respArgs("STORE", "key")))
         },
         testM("with empty string") {
           for {
             result <- Task(StoreInput.encode(Store("")))
-          } yield assert(result)(equalTo(Chunk("$5\r\nSTORE\r\n", "$0\r\n\r\n")))
+          } yield assert(result)(equalTo(respArgs("STORE", "")))
         }
       ),
       suite("ScoreRange")(
         testM("with infinite min and infinite max") {
           for {
             result <- Task(ScoreRangeInput.encode(ScoreRange(ScoreMinimum.Infinity, ScoreMaximum.Infinity)))
-          } yield assert(result)(equalTo(Chunk("$4\r\n-inf\r\n", "$4\r\n+inf\r\n")))
+          } yield assert(result)(equalTo(respArgs("-inf", "+inf")))
         },
         testM("with open min and infinite max") {
           for {
             result <- Task(ScoreRangeInput.encode(ScoreRange(ScoreMinimum.Open(4.2d), ScoreMaximum.Infinity)))
-          } yield assert(result)(equalTo(Chunk("$4\r\n(4.2\r\n", "$4\r\n+inf\r\n")))
+          } yield assert(result)(equalTo(respArgs("(4.2", "+inf")))
         },
         testM("with closed min and infinite max") {
           for {
             result <- Task(ScoreRangeInput.encode(ScoreRange(ScoreMinimum.Closed(4.2d), ScoreMaximum.Infinity)))
-          } yield assert(result)(equalTo(Chunk("$3\r\n4.2\r\n", "$4\r\n+inf\r\n")))
+          } yield assert(result)(equalTo(respArgs("4.2", "+inf")))
         },
         testM("with infinite min and open max") {
           for {
             result <- Task(ScoreRangeInput.encode(ScoreRange(ScoreMinimum.Infinity, ScoreMaximum.Open(5.2d))))
-          } yield assert(result)(equalTo(Chunk("$4\r\n-inf\r\n", "$4\r\n(5.2\r\n")))
+          } yield assert(result)(equalTo(respArgs("-inf", "(5.2")))
         },
         testM("with open min and open max") {
           for {
             result <- Task(ScoreRangeInput.encode(ScoreRange(ScoreMinimum.Open(4.2d), ScoreMaximum.Open(5.2d))))
-          } yield assert(result)(equalTo(Chunk("$4\r\n(4.2\r\n", "$4\r\n(5.2\r\n")))
+          } yield assert(result)(equalTo(respArgs("(4.2", "(5.2")))
         },
         testM("with closed min and open max") {
           for {
             result <- Task(ScoreRangeInput.encode(ScoreRange(ScoreMinimum.Closed(4.2d), ScoreMaximum.Open(5.2d))))
-          } yield assert(result)(equalTo(Chunk("$3\r\n4.2\r\n", "$4\r\n(5.2\r\n")))
+          } yield assert(result)(equalTo(respArgs("4.2", "(5.2")))
         },
         testM("with infinite min and closed max") {
           for {
             result <- Task(ScoreRangeInput.encode(ScoreRange(ScoreMinimum.Infinity, ScoreMaximum.Closed(5.2d))))
-          } yield assert(result)(equalTo(Chunk("$4\r\n-inf\r\n", "$3\r\n5.2\r\n")))
+          } yield assert(result)(equalTo(respArgs("-inf", "5.2")))
         },
         testM("with open min and closed max") {
           for {
             result <- Task(ScoreRangeInput.encode(ScoreRange(ScoreMinimum.Open(4.2d), ScoreMaximum.Closed(5.2d))))
-          } yield assert(result)(equalTo(Chunk("$4\r\n(4.2\r\n", "$3\r\n5.2\r\n")))
+          } yield assert(result)(equalTo(respArgs("(4.2", "5.2")))
         },
         testM("with closed min and closed max") {
           for {
             result <- Task(ScoreRangeInput.encode(ScoreRange(ScoreMinimum.Closed(4.2d), ScoreMaximum.Closed(5.2d))))
-          } yield assert(result)(equalTo(Chunk("$3\r\n4.2\r\n", "$3\r\n5.2\r\n")))
+          } yield assert(result)(equalTo(respArgs("4.2", "5.2")))
         }
       ),
       suite("String")(
         testM("non-empty value") {
           for {
             result <- Task(StringInput.encode("non-empty"))
-          } yield assert(result)(equalTo(Chunk.single("$9\r\nnon-empty\r\n")))
+          } yield assert(result)(equalTo(respArgs("non-empty")))
         },
         testM("empty value") {
           for {
             result <- Task(StringInput.encode(""))
-          } yield assert(result)(equalTo(Chunk.single("$0\r\n\r\n")))
+          } yield assert(result)(equalTo(respArgs("")))
         }
       ),
       suite("Optional")(
@@ -616,62 +619,62 @@ object InputSpec extends BaseSpec {
         testM("some") {
           for {
             result <- Task(OptionalInput(LongInput).encode(Some(2L)))
-          } yield assert(result)(equalTo(Chunk.single("$1\r\n2\r\n")))
+          } yield assert(result)(equalTo(respArgs("2")))
         }
       ),
       suite("TimeSeconds")(
         testM("positiv value") {
           for {
             result <- Task(TimeSecondsInput.encode(Instant.ofEpochSecond(3L)))
-          } yield assert(result)(equalTo(Chunk("$1\r\n3\r\n")))
+          } yield assert(result)(equalTo(respArgs("3")))
         },
         testM("zero value") {
           for {
             result <- Task(TimeSecondsInput.encode(Instant.ofEpochSecond(0L)))
-          } yield assert(result)(equalTo(Chunk("$1\r\n0\r\n")))
+          } yield assert(result)(equalTo(respArgs("0")))
         },
         testM("negative value") {
           for {
             result <- Task(TimeSecondsInput.encode(Instant.ofEpochSecond(-3L)))
-          } yield assert(result)(equalTo(Chunk("$2\r\n-3\r\n")))
+          } yield assert(result)(equalTo(respArgs("-3")))
         }
       ),
       suite("TimeMilliseconds")(
         testM("positiv value") {
           for {
             result <- Task(TimeMillisecondsInput.encode(Instant.ofEpochSecond(3L)))
-          } yield assert(result)(equalTo(Chunk("$4\r\n3000\r\n")))
+          } yield assert(result)(equalTo(respArgs("3000")))
         },
         testM("zero value") {
           for {
             result <- Task(TimeMillisecondsInput.encode(Instant.ofEpochSecond(0L)))
-          } yield assert(result)(equalTo(Chunk("$1\r\n0\r\n")))
+          } yield assert(result)(equalTo(respArgs("0")))
         },
         testM("negative value") {
           for {
             result <- Task(TimeMillisecondsInput.encode(Instant.ofEpochSecond(-3L)))
-          } yield assert(result)(equalTo(Chunk("$5\r\n-3000\r\n")))
+          } yield assert(result)(equalTo(respArgs("-3000")))
         }
       ),
       suite("Tuple2")(
         testM("valid value") {
           for {
             result <- Task(Tuple2(StringInput, LongInput).encode(("one", 2L)))
-          } yield assert(result)(equalTo(Chunk("$3\r\none\r\n", "$1\r\n2\r\n")))
+          } yield assert(result)(equalTo(respArgs("one", "2")))
         }
       ),
       suite("Tuple3")(
         testM("valid value") {
           for {
             result <- Task(Tuple3(StringInput, LongInput, StringInput).encode(("one", 2, "three")))
-          } yield assert(result)(equalTo(Chunk("$3\r\none\r\n", "$1\r\n2\r\n", "$5\r\nthree\r\n")))
+          } yield assert(result)(equalTo(respArgs("one", "2", "three")))
         }
       ),
       suite("Tuple4")(
         testM("valid value") {
           for {
             result <- Task(Tuple4(StringInput, LongInput, StringInput, LongInput).encode(("one", 2, "three", 4)))
-          } yield assert(result)(equalTo(Chunk("$3\r\none\r\n", "$1\r\n2\r\n", "$5\r\nthree\r\n", "$1\r\n4\r\n")))
+          } yield assert(result)(equalTo(respArgs("one", "2", "three", "4")))
         }
       ),
       suite("Tuple5")(
@@ -682,7 +685,7 @@ object InputSpec extends BaseSpec {
                           .encode(("one", 2, "three", 4, "five"))
                       )
           } yield assert(result)(
-            equalTo(Chunk("$3\r\none\r\n", "$1\r\n2\r\n", "$5\r\nthree\r\n", "$1\r\n4\r\n", "$4\r\nfive\r\n"))
+            equalTo(respArgs("one", "2", "three", "4", "five"))
           )
         }
       ),
@@ -695,14 +698,14 @@ object InputSpec extends BaseSpec {
                       )
           } yield assert(result)(
             equalTo(
-              Chunk(
-                "$3\r\none\r\n",
-                "$1\r\n2\r\n",
-                "$5\r\nthree\r\n",
-                "$1\r\n4\r\n",
-                "$4\r\nfive\r\n",
-                "$1\r\n6\r\n",
-                "$5\r\nseven\r\n"
+              respArgs(
+                "one",
+                "2",
+                "three",
+                "4",
+                "five",
+                "6",
+                "seven"
               )
             )
           )
@@ -726,16 +729,16 @@ object InputSpec extends BaseSpec {
                       )
           } yield assert(result)(
             equalTo(
-              Chunk(
-                "$3\r\none\r\n",
-                "$1\r\n2\r\n",
-                "$5\r\nthree\r\n",
-                "$1\r\n4\r\n",
-                "$4\r\nfive\r\n",
-                "$1\r\n6\r\n",
-                "$5\r\nseven\r\n",
-                "$1\r\n8\r\n",
-                "$4\r\nnine\r\n"
+              respArgs(
+                "one",
+                "2",
+                "three",
+                "4",
+                "five",
+                "6",
+                "seven",
+                "8",
+                "nine"
               )
             )
           )
@@ -761,18 +764,18 @@ object InputSpec extends BaseSpec {
                       )
           } yield assert(result)(
             equalTo(
-              Chunk(
-                "$3\r\none\r\n",
-                "$1\r\n2\r\n",
-                "$5\r\nthree\r\n",
-                "$1\r\n4\r\n",
-                "$4\r\nfive\r\n",
-                "$1\r\n6\r\n",
-                "$5\r\nseven\r\n",
-                "$1\r\n8\r\n",
-                "$4\r\nnine\r\n",
-                "$2\r\n10\r\n",
-                "$6\r\neleven\r\n"
+              respArgs(
+                "one",
+                "2",
+                "three",
+                "4",
+                "five",
+                "6",
+                "seven",
+                "8",
+                "nine",
+                "10",
+                "eleven"
               )
             )
           )
@@ -782,19 +785,19 @@ object InputSpec extends BaseSpec {
         testM("set existing") {
           for {
             result <- Task(UpdateInput.encode(Update.SetExisting))
-          } yield assert(result)(equalTo(Chunk.single("$2\r\nXX\r\n")))
+          } yield assert(result)(equalTo(respArgs("XX")))
         },
         testM("set new") {
           for {
             result <- Task(UpdateInput.encode(Update.SetNew))
-          } yield assert(result)(equalTo(Chunk.single("$2\r\nNX\r\n")))
+          } yield assert(result)(equalTo(respArgs("NX")))
         }
       ),
       suite("Varargs")(
         testM("with multiple elements") {
           for {
             result <- Task(Varargs(LongInput).encode(List(1, 2, 3)))
-          } yield assert(result)(equalTo(Chunk("$1\r\n1\r\n", "$1\r\n2\r\n", "$1\r\n3\r\n")))
+          } yield assert(result)(equalTo(respArgs("1", "2", "3")))
         },
         testM("with no elements") {
           for {
@@ -806,28 +809,28 @@ object InputSpec extends BaseSpec {
         testM("valid value") {
           for {
             result <- Task(WithScoresInput.encode(WithScores))
-          } yield assert(result)(equalTo(Chunk.single("$10\r\nWITHSCORES\r\n")))
+          } yield assert(result)(equalTo(respArgs("WITHSCORES")))
         }
       ),
       suite("WithCoord")(
         testM("valid value") {
           for {
             result <- Task(WithCoordInput.encode(WithCoord))
-          } yield assert(result)(equalTo(Chunk.single("$9\r\nWITHCOORD\r\n")))
+          } yield assert(result)(equalTo(respArgs("WITHCOORD")))
         }
       ),
       suite("WithDist")(
         testM("valid value") {
           for {
             result <- Task(WithDistInput.encode(WithDist))
-          } yield assert(result)(equalTo(Chunk.single("$8\r\nWITHDIST\r\n")))
+          } yield assert(result)(equalTo(respArgs("WITHDIST")))
         }
       ),
       suite("WithHash")(
         testM("valid value") {
           for {
             result <- Task(WithHashInput.encode(WithHash))
-          } yield assert(result)(equalTo(Chunk.single("$8\r\nWITHHASH\r\n")))
+          } yield assert(result)(equalTo(respArgs("WITHHASH")))
         }
       )
     )

--- a/redis/src/test/scala/zio/redis/ListSpec.scala
+++ b/redis/src/test/scala/zio/redis/ListSpec.scala
@@ -174,9 +174,9 @@ trait ListSpec extends BaseSpec {
             dest    <- uuid
             _       <- rPush(dest, "four")
             st      <- currentTime(TimeUnit.SECONDS)
-            s       <- brPopLPush(key, dest, 1.seconds).either
+            s       <- brPopLPush(key, dest, 1.seconds)
             endTime <- currentTime(TimeUnit.SECONDS)
-          } yield assert(s)(isLeft) && assert(endTime - st)(isGreaterThanEqualTo(1L))
+          } yield assert(s)(isNone) && assert(endTime - st)(isGreaterThanEqualTo(1L))
         },
         testM("brPopLPush error when not list") {
           for {

--- a/redis/src/test/scala/zio/redis/RespValueSpec.scala
+++ b/redis/src/test/scala/zio/redis/RespValueSpec.scala
@@ -1,0 +1,56 @@
+package zio.redis
+import java.nio.charset.StandardCharsets
+
+import zio.Chunk
+import zio.test._
+import zio.test.Assertion._
+import zio.stream.Stream
+
+object RespValueSpec extends BaseSpec {
+
+  private def encode(s: String) = Chunk.fromArray(s.getBytes(StandardCharsets.UTF_8))
+
+  override def spec =
+    suite("RespValue")(
+      suite("serialization")(
+        test("array") {
+          val expected = encode("*3\r\n$3\r\nabc\r\n:123\r\n$-1\r\n")
+          val v        = RespValue.array(RespValue.bulkString("abc"), RespValue.Integer(123), RespValue.NullValue)
+          assert(v.serialize)(equalTo(expected))
+        }
+      ),
+      suite("deserialization")(
+        testM("simple string") {
+          val s     = "Hello, world."
+          val bytes = Chunk.fromArray((s + "\r\n").getBytes(StandardCharsets.UTF_8))
+          Stream.fromChunk(bytes).run(RespValue.simpleStringDeserialize).map(assert(_)(equalTo(s)))
+        },
+        testM("an array") {
+          val value = RespValue.array(
+            RespValue.bulkString("hi there"),
+            RespValue.Integer(42L),
+            RespValue.NullValue,
+            RespValue.bulkString("last")
+          )
+          Stream.fromChunk(value.serialize).run(RespValue.deserialize).map(assert(_)(equalTo(value)))
+        },
+        testM("a bulk string") {
+          val bytes = encode("$6\r\nfoobar\r\n$4\r\ntest\r\n")
+          Stream.fromChunk(bytes).run(RespValue.deserialize).map(assert(_)(equalTo(RespValue.bulkString("foobar"))))
+        },
+        testM("as transducer") {
+          val values = Chunk(
+            RespValue.SimpleString("OK"),
+            RespValue.bulkString("test1"),
+            RespValue.array(RespValue.Integer(42L), RespValue.bulkString("in array"))
+          )
+          val bytes  = values.flatMap(_.serialize)
+          Stream
+            .fromChunk(bytes)
+            .transduce(RespValue.deserialize.toTransducer)
+            .runCollect
+            .map(assert(_)(equalTo(values)))
+        }
+      )
+    )
+}

--- a/redis/src/test/scala/zio/redis/RespValueSpec.scala
+++ b/redis/src/test/scala/zio/redis/RespValueSpec.scala
@@ -2,9 +2,9 @@ package zio.redis
 import java.nio.charset.StandardCharsets
 
 import zio.Chunk
-import zio.test._
-import zio.test.Assertion._
 import zio.stream.Stream
+import zio.test.Assertion._
+import zio.test._
 
 object RespValueSpec extends BaseSpec {
 


### PR DESCRIPTION
First attempt at addressing issues discussed in #136.

In master the RESP ([REdis Serialization Protocol](https://redis.io/topics/protocol)) handling is mixed in with the command-specific handling in `Input.scala` and `Output.scala`. This change splits out the RESP serialisation (which works the same way for all commands) into `RespValue.scala`, which constructs an ADT description of the the RESP values.

This produced major changes in `Output.scala`, as the command-specific processing is no longer examining raw RESP strings, but is instead pattern matching on the `RespValue` ADT.

Interpreter has been rewritten to accept and return `RespValue`s. It now uses `AsynchronousSocketChannel`, as that's the simplest way to avoid busy-waiting on a non-blocking socket, without needing blocking threads. More work is likely needed to gracefully handle IO exceptions.

The RESP deserialisation is implemented in the most straight-forward way, processing one byte at a time. This will be slow. At some point it will need to be replaced by Chunk-based sinks to perform decently.

More tests of the RESP serialisation/deserialisation are needed. It's nice that this can now be tested independently
of specific commands. Command tests that were merely testing serialisation have been removed.

A note on `RespValue.BulkString` - this uses `Chunk[Byte]` as its representation, instead of `String`. One of my own major use-cases for Redis is storing raw Protobuf objects, which string doesn't support well. I think a number of the commands should also be changed from `String` to `Chunk[Byte]`, with convenience APIs to accept and return strings. However, this PR is already big enough, so I haven't changed anything in the public API.