### PR TITLE
WIP issue/160 [hackathon] add pubsub commands

### DIFF
--- a/redis/src/main/scala/zio/redis/Input.scala
+++ b/redis/src/main/scala/zio/redis/Input.scala
@@ -149,6 +149,11 @@ object Input {
       (data._1 :: data._2).foldLeft(Chunk.empty: Chunk[RespValue.BulkString])((acc, a) => acc ++ input.encode(a))
   }
 
+  final case class ListInput[-A](input: Input[A]) extends Input[List[A]] {
+    def encode(data: List[A]): Chunk[RespValue.BulkString] =
+      data.foldLeft(Chunk.empty: Chunk[RespValue.BulkString])((acc, a) => acc ++ input.encode(a))
+  }
+
   case object OrderInput extends Input[Order] {
     def encode(data: Order): Chunk[RespValue.BulkString] = Chunk.single(stringEncode(data.stringify))
   }

--- a/redis/src/main/scala/zio/redis/api/PubSub.scala
+++ b/redis/src/main/scala/zio/redis/api/PubSub.scala
@@ -1,0 +1,41 @@
+package zio.redis.api
+
+import zio.redis.Input._
+import zio.redis.Output._
+import zio.redis._
+import zio.{ Chunk, ZIO }
+
+trait PubSub {
+  import PubSub._
+
+  final def pSubscribe(a: String, as: String*): ZIO[RedisExecutor, RedisError, Unit] = PSubscribe.run((a, as.toList))
+
+  final def pubSubChannels(a: String): ZIO[RedisExecutor, RedisError, Chunk[String]] =
+    PubSubChannels.run(("CHANNELS", List(a)))
+
+  final def pubSubNumSub(a: String, as: String*): ZIO[RedisExecutor, RedisError, Map[String, Long]] =
+    PubSubNumSub.run(("NUMSUB", a :: as.toList))
+
+  final def pubSubNumPat(): ZIO[RedisExecutor, RedisError, Long] = PubSubNumPat.run("NUMPAT")
+
+  final def publish(a: String, b: String): ZIO[RedisExecutor, RedisError, Long] = Publish.run((a, b))
+
+  final def pUnSubscribe(as: String*): ZIO[RedisExecutor, RedisError, Unit] = PUnSubscribe.run(as.toList)
+
+  final def subscribe(a: String, as: String*): ZIO[RedisExecutor, RedisError, Unit] = Subscribe.run((a, as.toList))
+
+  final def unSubscribe(as: String*): ZIO[RedisExecutor, RedisError, Unit] = UnSubscribe.run(as.toList)
+
+}
+
+private object PubSub {
+  final val PSubscribe     = RedisCommand("PSUBSCRIBE", NonEmptyList(StringInput), UnitOutput)
+  final val PubSubChannels = RedisCommand("PUBSUB", NonEmptyList(StringInput), ChunkOutput)
+  final val PubSubNumSub   = RedisCommand("PUBSUB", NonEmptyList(StringInput), KeyLongValueOutput)
+  final val PubSubNumPat   = RedisCommand("PUBSUB", StringInput, LongOutput)
+  final val Publish        = RedisCommand("PUBLISH", Tuple2(StringInput, StringInput), LongOutput)
+  final val PUnSubscribe   = RedisCommand("PUNSUBSCRIBE", ListInput(StringInput), UnitOutput)
+  final val Subscribe      = RedisCommand("SUBSCRIBE", NonEmptyList(StringInput), UnitOutput)
+  final val UnSubscribe    = RedisCommand("UNSUBSCRIBE", ListInput(StringInput), UnitOutput)
+
+}


### PR DESCRIPTION
WIP as i have questions related to my solution, also not complete yet (not tested and missing tests).

Problems/questions
* The command PUBSUB has a sub command, which makes things harder because the input/output type depends on the type of the subcommand. I tried creating a sealed trait for the sub commands but i was unable to create a nice solution with that. Currently i made simply 3 functions (`pubSubChannels`, `pubSubNumSub ` and `pubSubNumPat`).
* What is the right approach to reuse an Output ? See `KeyLongValueOutput` uses `KeyValueOutput`

Thx