### PR TITLE
Get the dump/restore commands working.

### DIFF
--- a/redis/src/main/scala/zio/redis/Input.scala
+++ b/redis/src/main/scala/zio/redis/Input.scala
@@ -187,6 +187,10 @@ object Input {
     def encode(data: String): Chunk[RespValue.BulkString] = Chunk.single(stringEncode(data))
   }
 
+  case object ByteInput extends Input[Chunk[Byte]] {
+    override private[redis] def encode(data: Chunk[Byte]) = Chunk.single(RespValue.BulkString(data))
+  }
+
   final case class OptionalInput[-A](a: Input[A]) extends Input[Option[A]] {
     def encode(data: Option[A]): Chunk[RespValue.BulkString] =
       data.fold(Chunk.empty: Chunk[RespValue.BulkString])(a.encode)

--- a/redis/src/main/scala/zio/redis/Output.scala
+++ b/redis/src/main/scala/zio/redis/Output.scala
@@ -159,6 +159,14 @@ object Output {
 
   }
 
+  case object BulkStringOutput extends Output[Chunk[Byte]] {
+    override protected def tryDecode(respValue: RespValue): Chunk[Byte] =
+      respValue match {
+        case RespValue.BulkString(value) => value
+        case other                       => throw ProtocolError(s"$other isn't a bulk string")
+      }
+  }
+
   case object MultiStringChunkOutput extends Output[Chunk[String]] {
 
     override protected def tryDecode(respValue: RespValue): Chunk[String] =

--- a/redis/src/main/scala/zio/redis/api/Keys.scala
+++ b/redis/src/main/scala/zio/redis/api/Keys.scala
@@ -15,7 +15,7 @@ trait Keys {
 
   final def del(a: String, as: String*): ZIO[RedisExecutor, RedisError, Long] = Del.run((a, as.toList))
 
-  final def dump(a: String): ZIO[RedisExecutor, RedisError, String] = Dump.run(a)
+  final def dump(a: String): ZIO[RedisExecutor, RedisError, Chunk[Byte]] = Dump.run(a)
 
   final def exists(a: String, as: String*): ZIO[RedisExecutor, RedisError, Boolean] = Exists.run((a, as.toList))
 
@@ -56,7 +56,7 @@ trait Keys {
   final def restore(
     a: String,
     b: Long,
-    c: String,
+    c: Chunk[Byte],
     d: Option[Replace] = None,
     e: Option[AbsTtl] = None,
     f: Option[IdleTime] = None,
@@ -83,7 +83,7 @@ trait Keys {
 
 private object Keys {
   final val Del      = RedisCommand("DEL", NonEmptyList(StringInput), LongOutput)
-  final val Dump     = RedisCommand("DUMP", StringInput, MultiStringOutput)
+  final val Dump     = RedisCommand("DUMP", StringInput, BulkStringOutput)
   final val Exists   = RedisCommand("EXISTS", NonEmptyList(StringInput), BoolOutput)
   final val Expire   = RedisCommand("EXPIRE", Tuple2(StringInput, DurationSecondsInput), BoolOutput)
   final val ExpireAt = RedisCommand("EXPIREAT", Tuple2(StringInput, TimeSecondsInput), BoolOutput)
@@ -121,7 +121,7 @@ private object Keys {
       Tuple7(
         StringInput,
         LongInput,
-        StringInput,
+        ByteInput,
         OptionalInput(ReplaceInput),
         OptionalInput(AbsTtlInput),
         OptionalInput(IdleTimeInput),

--- a/redis/src/test/scala/zio/redis/KeysSpec.scala
+++ b/redis/src/test/scala/zio/redis/KeysSpec.scala
@@ -105,7 +105,7 @@ trait KeysSpec extends BaseSpec {
           restore  <- restore(key, 0L, dumped).either
           restored <- get(key)
         } yield assert(restore)(isRight) && assert(restored)(isSome(equalTo(value)))
-      } @@ ignore,
+      },
       suite("ttl")(
         testM("check ttl for existing key") {
           for {


### PR DESCRIPTION
The executor now operates with `Chunk[Byte]` instead of `String`, so we can just switch to bytes in the API to pass along the exact bytes that Redis gives us.

Fixes #78 