### PR TITLE
Update Scan api to return Long instead of String

### DIFF
--- a/redis/src/main/scala/zio/redis/Output.scala
+++ b/redis/src/main/scala/zio/redis/Output.scala
@@ -110,16 +110,16 @@ object Output {
 
   }
 
-  case object ScanOutput extends Output[(String, Chunk[String])] {
+  case object ScanOutput extends Output[(Long, Chunk[String])] {
 
-    override protected def tryDecode(respValue: RespValue): (String, Chunk[String]) =
+    override protected def tryDecode(respValue: RespValue): (Long, Chunk[String]) =
       respValue match {
         case RespValue.ArrayValues(cursor @ RespValue.BulkString(_), RespValue.Array(items)) =>
           val strings = items.map {
             case s @ RespValue.BulkString(_) => s.asString
             case other                       => s"$other is not a bulk string"
           }
-          (cursor.asString, strings)
+          (cursor.asString.toLong, strings)
         case other                                                                           =>
           throw ProtocolError(s"$other isn't scan output")
       }

--- a/redis/src/main/scala/zio/redis/api/Hashes.scala
+++ b/redis/src/main/scala/zio/redis/api/Hashes.scala
@@ -36,7 +36,7 @@ trait Hashes {
     b: Option[Regex] = None,
     c: Option[Long] = None,
     d: Option[String] = None
-  ): ZIO[RedisExecutor, RedisError, (String, Chunk[String])] = HScan.run((a, b, c, d))
+  ): ZIO[RedisExecutor, RedisError, (Long, Chunk[String])] = HScan.run((a, b, c, d))
 
   final def hSet(a: String, b: (String, String), bs: (String, String)*): ZIO[RedisExecutor, RedisError, Long] =
     HSet.run((a, (b, bs.toList)))

--- a/redis/src/main/scala/zio/redis/api/Keys.scala
+++ b/redis/src/main/scala/zio/redis/api/Keys.scala
@@ -68,7 +68,7 @@ trait Keys {
     b: Option[Regex] = None,
     c: Option[Long] = None,
     d: Option[String] = None
-  ): ZIO[RedisExecutor, RedisError, (String, Chunk[String])] = Scan.run((a, b, c, d))
+  ): ZIO[RedisExecutor, RedisError, (Long, Chunk[String])] = Scan.run((a, b, c, d))
 
   final def touch(a: String, as: String*): ZIO[RedisExecutor, RedisError, Long] = Touch.run((a, as.toList))
 

--- a/redis/src/main/scala/zio/redis/api/Sets.scala
+++ b/redis/src/main/scala/zio/redis/api/Sets.scala
@@ -13,12 +13,12 @@ trait Sets {
   /** Add one or more members to a set
    *
     * @param key Key of set to add to
-   * @param firstMember first member to add
-   * @param restMembers subsequent members to add
+   * @param member first member to add
+   * @param members subsequent members to add
    * @return Returns the number of elements that were added to the set, not including all the elements already present into the set
    */
-  final def sAdd(key: String, firstMember: String, restMembers: String*): ZIO[RedisExecutor, RedisError, Long] =
-    SAdd.run((key, (firstMember, restMembers.toList)))
+  final def sAdd(key: String, member: String, members: String*): ZIO[RedisExecutor, RedisError, Long] =
+    SAdd.run((key, (member, members.toList)))
 
   /** Get the number of members in a set
    *
@@ -29,22 +29,22 @@ trait Sets {
 
   /** Subtract multiple sets
    *
-    * @param firstKey Key of the set to subtract from
-   * @param restKeys Keys of the sets to subtract
+    * @param key Key of the set to subtract from
+   * @param keys Keys of the sets to subtract
    * @return Returns the members of the set resulting from the difference between the first set and all the successive sets
    */
-  final def sDiff(firstKey: String, restKeys: String*): ZIO[RedisExecutor, RedisError, Chunk[String]] =
-    SDiff.run((firstKey, restKeys.toList))
+  final def sDiff(key: String, keys: String*): ZIO[RedisExecutor, RedisError, Chunk[String]] =
+    SDiff.run((key, keys.toList))
 
   /** Subtract multiple sets and store the resulting set in a key
    *
     * @param destination Key of set to store the resulting set
-   * @param firstKey Key of set to be subtracted from
-   * @param restKeys Keys of sets to subtract
+   * @param key Key of set to be subtracted from
+   * @param keys Keys of sets to subtract
    * @return Returns the number of elements in the resulting set
    */
-  final def sDiffStore(destination: String, firstKey: String, restKeys: String*): ZIO[RedisExecutor, RedisError, Long] =
-    SDiffStore.run((destination, (firstKey, restKeys.toList)))
+  final def sDiffStore(destination: String, key: String, keys: String*): ZIO[RedisExecutor, RedisError, Long] =
+    SDiffStore.run((destination, (key, keys.toList)))
 
   /** Intersect multiple sets and store the resulting set in a key
    *
@@ -58,16 +58,16 @@ trait Sets {
   /** Intersect multiple sets and store the resulting set in a key
    *
     * @param destination Key of set to store the resulting set
-   * @param firstKey Key of first set to intersect
-   * @param restKeys Keys of subsequent sets to intersect
+   * @param key Key of first set to intersect
+   * @param keys Keys of subsequent sets to intersect
    * @return Returns the number of elements in the resulting set
    */
   final def sInterStore(
     destination: String,
-    firstKey: String,
-    restKeys: String*
+    key: String,
+    keys: String*
   ): ZIO[RedisExecutor, RedisError, Long] =
-    SInterStore.run((destination, (firstKey, restKeys.toList)))
+    SInterStore.run((destination, (key, keys.toList)))
 
   /** Determine if a given value is a member of a set
    *
@@ -116,12 +116,12 @@ trait Sets {
   /** Remove one of more members from a set
    *
     * @param key Key of the set to remove members from
-   * @param firstMember Value of the first element to remove
-   * @param restMembers Subsequent values of elements to remove
+   * @param member Value of the first element to remove
+   * @param members Subsequent values of elements to remove
    * @return Returns the number of members that were removed from the set, not including non existing members
    */
-  final def sRem(key: String, firstMember: String, restMembers: String*): ZIO[RedisExecutor, RedisError, Long] =
-    SRem.run((key, (firstMember, restMembers.toList)))
+  final def sRem(key: String, member: String, members: String*): ZIO[RedisExecutor, RedisError, Long] =
+    SRem.run((key, (member, members.toList)))
 
   /** Incrementally iterate Set elements
    *
@@ -144,26 +144,26 @@ trait Sets {
   /**
    * Add multiple sets
    *
-    * @param firstKey Key of the first set to add
-   * @param restKeys Keys of the subsequent sets to add
+    * @param key Key of the first set to add
+   * @param keys Keys of the subsequent sets to add
    * @return Returns a list with members of the resulting set
    */
-  final def sUnion(firstKey: String, restKeys: String*): ZIO[RedisExecutor, RedisError, Chunk[String]] =
-    SUnion.run((firstKey, restKeys.toList))
+  final def sUnion(key: String, keys: String*): ZIO[RedisExecutor, RedisError, Chunk[String]] =
+    SUnion.run((key, keys.toList))
 
   /** Add multiple sets and add the resulting set in a key
    *
     * @param destination Key of destination to store the result
-   * @param firstKey Key of first set to add
-   * @param restKeys Subsequent keys of sets to add
+   * @param key Key of first set to add
+   * @param keys Subsequent keys of sets to add
    * @return Returns the number of elements in the resulting set
    */
   final def sUnionStore(
     destination: String,
-    firstKey: String,
-    restKeys: String*
+    key: String,
+    keys: String*
   ): ZIO[RedisExecutor, RedisError, Long] =
-    SUnionStore.run((destination, (firstKey, restKeys.toList)))
+    SUnionStore.run((destination, (key, keys.toList)))
 }
 
 private[redis] object Sets {

--- a/redis/src/main/scala/zio/redis/api/Sets.scala
+++ b/redis/src/main/scala/zio/redis/api/Sets.scala
@@ -10,9 +10,10 @@ import zio.{ Chunk, ZIO }
 trait Sets {
   import Sets._
 
-  /** Add one or more members to a set
+  /**
+   * Add one or more members to a set
    *
-    * @param key Key of set to add to
+   * @param key Key of set to add to
    * @param member first member to add
    * @param members subsequent members to add
    * @return Returns the number of elements that were added to the set, not including all the elements already present into the set
@@ -20,25 +21,28 @@ trait Sets {
   final def sAdd(key: String, member: String, members: String*): ZIO[RedisExecutor, RedisError, Long] =
     SAdd.run((key, (member, members.toList)))
 
-  /** Get the number of members in a set
+  /**
+   * Get the number of members in a set
    *
-    * @param key Key of set to get the number of members of
+   * @param key Key of set to get the number of members of
    * @return Returns the cardinality (number of elements) of the set, or 0 if key does not exist
    */
   final def sCard(key: String): ZIO[RedisExecutor, RedisError, Long] = SCard.run(key)
 
-  /** Subtract multiple sets
+  /**
+   * Subtract multiple sets
    *
-    * @param key Key of the set to subtract from
+   * @param key Key of the set to subtract from
    * @param keys Keys of the sets to subtract
    * @return Returns the members of the set resulting from the difference between the first set and all the successive sets
    */
   final def sDiff(key: String, keys: String*): ZIO[RedisExecutor, RedisError, Chunk[String]] =
     SDiff.run((key, keys.toList))
 
-  /** Subtract multiple sets and store the resulting set in a key
+  /**
+   * Subtract multiple sets and store the resulting set in a key
    *
-    * @param destination Key of set to store the resulting set
+   * @param destination Key of set to store the resulting set
    * @param key Key of set to be subtracted from
    * @param keys Keys of sets to subtract
    * @return Returns the number of elements in the resulting set
@@ -46,18 +50,20 @@ trait Sets {
   final def sDiffStore(destination: String, key: String, keys: String*): ZIO[RedisExecutor, RedisError, Long] =
     SDiffStore.run((destination, (key, keys.toList)))
 
-  /** Intersect multiple sets and store the resulting set in a key
+  /**
+   * Intersect multiple sets and store the resulting set in a key
    *
-    * @param destination Key of set to store the resulting set
+   * @param destination Key of set to store the resulting set
    * @param keys Keys of the sets to intersect with each other
    * @return Returns the members of the set resulting from the intersection of all the given sets
    */
   final def sInter(destination: String, keys: String*): ZIO[RedisExecutor, RedisError, Chunk[String]] =
     SInter.run((destination, keys.toList))
 
-  /** Intersect multiple sets and store the resulting set in a key
+  /**
+   * Intersect multiple sets and store the resulting set in a key
    *
-    * @param destination Key of set to store the resulting set
+   * @param destination Key of set to store the resulting set
    * @param key Key of first set to intersect
    * @param keys Keys of subsequent sets to intersect
    * @return Returns the number of elements in the resulting set
@@ -69,25 +75,28 @@ trait Sets {
   ): ZIO[RedisExecutor, RedisError, Long] =
     SInterStore.run((destination, (key, keys.toList)))
 
-  /** Determine if a given value is a member of a set
+  /**
+   * Determine if a given value is a member of a set
    *
-    * @param key
+   * @param key
    * @param member
    * @return Returns 1 if the element is a member of the set. 0 if the element is not a member of the set, or if key does not exist
    */
   final def sIsMember(key: String, member: String): ZIO[RedisExecutor, RedisError, Boolean] =
     SIsMember.run((key, member))
 
-  /** Get all the members in a set
+  /**
+   * Get all the members in a set
    *
-    * @param key Key of the set to get the members of
+   * @param key Key of the set to get the members of
    * @return Returns the members of the set
    */
   final def sMembers(key: String): ZIO[RedisExecutor, RedisError, Chunk[String]] = SMembers.run(key)
 
-  /** Move a member from one set to another
+  /**
+   * Move a member from one set to another
    *
-    * @param source Key of the set to move the member from
+   * @param source Key of the set to move the member from
    * @param destination Key of the set to move the member to
    * @param member Element to move
    * @return Returns 1 if the element was moved. 0 if it was not found.
@@ -95,27 +104,30 @@ trait Sets {
   final def sMove(source: String, destination: String, member: String): ZIO[RedisExecutor, RedisError, Boolean] =
     SMove.run((source, destination, member))
 
-  /** Remove and return one or multiple random members from a set
+  /**
+   * Remove and return one or multiple random members from a set
    *
-    * @param key Key of the set to remove items from
+   * @param key Key of the set to remove items from
    * @param count Number of elements to remove
    * @return Returns the elements removed
    */
   final def sPop(key: String, count: Option[Long] = None): ZIO[RedisExecutor, RedisError, Chunk[String]] =
     SPop.run((key, count))
 
-  /** Get one or multiple random members from a set
+  /**
+   * Get one or multiple random members from a set
    *
-    * @param key Key of the set to get members from
+   * @param key Key of the set to get members from
    * @param count Number of elements to randomly get
    * @return Returns the random members
    */
   final def sRandMember(key: String, count: Option[Long] = None): ZIO[RedisExecutor, RedisError, Chunk[String]] =
     SRandMember.run((key, count))
 
-  /** Remove one of more members from a set
+  /**
+   * Remove one of more members from a set
    *
-    * @param key Key of the set to remove members from
+   * @param key Key of the set to remove members from
    * @param member Value of the first element to remove
    * @param members Subsequent values of elements to remove
    * @return Returns the number of members that were removed from the set, not including non existing members
@@ -123,12 +135,13 @@ trait Sets {
   final def sRem(key: String, member: String, members: String*): ZIO[RedisExecutor, RedisError, Long] =
     SRem.run((key, (member, members.toList)))
 
-  /** Incrementally iterate Set elements
+  /**
+   * Incrementally iterate Set elements
    *
-    * This is a cursor based scan of an entire set. Call initially with cursor set to 0 and on subsequent
+   * This is a cursor based scan of an entire set. Call initially with cursor set to 0 and on subsequent
    * calls pass the return value as the next cursor.
    *
-    * @param key Key of the set to scan
+   * @param key Key of the set to scan
    * @param cursor Cursor to use for this iteration of scan
    * @param regex Glob-style pattern that filters which elements are returned
    * @param count Count of elements. Roughly this number will be returned by Redis if possible
@@ -144,16 +157,17 @@ trait Sets {
   /**
    * Add multiple sets
    *
-    * @param key Key of the first set to add
+   * @param key Key of the first set to add
    * @param keys Keys of the subsequent sets to add
    * @return Returns a list with members of the resulting set
    */
   final def sUnion(key: String, keys: String*): ZIO[RedisExecutor, RedisError, Chunk[String]] =
     SUnion.run((key, keys.toList))
 
-  /** Add multiple sets and add the resulting set in a key
+  /**
+   * Add multiple sets and add the resulting set in a key
    *
-    * @param destination Key of destination to store the result
+   * @param destination Key of destination to store the result
    * @param key Key of first set to add
    * @param keys Subsequent keys of sets to add
    * @return Returns the number of elements in the resulting set

--- a/redis/src/main/scala/zio/redis/api/Sets.scala
+++ b/redis/src/main/scala/zio/redis/api/Sets.scala
@@ -145,14 +145,14 @@ trait Sets {
    * @param cursor Cursor to use for this iteration of scan
    * @param regex Glob-style pattern that filters which elements are returned
    * @param count Count of elements. Roughly this number will be returned by Redis if possible
-   * @return Returns the items for this iteration or nothing when you reach the end
+   * @return Returns the next cursor, and items for this iteration or nothing when you reach the end, as a tuple
    */
   final def sScan(
     key: String,
     cursor: Long,
     regex: Option[Regex] = None,
     count: Option[Count] = None
-  ): ZIO[RedisExecutor, RedisError, (String, Chunk[String])] = SScan.run((key, cursor, regex, count))
+  ): ZIO[RedisExecutor, RedisError, (Long, Chunk[String])] = SScan.run((key, cursor, regex, count))
 
   /**
    * Add multiple sets

--- a/redis/src/main/scala/zio/redis/api/SortedSets.scala
+++ b/redis/src/main/scala/zio/redis/api/SortedSets.scala
@@ -325,7 +325,7 @@ trait SortedSets {
     cursor: Long,
     regex: Option[Regex] = None,
     count: Option[Count] = None
-  ): ZIO[RedisExecutor, RedisError, (String, Chunk[String])] = ZScan.run((key, cursor, regex, count))
+  ): ZIO[RedisExecutor, RedisError, (Long, Chunk[String])] = ZScan.run((key, cursor, regex, count))
 
   /**
    * Get the score associated with the given member in a sorted set.

--- a/redis/src/test/scala/zio/redis/KeysSpec.scala
+++ b/redis/src/test/scala/zio/redis/KeysSpec.scala
@@ -84,7 +84,7 @@ trait KeysSpec extends BaseSpec {
           _               <- set(key, value)
           scan            <- scan(0L)
           (next, elements) = scan
-        } yield assert(next)(isNonEmptyString) && assert(elements)(isNonEmpty)
+        } yield assert(next)(isGreaterThan(0L)) && assert(elements)(isNonEmpty)
       },
       testM("fetch random key") {
         for {

--- a/redis/src/test/scala/zio/redis/OutputSpec.scala
+++ b/redis/src/test/scala/zio/redis/OutputSpec.scala
@@ -138,7 +138,7 @@ object OutputSpec extends BaseSpec {
           val input = respArrayVals(respBulkString("5"), respArray("foo", "bar"))
           for {
             res <- Task(ScanOutput.unsafeDecode(input))
-          } yield assert(res)(equalTo("5" -> Chunk("foo", "bar")))
+          } yield assert(res)(equalTo(5L -> Chunk("foo", "bar")))
         }
       ),
       suite("string")(

--- a/redis/src/test/scala/zio/redis/SetsSpec.scala
+++ b/redis/src/test/scala/zio/redis/SetsSpec.scala
@@ -746,7 +746,7 @@ trait SetsSpec extends BaseSpec {
             key              <- uuid
             scan             <- sScan(key, 0L)
             (cursor, members) = scan
-          } yield assert(cursor)(equalTo(0L)) &&
+          } yield assert(cursor)(isZero) &&
             assert(members)(isEmpty)
         },
         testM("with match over non-empty set") {

--- a/redis/src/test/scala/zio/redis/SetsSpec.scala
+++ b/redis/src/test/scala/zio/redis/SetsSpec.scala
@@ -738,7 +738,7 @@ trait SetsSpec extends BaseSpec {
             _                <- sAdd(key, "a", "b", "c")
             scan             <- sScan(key, 0L)
             (cursor, members) = scan
-          } yield assert(cursor)(isNonEmptyString) &&
+          } yield assert(cursor)(equalTo(0L)) &&
             assert(members)(isNonEmpty)
         },
         testM("empty set") {
@@ -746,7 +746,7 @@ trait SetsSpec extends BaseSpec {
             key              <- uuid
             scan             <- sScan(key, 0L)
             (cursor, members) = scan
-          } yield assert(cursor)(equalTo("0")) &&
+          } yield assert(cursor)(equalTo(0L)) &&
             assert(members)(isEmpty)
         },
         testM("with match over non-empty set") {
@@ -755,8 +755,20 @@ trait SetsSpec extends BaseSpec {
             _                <- sAdd(key, "one", "two", "three")
             scan             <- sScan(key, 0L, Some("t[a-z]*".r))
             (cursor, members) = scan
-          } yield assert(cursor)(isNonEmptyString) &&
+          } yield assert(cursor)(equalTo(0L)) &&
             assert(members)(isNonEmpty)
+        },
+        testM("with count over non-empty set with two iterations") {
+          for {
+            key                <- uuid
+            _                  <- sAdd(key, "a", "b", "c", "d", "e")
+            scan               <- sScan(key, 0L, count = Some(Count(3L)))
+            (cursor, members)   = scan
+            scan2              <- sScan(key, cursor, count = Some(Count(3L)))
+            (cursor2, members2) = scan2
+          } yield assert(cursor)(isGreaterThan(0L)) &&
+            assert(members)(isNonEmpty) &&
+            assert(cursor2)(equalTo(0L))
         },
         testM("with count over non-empty set") {
           for {
@@ -764,7 +776,7 @@ trait SetsSpec extends BaseSpec {
             _                <- sAdd(key, "a", "b", "c", "d", "e")
             scan             <- sScan(key, 0L, count = Some(Count(3L)))
             (cursor, members) = scan
-          } yield assert(cursor)(isNonEmptyString) &&
+          } yield assert(cursor)(isGreaterThan(0L)) &&
             assert(members)(isNonEmpty)
         },
         testM("error when not set") {

--- a/redis/src/test/scala/zio/redis/SetsSpec.scala
+++ b/redis/src/test/scala/zio/redis/SetsSpec.scala
@@ -755,7 +755,7 @@ trait SetsSpec extends BaseSpec {
             _                <- sAdd(key, "one", "two", "three")
             scan             <- sScan(key, 0L, Some("t[a-z]*".r))
             (cursor, members) = scan
-          } yield assert(cursor)(equalTo(0L)) &&
+          } yield assert(cursor)(isZero) &&
             assert(members)(isNonEmpty)
         },
         testM("with count over non-empty set with two iterations") {

--- a/redis/src/test/scala/zio/redis/SetsSpec.scala
+++ b/redis/src/test/scala/zio/redis/SetsSpec.scala
@@ -768,7 +768,7 @@ trait SetsSpec extends BaseSpec {
             (cursor2, members2) = scan2
           } yield assert(cursor)(isGreaterThan(0L)) &&
             assert(members)(isNonEmpty) &&
-            assert(cursor2)(equalTo(0L))
+            assert(cursor2)(isZero)
         },
         testM("with count over non-empty set") {
           for {

--- a/redis/src/test/scala/zio/redis/SetsSpec.scala
+++ b/redis/src/test/scala/zio/redis/SetsSpec.scala
@@ -738,7 +738,7 @@ trait SetsSpec extends BaseSpec {
             _                <- sAdd(key, "a", "b", "c")
             scan             <- sScan(key, 0L)
             (cursor, members) = scan
-          } yield assert(cursor)(equalTo(0L)) &&
+          } yield assert(cursor)(isZero) &&
             assert(members)(isNonEmpty)
         },
         testM("empty set") {

--- a/redis/src/test/scala/zio/redis/SortedSetsSpec.scala
+++ b/redis/src/test/scala/zio/redis/SortedSetsSpec.scala
@@ -794,14 +794,14 @@ trait SortedSetsSpec extends BaseSpec {
             _                <- zAdd(key)(MemberScore(1d, "atest"), MemberScore(2d, "btest"), MemberScore(3d, "ctest"))
             scan             <- zScan(key, 0L)
             (cursor, members) = scan
-          } yield assert(cursor)(isNonEmptyString) && assert(members)(isNonEmpty)
+          } yield assert(cursor)(equalTo(0L)) && assert(members)(isNonEmpty)
         },
         testM("empty set") {
           for {
             key              <- uuid
             scan             <- zScan(key, 0L)
             (cursor, members) = scan
-          } yield assert(cursor)(equalTo("0")) && assert(members)(isEmpty)
+          } yield assert(cursor)(equalTo(0L)) && assert(members)(isEmpty)
         },
         testM("with match over non-empty set") {
           for {
@@ -809,7 +809,7 @@ trait SortedSetsSpec extends BaseSpec {
             _                <- zAdd(key)(MemberScore(1d, "one"), MemberScore(2d, "two"), MemberScore(3d, "three"))
             scan             <- zScan(key, 0L, Some("t[a-z]*".r))
             (cursor, members) = scan
-          } yield assert(cursor)(isNonEmptyString) && assert(members)(isNonEmpty)
+          } yield assert(cursor)(equalTo(0L)) && assert(members)(isNonEmpty)
         },
         testM("with count over non-empty set") {
           for {
@@ -823,7 +823,7 @@ trait SortedSetsSpec extends BaseSpec {
                  )
             scan             <- zScan(key, 0L, None, Some(Count(3L)))
             (cursor, members) = scan
-          } yield assert(cursor)(isNonEmptyString) && assert(members)(isNonEmpty)
+          } yield assert(cursor)(equalTo(0L)) && assert(members)(isNonEmpty)
         },
         testM("match with count over non-empty set") {
           for {
@@ -837,7 +837,7 @@ trait SortedSetsSpec extends BaseSpec {
                  )
             scan             <- zScan(key, 0L, Some("t[a-z]*".r), Some(Count(3L)))
             (cursor, members) = scan
-          } yield assert(cursor)(isNonEmptyString) && assert(members)(isNonEmpty)
+          } yield assert(cursor)(equalTo(0L)) && assert(members)(isNonEmpty)
         },
         testM("error when not set") {
           for {

--- a/redis/src/test/scala/zio/redis/SortedSetsSpec.scala
+++ b/redis/src/test/scala/zio/redis/SortedSetsSpec.scala
@@ -794,7 +794,7 @@ trait SortedSetsSpec extends BaseSpec {
             _                <- zAdd(key)(MemberScore(1d, "atest"), MemberScore(2d, "btest"), MemberScore(3d, "ctest"))
             scan             <- zScan(key, 0L)
             (cursor, members) = scan
-          } yield assert(cursor)(equalTo(0L)) && assert(members)(isNonEmpty)
+          } yield assert(cursor)(isZero) && assert(members)(isNonEmpty)
         },
         testM("empty set") {
           for {

--- a/redis/src/test/scala/zio/redis/SortedSetsSpec.scala
+++ b/redis/src/test/scala/zio/redis/SortedSetsSpec.scala
@@ -823,7 +823,7 @@ trait SortedSetsSpec extends BaseSpec {
                  )
             scan             <- zScan(key, 0L, None, Some(Count(3L)))
             (cursor, members) = scan
-          } yield assert(cursor)(equalTo(0L)) && assert(members)(isNonEmpty)
+          } yield assert(cursor)(isZero) && assert(members)(isNonEmpty)
         },
         testM("match with count over non-empty set") {
           for {

--- a/redis/src/test/scala/zio/redis/SortedSetsSpec.scala
+++ b/redis/src/test/scala/zio/redis/SortedSetsSpec.scala
@@ -809,7 +809,7 @@ trait SortedSetsSpec extends BaseSpec {
             _                <- zAdd(key)(MemberScore(1d, "one"), MemberScore(2d, "two"), MemberScore(3d, "three"))
             scan             <- zScan(key, 0L, Some("t[a-z]*".r))
             (cursor, members) = scan
-          } yield assert(cursor)(equalTo(0L)) && assert(members)(isNonEmpty)
+          } yield assert(cursor)(isZero) && assert(members)(isNonEmpty)
         },
         testM("with count over non-empty set") {
           for {

--- a/redis/src/test/scala/zio/redis/SortedSetsSpec.scala
+++ b/redis/src/test/scala/zio/redis/SortedSetsSpec.scala
@@ -837,7 +837,7 @@ trait SortedSetsSpec extends BaseSpec {
                  )
             scan             <- zScan(key, 0L, Some("t[a-z]*".r), Some(Count(3L)))
             (cursor, members) = scan
-          } yield assert(cursor)(equalTo(0L)) && assert(members)(isNonEmpty)
+          } yield assert(cursor)(isZero) && assert(members)(isNonEmpty)
         },
         testM("error when not set") {
           for {

--- a/redis/src/test/scala/zio/redis/SortedSetsSpec.scala
+++ b/redis/src/test/scala/zio/redis/SortedSetsSpec.scala
@@ -801,7 +801,7 @@ trait SortedSetsSpec extends BaseSpec {
             key              <- uuid
             scan             <- zScan(key, 0L)
             (cursor, members) = scan
-          } yield assert(cursor)(equalTo(0L)) && assert(members)(isEmpty)
+          } yield assert(cursor)(isZero) && assert(members)(isEmpty)
         },
         testM("with match over non-empty set") {
           for {


### PR DESCRIPTION
fixes #208 

Updated API to return a Long
Updated response handling to convert the cursor from Redis to Long
Updated tests