### PR TITLE
Fix tests that rely on the SCAN cursor behaviour which is undefined

### DIFF
--- a/redis/src/test/scala/zio/redis/SetsSpec.scala
+++ b/redis/src/test/scala/zio/redis/SetsSpec.scala
@@ -11,7 +11,7 @@ import zio.test.Assertion._
 import zio.test._
 
 trait SetsSpec extends BaseSpec {
-  val setsSuite =
+  val setsSuite                                    =
     suite("sets")(
       suite("sAdd")(
         testM("to empty set") {

--- a/redis/src/test/scala/zio/redis/SetsSpec.scala
+++ b/redis/src/test/scala/zio/redis/SetsSpec.scala
@@ -3,12 +3,12 @@ package zio.redis
 import scala.util.matching.Regex
 
 import zio.Chunk
+import zio.NonEmptyChunk
 import zio.ZIO
 import zio.redis.RedisError.WrongType
+import zio.stream.ZStream
 import zio.test.Assertion._
 import zio.test._
-import zio.NonEmptyChunk
-import zio.stream.ZStream
 
 trait SetsSpec extends BaseSpec {
   private def scanAll(

--- a/redis/src/test/scala/zio/redis/SetsSpec.scala
+++ b/redis/src/test/scala/zio/redis/SetsSpec.scala
@@ -11,20 +11,6 @@ import zio.test.Assertion._
 import zio.test._
 
 trait SetsSpec extends BaseSpec {
-  private def scanAll(
-    key: String,
-    regex: Option[Regex] = None,
-    count: Option[Count] = None
-  ): ZIO[RedisExecutor, RedisError, Chunk[String]] =
-    ZStream
-      .paginateChunkM(0L) { cursor =>
-        sScan(key, cursor, regex, count).map {
-          case (nc, nm) if nc == 0 => (nm, None)
-          case (nc, nm)            => (nm, Some(nc))
-        }
-      }
-      .runCollect
-
   val setsSuite =
     suite("sets")(
       suite("sAdd")(
@@ -793,4 +779,17 @@ trait SetsSpec extends BaseSpec {
         }
       ) @@ testExecutorUnsupported
     )
+  private def scanAll(
+    key: String,
+    regex: Option[Regex] = None,
+    count: Option[Count] = None
+  ): ZIO[RedisExecutor, RedisError, Chunk[String]] =
+    ZStream
+      .paginateChunkM(0L) { cursor =>
+        sScan(key, cursor, regex, count).map {
+          case (nc, nm) if nc == 0 => (nm, None)
+          case (nc, nm)            => (nm, Some(nc))
+        }
+      }
+      .runCollect
 }

--- a/redis/src/test/scala/zio/redis/SetsSpec.scala
+++ b/redis/src/test/scala/zio/redis/SetsSpec.scala
@@ -11,19 +11,19 @@ import zio.NonEmptyChunk
 import zio.stream.ZStream
 
 trait SetsSpec extends BaseSpec {
-  def scanAll(
+  private def scanAll(
     key: String,
     regex: Option[Regex] = None,
     count: Option[Count] = None
   ): ZIO[RedisExecutor, RedisError, Chunk[String]] =
-   ZStream
-    .paginateChunkM(0L) { cursor =>
-      sScan(key, cursor, regex, count).map {
-        case (nc, nm) if nc == 0 => (nm, None)
-        case (nc, nm)           => (nm, Some(nc))
+    ZStream
+      .paginateChunkM(0L) { cursor =>
+        sScan(key, cursor, regex, count).map {
+          case (nc, nm) if nc == 0 => (nm, None)
+          case (nc, nm)            => (nm, Some(nc))
+        }
       }
-    }
-    .runCollect
+      .runCollect
 
   val setsSuite =
     suite("sets")(
@@ -770,9 +770,9 @@ trait SetsSpec extends BaseSpec {
         testM("with match over non-empty set") {
           val testData = NonEmptyChunk("one", "two", "three")
           for {
-            key              <- uuid
-            _                <- sAdd(key, testData.head, testData.tail: _*)
-            members          <- scanAll(key, Some("t[a-z]*".r))
+            key     <- uuid
+            _       <- sAdd(key, testData.head, testData.tail: _*)
+            members <- scanAll(key, Some("t[a-z]*".r))
           } yield assert(members.toSet)(equalTo(Set("two", "three")))
         },
         testM("with count over non-empty set") {

--- a/redis/src/test/scala/zio/redis/SortedSetsSpec.scala
+++ b/redis/src/test/scala/zio/redis/SortedSetsSpec.scala
@@ -10,7 +10,7 @@ import zio.test.Assertion._
 import zio.test._
 
 trait SortedSetsSpec extends BaseSpec {
-  val sortedSetsSuite =
+  val sortedSetsSuite                              =
     suite("sorted sets")(
       suite("zAdd")(
         testM("to empty set") {

--- a/redis/src/test/scala/zio/redis/SortedSetsSpec.scala
+++ b/redis/src/test/scala/zio/redis/SortedSetsSpec.scala
@@ -3,8 +3,26 @@ package zio.redis
 import zio.redis.RedisError.{ ProtocolError, WrongType }
 import zio.test.Assertion._
 import zio.test._
+import scala.util.matching.Regex
+import zio.Chunk
+import zio.ZIO
+import zio.stream.ZStream
 
 trait SortedSetsSpec extends BaseSpec {
+  private def scanAll(
+    key: String,
+    regex: Option[Regex] = None,
+    count: Option[Count] = None
+  ): ZIO[RedisExecutor, RedisError, Chunk[String]] =
+    ZStream
+      .paginateChunkM(0L) { cursor =>
+        zScan(key, cursor, regex, count).map {
+          case (nc, nm) if nc == 0 => (nm, None)
+          case (nc, nm)            => (nm, Some(nc))
+        }
+      }
+      .runCollect
+
   val sortedSetsSuite =
     suite("sorted sets")(
       suite("zAdd")(
@@ -790,11 +808,10 @@ trait SortedSetsSpec extends BaseSpec {
       suite("zScan")(
         testM("non-empty set") {
           for {
-            key              <- uuid
-            _                <- zAdd(key)(MemberScore(1d, "atest"), MemberScore(2d, "btest"), MemberScore(3d, "ctest"))
-            scan             <- zScan(key, 0L)
-            (cursor, members) = scan
-          } yield assert(cursor)(isZero) && assert(members)(isNonEmpty)
+            key     <- uuid
+            _       <- zAdd(key)(MemberScore(1d, "atest"), MemberScore(2d, "btest"), MemberScore(3d, "ctest"))
+            members <- scanAll(key)
+          } yield assert(members)(equalTo(Chunk("atest", "1", "btest", "2", "ctest", "3")))
         },
         testM("empty set") {
           for {
@@ -805,39 +822,36 @@ trait SortedSetsSpec extends BaseSpec {
         },
         testM("with match over non-empty set") {
           for {
-            key              <- uuid
-            _                <- zAdd(key)(MemberScore(1d, "one"), MemberScore(2d, "two"), MemberScore(3d, "three"))
-            scan             <- zScan(key, 0L, Some("t[a-z]*".r))
-            (cursor, members) = scan
-          } yield assert(cursor)(isZero) && assert(members)(isNonEmpty)
+            key     <- uuid
+            _       <- zAdd(key)(MemberScore(1d, "one"), MemberScore(2d, "two"), MemberScore(3d, "three"))
+            members <- scanAll(key, Some("t[a-z]*".r))
+          } yield assert(members)(equalTo((Chunk("two", "2", "three", "3"))))
         },
         testM("with count over non-empty set") {
           for {
-            key              <- uuid
-            _                <- zAdd(key)(
+            key     <- uuid
+            _       <- zAdd(key)(
                    MemberScore(1d, "a"),
                    MemberScore(2d, "b"),
                    MemberScore(3d, "c"),
                    MemberScore(4d, "d"),
                    MemberScore(5d, "e")
                  )
-            scan             <- zScan(key, 0L, None, Some(Count(3L)))
-            (cursor, members) = scan
-          } yield assert(cursor)(isZero) && assert(members)(isNonEmpty)
+            members <- scanAll(key, count = Some(Count(3L)))
+          } yield assert(members)(isNonEmpty)
         },
         testM("match with count over non-empty set") {
           for {
-            key              <- uuid
-            _                <- zAdd(key)(
+            key     <- uuid
+            _       <- zAdd(key)(
                    MemberScore(1d, "testa"),
                    MemberScore(2d, "testb"),
                    MemberScore(3d, "testc"),
                    MemberScore(4d, "testd"),
                    MemberScore(5d, "teste")
                  )
-            scan             <- zScan(key, 0L, Some("t[a-z]*".r), Some(Count(3L)))
-            (cursor, members) = scan
-          } yield assert(cursor)(isZero) && assert(members)(isNonEmpty)
+            members <- scanAll(key, Some("t[a-z]*".r), Some(Count(3L)))
+          } yield assert(members)(isNonEmpty)
         },
         testM("error when not set") {
           for {

--- a/redis/src/test/scala/zio/redis/SortedSetsSpec.scala
+++ b/redis/src/test/scala/zio/redis/SortedSetsSpec.scala
@@ -10,20 +10,6 @@ import zio.test.Assertion._
 import zio.test._
 
 trait SortedSetsSpec extends BaseSpec {
-  private def scanAll(
-    key: String,
-    regex: Option[Regex] = None,
-    count: Option[Count] = None
-  ): ZIO[RedisExecutor, RedisError, Chunk[String]] =
-    ZStream
-      .paginateChunkM(0L) { cursor =>
-        zScan(key, cursor, regex, count).map {
-          case (nc, nm) if nc == 0 => (nm, None)
-          case (nc, nm)            => (nm, Some(nc))
-        }
-      }
-      .runCollect
-
   val sortedSetsSuite =
     suite("sorted sets")(
       suite("zAdd")(
@@ -1007,4 +993,17 @@ trait SortedSetsSpec extends BaseSpec {
         }
       )
     )
+  private def scanAll(
+    key: String,
+    regex: Option[Regex] = None,
+    count: Option[Count] = None
+  ): ZIO[RedisExecutor, RedisError, Chunk[String]] =
+    ZStream
+      .paginateChunkM(0L) { cursor =>
+        zScan(key, cursor, regex, count).map {
+          case (nc, nm) if nc == 0 => (nm, None)
+          case (nc, nm)            => (nm, Some(nc))
+        }
+      }
+      .runCollect
 }

--- a/redis/src/test/scala/zio/redis/SortedSetsSpec.scala
+++ b/redis/src/test/scala/zio/redis/SortedSetsSpec.scala
@@ -1,12 +1,13 @@
 package zio.redis
 
-import zio.redis.RedisError.{ ProtocolError, WrongType }
-import zio.test.Assertion._
-import zio.test._
 import scala.util.matching.Regex
+
 import zio.Chunk
 import zio.ZIO
+import zio.redis.RedisError.{ ProtocolError, WrongType }
 import zio.stream.ZStream
+import zio.test.Assertion._
+import zio.test._
 
 trait SortedSetsSpec extends BaseSpec {
   private def scanAll(


### PR DESCRIPTION
Rather than expect exact cursor values we instead will repeatedly call scan until it returns a zero cursor, then compare the accumulated results with the original data we added to Redis.