### PR TITLE
Test streams API

### DIFF
--- a/redis/src/main/scala/zio/redis/Input.scala
+++ b/redis/src/main/scala/zio/redis/Input.scala
@@ -276,7 +276,7 @@ object Input {
   case object StreamsInput extends Input[((String, String), Chunk[(String, String)])] {
     def encode(data: ((String, String), Chunk[(String, String)])): Chunk[RespValue.BulkString] = {
       val (keys, ids) =
-        Chunk.fromIterable(data._1 +: data._2).map(pair => (stringEncode(pair._1), stringEncode(pair._2))).unzip
+        (data._1 +: data._2).map(pair => (stringEncode(pair._1), stringEncode(pair._2))).unzip
 
       Chunk.single(stringEncode("STREAMS")) ++ keys ++ ids
     }

--- a/redis/src/main/scala/zio/redis/Output.scala
+++ b/redis/src/main/scala/zio/redis/Output.scala
@@ -15,6 +15,8 @@ sealed trait Output[+A] {
         throw RedisError.WrongType(msg.drop(9).trim)
       case RespValue.Error(msg) if msg.startsWith("BUSYGROUP") =>
         throw RedisError.WrongType(msg.drop(9).trim)
+      case RespValue.Error(msg) if msg.startsWith("NOGROUP")   =>
+        throw RedisError.NoGroup(msg.drop(7).trim)
       case RespValue.Error(msg)                                =>
         throw RedisError.ProtocolError(msg.trim)
       case success                                             =>

--- a/redis/src/main/scala/zio/redis/Output.scala
+++ b/redis/src/main/scala/zio/redis/Output.scala
@@ -14,7 +14,7 @@ sealed trait Output[+A] {
       case RespValue.Error(msg) if msg.startsWith("WRONGTYPE") =>
         throw RedisError.WrongType(msg.drop(9).trim)
       case RespValue.Error(msg) if msg.startsWith("BUSYGROUP") =>
-        throw RedisError.WrongType(msg.drop(9).trim)
+        throw RedisError.BusyGroup(msg.drop(9).trim)
       case RespValue.Error(msg) if msg.startsWith("NOGROUP")   =>
         throw RedisError.NoGroup(msg.drop(7).trim)
       case RespValue.Error(msg)                                =>

--- a/redis/src/main/scala/zio/redis/Output.scala
+++ b/redis/src/main/scala/zio/redis/Output.scala
@@ -325,6 +325,8 @@ object Output {
           }
 
           output.toMap
+        case RespValue.NullValue       =>
+          Map.empty[String, Map[String, String]]
         case other                     =>
           throw ProtocolError(s"$other isn't an array")
       }
@@ -394,6 +396,8 @@ object Output {
           }
 
           output.toMap
+        case RespValue.NullValue      =>
+          Map.empty[String, Map[String, Map[String, String]]]
         case other                    =>
           throw ProtocolError(s"$other isn't an array")
       }

--- a/redis/src/main/scala/zio/redis/api/Streams.scala
+++ b/redis/src/main/scala/zio/redis/api/Streams.scala
@@ -28,12 +28,16 @@ trait Streams {
   ): ZIO[RedisExecutor, RedisError, String] =
     XAdd.run((key, Some(MaxLen(approximate, count)), id, (pair, pairs.toList)))
 
-  final def xClaim(key: String, group: String, consumer: String, minIdleTime: Duration, id: String, ids: String*)(
+  final def xClaim(
+    key: String,
+    group: String,
+    consumer: String,
+    minIdleTime: Duration,
     idle: Option[Duration] = None,
     time: Option[Duration] = None,
     retryCount: Option[Long] = None,
     force: Boolean = false
-  ): ZIO[RedisExecutor, RedisError, Map[String, Map[String, String]]] =
+  )(id: String, ids: String*): ZIO[RedisExecutor, RedisError, Map[String, Map[String, String]]] =
     XClaim.run(
       (
         key,
@@ -53,14 +57,11 @@ trait Streams {
     group: String,
     consumer: String,
     minIdleTime: Duration,
-    id: String,
-    ids: String*
-  )(
     idle: Option[Duration] = None,
     time: Option[Duration] = None,
     retryCount: Option[Long] = None,
     force: Boolean = false
-  ): ZIO[RedisExecutor, RedisError, Chunk[String]] =
+  )(id: String, ids: String*): ZIO[RedisExecutor, RedisError, Chunk[String]] =
     XClaimWithJustId.run(
       (
         key,

--- a/redis/src/main/scala/zio/redis/api/Streams.scala
+++ b/redis/src/main/scala/zio/redis/api/Streams.scala
@@ -11,9 +11,27 @@ trait Streams {
   import Streams._
   import XGroupCommand._
 
+  /**
+   * Removes one or multiple messages from the pending entries list (PEL) of a stream consumer group.
+   *
+   * @param key ID of the stream
+   * @param group ID of the consumer group
+   * @param id ID of the message
+   * @param ids IDs of the rest of the messages
+   * @return the number of messages successfully acknowledged.
+   */
   final def xAck(key: String, group: String, id: String, ids: String*): ZIO[RedisExecutor, RedisError, Long] =
     XAck.run((key, group, (id, ids.toList)))
 
+  /**
+   * Appends the specified stream entry to the stream at the specified key.
+   *
+   * @param key ID of the stream
+   * @param id ID of the message
+   * @param pair field and value pair
+   * @param pairs rest of the field and value pairs
+   * @return ID of the added entry.
+   */
   final def xAdd(
     key: String,
     id: String,
@@ -22,12 +40,38 @@ trait Streams {
   ): ZIO[RedisExecutor, RedisError, String] =
     XAdd.run((key, None, id, (pair, pairs.toList)))
 
+  /**
+   * Appends the specified stream entry to the stream at the specified key while limiting the size of the stream.
+   *
+   * @param key ID of the stream
+   * @param id ID of the message
+   * @param count maximum number of elements in a stream
+   * @param approximate flag that indicates if a stream should be limited to the exact number of elements
+   * @param pair field and value pair
+   * @param pairs rest of the field and value pairs
+   * @return ID of the added entry.
+   */
   final def xAddWithMaxLen(key: String, id: String, count: Long, approximate: Boolean = false)(
     pair: (String, String),
     pairs: (String, String)*
   ): ZIO[RedisExecutor, RedisError, String] =
     XAdd.run((key, Some(MaxLen(approximate, count)), id, (pair, pairs.toList)))
 
+  /**
+   * Changes the ownership of a pending message.
+   *
+   * @param key ID of the stream
+   * @param group ID of the consumer group
+   * @param consumer ID of the consumer
+   * @param minIdleTime minimum idle time of a message
+   * @param idle idle time (last time it was delivered) of the message that will be set
+   * @param time same as idle but instead of a relative amount of milliseconds, it sets the idle time to a specific Unix time (in milliseconds)
+   * @param retryCount retry counter of a message that will be set
+   * @param force flag that indicates that a message doesn't have to be in a pending entries list (PEL)
+   * @param id ID of a message
+   * @param ids IDs of the rest of the messages
+   * @return messages successfully claimed.
+   */
   final def xClaim(
     key: String,
     group: String,
@@ -52,6 +96,21 @@ trait Streams {
       )
     )
 
+  /**
+   * Changes the ownership of a pending message.
+   *
+   * @param key ID of the stream
+   * @param group ID of the consumer group
+   * @param consumer ID of the consumer
+   * @param minIdleTime minimum idle time of a message
+   * @param idle idle time (last time it was delivered) of the message that will be set
+   * @param time same as idle but instead of a relative amount of milliseconds, it sets the idle time to a specific Unix time (in milliseconds)
+   * @param retryCount retry counter of a message that will be set
+   * @param force flag that indicates that a message doesn't have to be in a pending entries list (PEL)
+   * @param id ID of a message
+   * @param ids IDs of the rest of the messages
+   * @return IDs of the messages that are successfully claimed.
+   */
   final def xClaimWithJustId(
     key: String,
     group: String,
@@ -77,9 +136,25 @@ trait Streams {
       )
     )
 
+  /**
+   * Removes the specified entries from a stream.
+   *
+   * @param key ID of the stream
+   * @param id ID of the message
+   * @param ids IDs of the rest of the messages
+   * @return the number of entries deleted.
+   */
   final def xDel(key: String, id: String, ids: String*): ZIO[RedisExecutor, RedisError, Long] =
     XDel.run((key, (id, ids.toList)))
 
+  /**
+   * Create a new consumer group associated with a stream.
+   *
+   * @param key ID of the stream
+   * @param group ID of the consumer group
+   * @param id ID of the last item in the stream to consider already delivered
+   * @param mkStream ID of the last item in the stream to consider already delivered
+   */
   final def xGroupCreate(
     key: String,
     group: String,
@@ -88,27 +163,89 @@ trait Streams {
   ): ZIO[RedisExecutor, RedisError, Unit] =
     XGroupCreate.run(Create(key, group, id, mkStream))
 
+  /**
+   * Set the consumer group last delivered ID to something else.
+   *
+   * @param key ID of the stream
+   * @param group ID of the consumer group
+   * @param id last delivered ID to set
+   */
   final def xGroupSetId(key: String, group: String, id: String): ZIO[RedisExecutor, RedisError, Unit] =
     XGroupSetId.run(SetId(key, group, id))
 
+  /**
+   * Destroy a consumer group.
+   *
+   * @param key ID of the stream
+   * @param group ID of the consumer group
+   * @return flag that indicates if the deletion was successful.
+   */
   final def xGroupDestroy(key: String, group: String): ZIO[RedisExecutor, RedisError, Boolean] =
     XGroupDestroy.run(Destroy(key, group))
 
+  /**
+   * Create a new consumer associated with a consumer group.
+   *
+   * @param key ID of the stream
+   * @param group ID of the consumer group
+   * @param consumer ID of the consumer
+   */
   final def xGroupCreateConsumer(key: String, group: String, consumer: String): ZIO[RedisExecutor, RedisError, Unit] =
     XGroupCreateConsumer.run(CreateConsumer(key, group, consumer))
 
+  /**
+   * Remove a specific consumer from a consumer group.
+   *
+   * @param key ID of the stream
+   * @param group ID of the consumer group
+   * @param consumer ID of the consumer
+   * @return the number of pending messages that the consumer had before it was deleted.
+   */
   final def xGroupDelConsumer(key: String, group: String, consumer: String): ZIO[RedisExecutor, RedisError, Long] =
     XGroupDelConsumer.run(DelConsumer(key, group, consumer))
 
+  /**
+   * Fetches the number of entries inside a stream.
+   *
+   * @param key ID of the stream
+   * @return the number of entries inside a stream
+   */
   final def xLen(key: String): ZIO[RedisExecutor, RedisError, Long] =
     XLen.run(key)
 
+  /**
+   * Inspects the list of pending messages.
+   *
+   * @param key ID of the stream
+   * @param group ID of the consumer group
+   * @return summary about the pending messages in a given consumer group.
+   */
   final def xPending(key: String, group: String): ZIO[RedisExecutor, RedisError, PendingInfo] =
     XPending.run((key, group, None))
 
+  /**
+   * Inspects the list of pending messages.
+   *
+   * @param key ID of the stream
+   * @param group ID of the consumer group
+   * @param idle idle time of a pending message by which message are filtered
+   * @return summary about the pending messages in a given consumer group.
+   */
   final def xPending(key: String, group: String, idle: Duration): ZIO[RedisExecutor, RedisError, PendingInfo] =
     XPending.run((key, group, Some(idle)))
 
+  /**
+   * Inspects the list of pending messages.
+   *
+   * @param key ID of the stream
+   * @param group ID of the consumer group
+   * @param start start of the range of IDs
+   * @param end end of the range of IDs
+   * @param count maximum number of messages returned
+   * @param consumer ID of the consumer
+   * @param idle idle time of a pending message by which message are filtered
+   * @return detailed information for each message in the pending entries list.
+   */
   final def xPending(
     key: String,
     group: String,
@@ -120,6 +257,14 @@ trait Streams {
   ): ZIO[RedisExecutor, RedisError, Chunk[PendingMessage]] =
     XPendingMessages.run((key, group, start, end, count, consumer, idle))
 
+  /**
+   * Fetches the stream entries matching a given range of IDs.
+   *
+   * @param key ID of the stream
+   * @param start start of the range of IDs
+   * @param end end of the range of IDs
+   * @return the complete entries with IDs matching the specified range.
+   */
   final def xRange(
     key: String,
     start: String,
@@ -127,6 +272,15 @@ trait Streams {
   ): ZIO[RedisExecutor, RedisError, Map[String, Map[String, String]]] =
     XRange.run((key, start, end, None))
 
+  /**
+   * Fetches the stream entries matching a given range of IDs.
+   *
+   * @param key ID of the stream
+   * @param start start of the range of IDs
+   * @param end end of the range of IDs
+   * @param count maximum number of entries returned
+   * @return the complete entries with IDs matching the specified range.
+   */
   final def xRange(
     key: String,
     start: String,
@@ -135,12 +289,33 @@ trait Streams {
   ): ZIO[RedisExecutor, RedisError, Map[String, Map[String, String]]] =
     XRange.run((key, start, end, Some(Count(count))))
 
+  /**
+   * Read data from one or multiple streams.
+   *
+   * @param count maximum number of elements returned per stream
+   * @param block duration for which we want to block before timing out
+   * @param stream pair that contains stream ID and the last ID that the consumer received for that stream
+   * @param streams rest of the pairs
+   * @return complete entries with an ID greater than the last received ID per stream.
+   */
   final def xRead(count: Option[Long] = None, block: Option[Duration] = None)(
     stream: (String, String),
     streams: (String, String)*
   ): ZIO[RedisExecutor, RedisError, Map[String, Map[String, Map[String, String]]]] =
     XRead.run((count.map(Count), block, (stream, Chunk.fromIterable(streams))))
 
+  /**
+   * Read data from one or multiple streams using consumer group.
+   *
+   * @param group ID of the consumer group
+   * @param consumer ID of the consumer
+   * @param count maximum number of elements returned per stream
+   * @param block duration for which we want to block before timing out
+   * @param noAck flag that indicates that the read messages shouldn't be added to the pending entries list (PEL)
+   * @param stream pair that contains stream ID and the last ID that the consumer received for that stream
+   * @param streams rest of the pairs
+   * @return complete entries with an ID greater than the last received ID per stream.
+   */
   final def xReadGroup(
     group: String,
     consumer: String,
@@ -161,6 +336,14 @@ trait Streams {
       )
     )
 
+  /**
+   * Fetches the stream entries matching a given range of IDs in the reverse order.
+   *
+   * @param key ID of the stream
+   * @param end end of the range of IDs
+   * @param start start of the range of IDs
+   * @return the complete entries with IDs matching the specified range in the reverse order.
+   */
   final def xRevRange(
     key: String,
     end: String,
@@ -168,6 +351,15 @@ trait Streams {
   ): ZIO[RedisExecutor, RedisError, Map[String, Map[String, String]]] =
     XRevRange.run((key, end, start, None))
 
+  /**
+   * Fetches the stream entries matching a given range of IDs in the reverse order.
+   *
+   * @param key ID of the stream
+   * @param end end of the range of IDs
+   * @param start start of the range of IDs
+   * @param count maximum number of entries returned
+   * @return the complete entries with IDs matching the specified range in the reverse order.
+   */
   final def xRevRange(
     key: String,
     end: String,
@@ -176,6 +368,14 @@ trait Streams {
   ): ZIO[RedisExecutor, RedisError, Map[String, Map[String, String]]] =
     XRevRange.run((key, end, start, Some(Count(count))))
 
+  /**
+   * Trims the stream to a given number of items, evicting older items (items with lower IDs) if needed.
+   *
+   * @param key ID of the stream
+   * @param count stream length
+   * @param approximate flag that indicates if the stream length should be exactly count or few tens of entries more
+   * @return the number of entries deleted from the stream.
+   */
   final def xTrim(key: String, count: Long, approximate: Boolean = false): ZIO[RedisExecutor, RedisError, Long] =
     XTrim.run((key, MaxLen(approximate, count)))
 }

--- a/redis/src/main/scala/zio/redis/api/Streams.scala
+++ b/redis/src/main/scala/zio/redis/api/Streams.scala
@@ -91,7 +91,7 @@ trait Streams {
   final def xGroupSetId(key: String, group: String, id: String): ZIO[RedisExecutor, RedisError, Unit] =
     XGroupSetId.run(SetId(key, group, id))
 
-  final def xGroupDestroy(key: String, group: String): ZIO[RedisExecutor, RedisError, Long] =
+  final def xGroupDestroy(key: String, group: String): ZIO[RedisExecutor, RedisError, Boolean] =
     XGroupDestroy.run(Destroy(key, group))
 
   final def xGroupCreateConsumer(key: String, group: String, consumer: String): ZIO[RedisExecutor, RedisError, Unit] =
@@ -229,7 +229,7 @@ private object Streams {
 
   final val XGroupSetId = RedisCommand("XGROUP", XGroupSetIdInput, UnitOutput)
 
-  final val XGroupDestroy = RedisCommand("XGROUP", XGroupDestroyInput, LongOutput)
+  final val XGroupDestroy = RedisCommand("XGROUP", XGroupDestroyInput, BoolOutput)
 
   final val XGroupCreateConsumer = RedisCommand("XGROUP", XGroupCreateConsumerInput, UnitOutput)
 

--- a/redis/src/main/scala/zio/redis/api/Streams.scala
+++ b/redis/src/main/scala/zio/redis/api/Streams.scala
@@ -144,7 +144,9 @@ trait Streams {
   ): ZIO[RedisExecutor, RedisError, Map[String, Map[String, Map[String, String]]]] =
     XRead.run((count.map(Count), block, (stream, Chunk.fromIterable(streams))))
 
-  final def xReadGroup(group: String, consumer: String)(
+  final def xReadGroup(
+    group: String,
+    consumer: String,
     count: Option[Long] = None,
     block: Option[Duration] = None,
     noAck: Boolean = false

--- a/redis/src/main/scala/zio/redis/api/Streams.scala
+++ b/redis/src/main/scala/zio/redis/api/Streams.scala
@@ -22,11 +22,7 @@ trait Streams {
   ): ZIO[RedisExecutor, RedisError, String] =
     XAdd.run((key, None, id, (pair, pairs.toList)))
 
-  final def xAddWithMaxLen(
-    key: String,
-    id: String,
-    count: Long,
-    approximate: Boolean,
+  final def xAddWithMaxLen(key: String, id: String, count: Long, approximate: Boolean = false)(
     pair: (String, String),
     pairs: (String, String)*
   ): ZIO[RedisExecutor, RedisError, String] =

--- a/redis/src/main/scala/zio/redis/options/Streams.scala
+++ b/redis/src/main/scala/zio/redis/options/Streams.scala
@@ -33,8 +33,8 @@ trait Streams {
 
   case class PendingInfo(
     total: Long,
-    first: String,
-    last: String,
+    first: Option[String],
+    last: Option[String],
     consumers: Map[String, Long]
   )
 

--- a/redis/src/main/scala/zio/redis/package.scala
+++ b/redis/src/main/scala/zio/redis/package.scala
@@ -10,6 +10,7 @@ package object redis
     with api.Sets
     with api.Strings
     with api.SortedSets
+    with api.Streams
     with options.Geo
     with options.Keys
     with options.Shared

--- a/redis/src/test/scala/zio/redis/ApiSpec.scala
+++ b/redis/src/test/scala/zio/redis/ApiSpec.scala
@@ -13,7 +13,8 @@ object ApiSpec
     with StringsSpec
     with GeoSpec
     with HyperLogLogSpec
-    with HashSpec {
+    with HashSpec
+    with StreamsSpec {
 
   def spec =
     suite("Redis commands")(
@@ -26,7 +27,8 @@ object ApiSpec
         stringsSuite,
         geoSuite,
         hyperLogLogSuite,
-        hashSuite
+        hashSuite,
+        streamsSuite
       ).provideCustomLayerShared(Logging.ignore >>> Executor ++ Clock.live),
       suite("Test Executor")(
         connectionSuite,

--- a/redis/src/test/scala/zio/redis/StreamsSpec.scala
+++ b/redis/src/test/scala/zio/redis/StreamsSpec.scala
@@ -1,11 +1,11 @@
 package zio.redis
 
 import zio.Chunk
+import zio.duration._
 import zio.redis.RedisError._
 import zio.test.Assertion._
-import zio.test._
-import zio.duration._
 import zio.test.TestAspect.ignore
+import zio.test._
 
 trait StreamsSpec extends BaseSpec {
   val streamsSuite =

--- a/redis/src/test/scala/zio/redis/StreamsSpec.scala
+++ b/redis/src/test/scala/zio/redis/StreamsSpec.scala
@@ -1,10 +1,11 @@
 package zio.redis
 
 import zio.Chunk
-import zio.redis.RedisError.{ NoGroup, ProtocolError, WrongType }
+import zio.redis.RedisError.{ BusyGroup, NoGroup, ProtocolError, WrongType }
 import zio.test.Assertion._
 import zio.test._
 import zio.duration._
+import zio.test.TestAspect.ignore
 
 trait StreamsSpec extends BaseSpec {
   val streamsSuite =
@@ -511,6 +512,202 @@ trait StreamsSpec extends BaseSpec {
             stream <- uuid
             _      <- set(stream, "value")
             result <- xDel(stream, "1-0").either
+          } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
+        }
+      ),
+      suite("xGroupCreate")(
+        testM("new group") {
+          for {
+            stream <- uuid
+            group  <- uuid
+            result <- xGroupCreate(stream, group, "$", mkStream = true).either
+          } yield assert(result)(isRight)
+        },
+        testM("error when stream doesn't exist") {
+          for {
+            stream <- uuid
+            group  <- uuid
+            result <- xGroupCreate(stream, group, "$").either
+          } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
+        },
+        testM("error when invalid ID") {
+          for {
+            stream <- uuid
+            group  <- uuid
+            id     <- uuid
+            result <- xGroupCreate(stream, group, id, mkStream = true).either
+          } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
+        },
+        testM("error when group already exists") {
+          for {
+            stream <- uuid
+            group  <- uuid
+            _      <- xGroupCreate(stream, group, "$", mkStream = true)
+            result <- xGroupCreate(stream, group, "$").either
+          } yield assert(result)(isLeft(isSubtype[BusyGroup](anything)))
+        },
+        testM("error when not stream") {
+          for {
+            stream <- uuid
+            group  <- uuid
+            _      <- set(stream, "value")
+            result <- xGroupCreate(stream, group, "$").either
+          } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
+        }
+      ),
+      suite("xGroupSetId")(
+        testM("for an existing group and message") {
+          for {
+            stream <- uuid
+            group  <- uuid
+            id     <- xAdd(stream, "*", "a" -> "b")
+            _      <- xGroupCreate(stream, group, "$")
+            result <- xGroupSetId(stream, group, id).either
+          } yield assert(result)(isRight)
+        },
+        testM("error when non-existent group and an existing message") {
+          for {
+            stream <- uuid
+            group  <- uuid
+            id     <- xAdd(stream, "*", "a" -> "b")
+            result <- xGroupSetId(stream, group, id).either
+          } yield assert(result)(isLeft(isSubtype[NoGroup](anything)))
+        },
+        testM("error when an invalid id") {
+          for {
+            stream <- uuid
+            group  <- uuid
+            id     <- uuid
+            result <- xGroupSetId(stream, group, id).either
+          } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
+        },
+        testM("error when not stream") {
+          for {
+            stream <- uuid
+            group  <- uuid
+            result <- xGroupSetId(stream, group, "1-0").either
+          } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
+        }
+      ),
+      suite("xGroupDestroy")(
+        testM("an existing consumer group") {
+          for {
+            stream <- uuid
+            group  <- uuid
+            _      <- xGroupCreate(stream, group, "$", mkStream = true)
+            result <- xGroupDestroy(stream, group)
+          } yield assert(result)(isTrue)
+        },
+        testM("non-existent consumer group") {
+          for {
+            stream <- uuid
+            group  <- uuid
+            _      <- xAdd(stream, "*", "a" -> "b")
+            result <- xGroupDestroy(stream, group)
+          } yield assert(result)(isFalse)
+        },
+        testM("error when stream doesn't exist") {
+          for {
+            stream <- uuid
+            group  <- uuid
+            result <- xGroupDestroy(stream, group).either
+          } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
+        },
+        testM("error when not stream") {
+          for {
+            stream <- uuid
+            group  <- uuid
+            _      <- set(stream, "value")
+            result <- xGroupDestroy(stream, group).either
+          } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
+        }
+      ),
+      // TODO: unignore when docker image for redis 6.2 comes out
+      suite("xGroupCreateConsumer")(
+        testM("new consumer") {
+          for {
+            stream   <- uuid
+            group    <- uuid
+            consumer <- uuid
+            _        <- xGroupCreate(stream, group, "$", mkStream = true)
+            result   <- xGroupCreateConsumer(stream, group, consumer).either
+          } yield assert(result)(isRight)
+        },
+        testM("error when group doesn't exist") {
+          for {
+            stream   <- uuid
+            group    <- uuid
+            consumer <- uuid
+            result   <- xGroupCreateConsumer(stream, group, consumer).either
+          } yield assert(result)(isLeft)
+        },
+        testM("error when not stream") {
+          for {
+            stream   <- uuid
+            group    <- uuid
+            consumer <- uuid
+            _        <- set(stream, "value")
+            result   <- xGroupCreateConsumer(stream, group, consumer).either
+          } yield assert(result)(isLeft)
+        }
+      ) @@ ignore,
+      suite("xGroupDelConsumer")(
+        testM("non-existing consumer") {
+          for {
+            stream   <- uuid
+            group    <- uuid
+            consumer <- uuid
+            _        <- xGroupCreate(stream, group, "$", mkStream = true)
+            result   <- xGroupDelConsumer(stream, group, consumer)
+          } yield assert(result)(equalTo(0L))
+        },
+        testM("existing consumer with one pending message") {
+          for {
+            stream   <- uuid
+            group    <- uuid
+            consumer <- uuid
+            _        <- xGroupCreate(stream, group, "$", mkStream = true)
+            _        <- xAdd(stream, "*", "a" -> "b")
+            _        <- xReadGroup(group, consumer)(stream -> ">")
+            result   <- xGroupDelConsumer(stream, group, consumer)
+          } yield assert(result)(equalTo(1L))
+        },
+        testM("existing consumer with multiple pending message") {
+          for {
+            stream   <- uuid
+            group    <- uuid
+            consumer <- uuid
+            _        <- xGroupCreate(stream, group, "$", mkStream = true)
+            _        <- xAdd(stream, "*", "a" -> "b")
+            _        <- xAdd(stream, "*", "a" -> "b")
+            _        <- xReadGroup(group, consumer)(stream -> ">")
+            result   <- xGroupDelConsumer(stream, group, consumer)
+          } yield assert(result)(equalTo(2L))
+        },
+        testM("error when stream doesn't exist") {
+          for {
+            stream   <- uuid
+            group    <- uuid
+            consumer <- uuid
+            result   <- xGroupDelConsumer(stream, group, consumer).either
+          } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
+        },
+        testM("error when group doesn't exist") {
+          for {
+            stream   <- uuid
+            group    <- uuid
+            consumer <- uuid
+            _        <- xAdd(stream, "*", "a" -> "b")
+            result   <- xGroupDelConsumer(stream, group, consumer).either
+          } yield assert(result)(isLeft(isSubtype[NoGroup](anything)))
+        },
+        testM("error when not stream") {
+          for {
+            stream   <- uuid
+            group    <- uuid
+            consumer <- uuid
+            _        <- set(stream, "value")
+            result   <- xGroupDelConsumer(stream, group, consumer).either
           } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
         }
       )

--- a/redis/src/test/scala/zio/redis/StreamsSpec.scala
+++ b/redis/src/test/scala/zio/redis/StreamsSpec.scala
@@ -1,0 +1,71 @@
+package zio.redis
+
+import zio.test.Assertion._
+import zio.test._
+
+trait StreamsSpec extends BaseSpec {
+  val streamsSuite =
+    suite("streams")(
+      suite("xAck")(
+        testM("one message") {
+          for {
+            stream   <- uuid
+            group    <- uuid
+            consumer <- uuid
+            _        <- xGroupCreate(stream, group, "$", mkStream = true)
+            id       <- xAdd(stream, "*", "name" -> "Sara", "surname" -> "OConnor")
+            _        <- xReadGroup(group, consumer)(stream -> ">")
+            result   <- xAck(stream, group, id)
+          } yield assert(result)(equalTo(1L))
+        },
+        testM("multiple messages") {
+          for {
+            stream   <- uuid
+            group    <- uuid
+            consumer <- uuid
+            _        <- xGroupCreate(stream, group, "$", mkStream = true)
+            first    <- xAdd(stream, "*", "name" -> "Sara", "surname" -> "OConnor")
+            second   <- xAdd(stream, "*", "name" -> "Sara", "surname" -> "OConnor")
+            _        <- xReadGroup(group, consumer)(stream -> ">")
+            result   <- xAck(stream, group, first, second)
+          } yield assert(result)(equalTo(2L))
+        },
+        testM("when stream doesn't exist") {
+          for {
+            stream <- uuid
+            group  <- uuid
+            id     <- uuid
+            result <- xAck(stream, group, id)
+          } yield assert(result)(equalTo(0L))
+        },
+        testM("when group doesn't exist") {
+          for {
+            stream <- uuid
+            group  <- uuid
+            id     <- xAdd(stream, "*", "name" -> "Sara", "surname" -> "OConnor")
+            result <- xAck(stream, group, id)
+          } yield assert(result)(equalTo(0L))
+        },
+        testM("when message with the given ID doesn't exist") {
+          for {
+            stream   <- uuid
+            group    <- uuid
+            consumer <- uuid
+            _        <- xGroupCreate(stream, group, "$", mkStream = true)
+            _        <- xAdd(stream, "*", "name" -> "Sara", "surname" -> "OConnor")
+            _        <- xReadGroup(group, consumer)(stream -> ">")
+            result   <- xAck(stream, group, "0-0")
+          } yield assert(result)(equalTo(0L))
+        },
+        testM("error when ID has an invalid format") {
+          for {
+            stream <- uuid
+            group  <- uuid
+            id     <- uuid
+            _      <- xGroupCreate(stream, group, "$", mkStream = true)
+            result <- xAck(stream, group, id).either
+          } yield assert(result)(isLeft)
+        }
+      )
+    )
+}

--- a/redis/src/test/scala/zio/redis/StreamsSpec.scala
+++ b/redis/src/test/scala/zio/redis/StreamsSpec.scala
@@ -309,11 +309,11 @@ trait StreamsSpec extends BaseSpec {
         },
         testM("when not stream") {
           for {
-            stream   <- uuid
-            group    <- uuid
-            consumer <- uuid
-            _        <- set(stream, "value")
-            result   <- xClaim(stream, group, consumer, 0.millis, force = true)("1-0").either
+            nonStream <- uuid
+            group     <- uuid
+            consumer  <- uuid
+            _         <- set(nonStream, "value")
+            result    <- xClaim(nonStream, group, consumer, 0.millis, force = true)("1-0").either
           } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
@@ -478,11 +478,11 @@ trait StreamsSpec extends BaseSpec {
         },
         testM("when not stream") {
           for {
-            stream   <- uuid
-            group    <- uuid
-            consumer <- uuid
-            _        <- set(stream, "value")
-            result   <- xClaimWithJustId(stream, group, consumer, 0.millis, force = true)("1-0").either
+            nonStream <- uuid
+            group     <- uuid
+            consumer  <- uuid
+            _         <- set(nonStream, "value")
+            result    <- xClaimWithJustId(nonStream, group, consumer, 0.millis, force = true)("1-0").either
           } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
@@ -509,9 +509,9 @@ trait StreamsSpec extends BaseSpec {
         },
         testM("error when not stream") {
           for {
-            stream <- uuid
-            _      <- set(stream, "value")
-            result <- xDel(stream, "1-0").either
+            nonStream <- uuid
+            _         <- set(nonStream, "value")
+            result    <- xDel(nonStream, "1-0").either
           } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
@@ -548,10 +548,10 @@ trait StreamsSpec extends BaseSpec {
         },
         testM("error when not stream") {
           for {
-            stream <- uuid
-            group  <- uuid
-            _      <- set(stream, "value")
-            result <- xGroupCreate(stream, group, "$").either
+            nonStream <- uuid
+            group     <- uuid
+            _         <- set(nonStream, "value")
+            result    <- xGroupCreate(nonStream, group, "$").either
           } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
@@ -583,9 +583,9 @@ trait StreamsSpec extends BaseSpec {
         },
         testM("error when not stream") {
           for {
-            stream <- uuid
-            group  <- uuid
-            result <- xGroupSetId(stream, group, "1-0").either
+            nonStream <- uuid
+            group     <- uuid
+            result    <- xGroupSetId(nonStream, group, "1-0").either
           } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
         }
       ),
@@ -615,10 +615,10 @@ trait StreamsSpec extends BaseSpec {
         },
         testM("error when not stream") {
           for {
-            stream <- uuid
-            group  <- uuid
-            _      <- set(stream, "value")
-            result <- xGroupDestroy(stream, group).either
+            nonStream <- uuid
+            group     <- uuid
+            _         <- set(nonStream, "value")
+            result    <- xGroupDestroy(nonStream, group).either
           } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
@@ -643,11 +643,11 @@ trait StreamsSpec extends BaseSpec {
         },
         testM("error when not stream") {
           for {
-            stream   <- uuid
-            group    <- uuid
-            consumer <- uuid
-            _        <- set(stream, "value")
-            result   <- xGroupCreateConsumer(stream, group, consumer).either
+            nonStream <- uuid
+            group     <- uuid
+            consumer  <- uuid
+            _         <- set(nonStream, "value")
+            result    <- xGroupCreateConsumer(nonStream, group, consumer).either
           } yield assert(result)(isLeft)
         }
       ) @@ ignore,
@@ -703,11 +703,11 @@ trait StreamsSpec extends BaseSpec {
         },
         testM("error when not stream") {
           for {
-            stream   <- uuid
-            group    <- uuid
-            consumer <- uuid
-            _        <- set(stream, "value")
-            result   <- xGroupDelConsumer(stream, group, consumer).either
+            nonStream <- uuid
+            group     <- uuid
+            consumer  <- uuid
+            _         <- set(nonStream, "value")
+            result    <- xGroupDelConsumer(nonStream, group, consumer).either
           } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
@@ -729,9 +729,9 @@ trait StreamsSpec extends BaseSpec {
         },
         testM("error when not stream") {
           for {
-            stream <- uuid
-            _      <- set(stream, "value")
-            result <- xLen(stream).either
+            nonStream <- uuid
+            _         <- set(nonStream, "value")
+            result    <- xLen(nonStream).either
           } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
@@ -753,7 +753,7 @@ trait StreamsSpec extends BaseSpec {
             id       <- xAdd(stream, "*", "a" -> "b")
             _        <- xReadGroup(group, consumer)(stream -> ">")
             result   <- xPending(stream, group)
-          } yield assert(result)(equalTo(PendingInfo(1L, Some(id), Some(id), Map[String, Long](consumer -> 1L))))
+          } yield assert(result)(equalTo(PendingInfo(1L, Some(id), Some(id), Map(consumer -> 1L))))
         },
         testM("with multiple consumers and multiple messages") {
           for {
@@ -768,7 +768,7 @@ trait StreamsSpec extends BaseSpec {
             _        <- xReadGroup(group, second)(stream -> ">")
             result   <- xPending(stream, group)
           } yield assert(result)(
-            equalTo(PendingInfo(2L, Some(firstMsg), Some(lastMsg), Map[String, Long](first -> 1L, second -> 1L)))
+            equalTo(PendingInfo(2L, Some(firstMsg), Some(lastMsg), Map(first -> 1L, second -> 1L)))
           )
         },
         // TODO: unignore when redis docker image version 6.2 comes out
@@ -781,7 +781,7 @@ trait StreamsSpec extends BaseSpec {
             id       <- xAdd(stream, "*", "a" -> "b")
             _        <- xReadGroup(group, consumer)(stream -> ">")
             result   <- xPending(stream, group, 0.millis)
-          } yield assert(result)(equalTo(PendingInfo(1L, Some(id), Some(id), Map[String, Long](consumer -> 1L))))
+          } yield assert(result)(equalTo(PendingInfo(1L, Some(id), Some(id), Map(consumer -> 1L))))
         } @@ ignore,
         testM("with 60s idle time") {
           for {
@@ -804,10 +804,10 @@ trait StreamsSpec extends BaseSpec {
         },
         testM("error when not stream") {
           for {
-            stream <- uuid
-            group  <- uuid
-            _      <- set(stream, "value")
-            result <- xPending(stream, group).either
+            nonStream <- uuid
+            group     <- uuid
+            _         <- set(nonStream, "value")
+            result    <- xPending(nonStream, group).either
           } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
         },
         testM("with one message unlimited start, unlimited end and count with value 10") {
@@ -867,6 +867,65 @@ trait StreamsSpec extends BaseSpec {
             assert(result.owner)(equalTo(first)) &&
             assert(result.lastDelivered)(isGreaterThan(0.millis)) &&
             assert(result.counter)(equalTo(1L))
+        },
+        testM("error when invalid ID") {
+          for {
+            stream <- uuid
+            group  <- uuid
+            result <- xPending(stream, group, "-", "invalid", 10L).either
+          } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
+        }
+      ),
+      suite("xRange")(
+        testM("with an unlimited start and an unlimited end") {
+          for {
+            stream <- uuid
+            id     <- xAdd(stream, "*", "a" -> "b")
+            result <- xRange(stream, "-", "+")
+          } yield assert(result)(equalTo(Map(id -> Map("a" -> "b"))))
+        },
+        testM("with the positive count") {
+          for {
+            stream <- uuid
+            first  <- xAdd(stream, "*", "a" -> "b")
+            _      <- xAdd(stream, "*", "a" -> "b")
+            result <- xRange(stream, "-", "+", 1L)
+          } yield assert(result)(equalTo(Map(first -> Map("a" -> "b"))))
+        },
+        testM("with the negative count") {
+          for {
+            stream <- uuid
+            _      <- xAdd(stream, "*", "a" -> "b")
+            _      <- xAdd(stream, "*", "a" -> "b")
+            result <- xRange(stream, "-", "+", -1L)
+          } yield assert(result)(isEmpty)
+        },
+        testM("with the zero count") {
+          for {
+            stream <- uuid
+            _      <- xAdd(stream, "*", "a" -> "b")
+            _      <- xAdd(stream, "*", "a" -> "b")
+            result <- xRange(stream, "-", "+", 0L)
+          } yield assert(result)(isEmpty)
+        },
+        testM("when stream doesn't exist") {
+          for {
+            stream <- uuid
+            result <- xRange(stream, "-", "+")
+          } yield assert(result)(isEmpty)
+        },
+        testM("error when invalid ID") {
+          for {
+            stream <- uuid
+            result <- xRange(stream, "invalid", "+").either
+          } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
+        },
+        testM("error when not stream") {
+          for {
+            nonStream <- uuid
+            _         <- set(nonStream, "value")
+            result    <- xRange(nonStream, "-", "+").either
+          } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
         }
       )
     )

--- a/redis/src/test/scala/zio/redis/StreamsSpec.scala
+++ b/redis/src/test/scala/zio/redis/StreamsSpec.scala
@@ -1,8 +1,10 @@
 package zio.redis
 
-import zio.redis.RedisError.{ ProtocolError, WrongType }
+import zio.Chunk
+import zio.redis.RedisError.{ NoGroup, ProtocolError, WrongType }
 import zio.test.Assertion._
 import zio.test._
+import zio.duration._
 
 trait StreamsSpec extends BaseSpec {
   val streamsSuite =
@@ -14,7 +16,7 @@ trait StreamsSpec extends BaseSpec {
             group    <- uuid
             consumer <- uuid
             _        <- xGroupCreate(stream, group, "$", mkStream = true)
-            id       <- xAdd(stream, "*", "name" -> "Sara")
+            id       <- xAdd(stream, "*", "a" -> "b")
             _        <- xReadGroup(group, consumer)(stream -> ">")
             result   <- xAck(stream, group, id)
           } yield assert(result)(equalTo(1L))
@@ -25,8 +27,8 @@ trait StreamsSpec extends BaseSpec {
             group    <- uuid
             consumer <- uuid
             _        <- xGroupCreate(stream, group, "$", mkStream = true)
-            first    <- xAdd(stream, "*", "name" -> "Sara")
-            second   <- xAdd(stream, "*", "name" -> "Sara")
+            first    <- xAdd(stream, "*", "a" -> "b")
+            second   <- xAdd(stream, "*", "a" -> "b")
             _        <- xReadGroup(group, consumer)(stream -> ">")
             result   <- xAck(stream, group, first, second)
           } yield assert(result)(equalTo(2L))
@@ -43,7 +45,7 @@ trait StreamsSpec extends BaseSpec {
           for {
             stream <- uuid
             group  <- uuid
-            id     <- xAdd(stream, "*", "name" -> "Sara")
+            id     <- xAdd(stream, "*", "a" -> "b")
             result <- xAck(stream, group, id)
           } yield assert(result)(equalTo(0L))
         },
@@ -53,7 +55,7 @@ trait StreamsSpec extends BaseSpec {
             group    <- uuid
             consumer <- uuid
             _        <- xGroupCreate(stream, group, "$", mkStream = true)
-            _        <- xAdd(stream, "*", "name" -> "Sara")
+            _        <- xAdd(stream, "*", "a" -> "b")
             _        <- xReadGroup(group, consumer)(stream -> ">")
             result   <- xAck(stream, group, "0-0")
           } yield assert(result)(equalTo(0L))
@@ -82,28 +84,28 @@ trait StreamsSpec extends BaseSpec {
           for {
             stream <- uuid
             id      = "1-0"
-            result <- xAdd(stream, id, "name" -> "Sara")
+            result <- xAdd(stream, id, "a" -> "b")
           } yield assert(result)(equalTo(id))
         },
         testM("object with multiple fields") {
           for {
             stream <- uuid
             id      = "1-0"
-            result <- xAdd(stream, id, "name" -> "Sara", "surname" -> "OConnor")
+            result <- xAdd(stream, id, "a" -> "b", "c" -> "d")
           } yield assert(result)(equalTo(id))
         },
         testM("error when ID should be greater") {
           for {
             stream <- uuid
             id      = "0-0"
-            result <- xAdd(stream, id, "name" -> "Sara").either
+            result <- xAdd(stream, id, "a" -> "b").either
           } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
         },
         testM("error when invalid ID format") {
           for {
             stream <- uuid
             id     <- uuid
-            result <- xAdd(stream, id, "name" -> "Sara").either
+            result <- xAdd(stream, id, "a" -> "b").either
           } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
         },
         testM("error when not stream") {
@@ -111,7 +113,7 @@ trait StreamsSpec extends BaseSpec {
             nonStream <- uuid
             id         = "1-0"
             _         <- set(nonStream, "value")
-            result    <- xAdd(nonStream, id, "name" -> "Sara").either
+            result    <- xAdd(nonStream, id, "a" -> "b").either
           } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
@@ -120,29 +122,367 @@ trait StreamsSpec extends BaseSpec {
           for {
             stream <- uuid
             id      = "1-0"
-            result <- xAddWithMaxLen(stream, id, 10)("name" -> "Sara")
+            result <- xAddWithMaxLen(stream, id, 10)("a" -> "b")
           } yield assert(result)(equalTo(id))
         },
         testM("with positive count and with approximate") {
           for {
             stream <- uuid
             id      = "1-0"
-            result <- xAddWithMaxLen(stream, id, 10, approximate = true)("name" -> "Sara")
+            result <- xAddWithMaxLen(stream, id, 10, approximate = true)("a" -> "b")
           } yield assert(result)(equalTo(id))
         },
         testM("error with negative count and without approximate") {
           for {
             stream <- uuid
             id      = "1-0"
-            result <- xAddWithMaxLen(stream, id, -10)("name" -> "Sara").either
+            result <- xAddWithMaxLen(stream, id, -10)("a" -> "b").either
           } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
         },
         testM("error with negative count and with approximate") {
           for {
             stream <- uuid
             id      = "1-0"
-            result <- xAddWithMaxLen(stream, id, -10, approximate = true)("name" -> "Sara").either
+            result <- xAddWithMaxLen(stream, id, -10, approximate = true)("a" -> "b").either
           } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
+        }
+      ),
+      suite("xClaim")(
+        testM("one pending message") {
+          for {
+            stream <- uuid
+            group  <- uuid
+            first  <- uuid
+            second <- uuid
+            _      <- xGroupCreate(stream, group, "$", mkStream = true)
+            id     <- xAdd(stream, "*", "a" -> "b")
+            _      <- xReadGroup(group, first)(stream -> ">")
+            result <- xClaim(stream, group, second, 0.millis)(id)
+          } yield assert(result)(equalTo(Map(id -> Map("a" -> "b"))))
+        },
+        testM("multiple pending messages") {
+          for {
+            stream <- uuid
+            group  <- uuid
+            first  <- uuid
+            second <- uuid
+            _      <- xGroupCreate(stream, group, "$", mkStream = true)
+            id     <- xAdd(stream, "*", "a" -> "b")
+            id1    <- xAdd(stream, "*", "c" -> "d", "e" -> "f")
+            _      <- xReadGroup(group, first)(stream -> ">")
+            result <- xClaim(stream, group, second, 0.millis)(id, id1)
+          } yield assert(result)(equalTo(Map(id -> Map("a" -> "b"), id1 -> Map("c" -> "d", "e" -> "f"))))
+        },
+        testM("non-existent message") {
+          for {
+            stream   <- uuid
+            group    <- uuid
+            consumer <- uuid
+            _        <- xGroupCreate(stream, group, "$", mkStream = true)
+            result   <- xClaim(stream, group, consumer, 0.millis)("1-0")
+          } yield assert(result)(isEmpty)
+        },
+        testM("existing message that is not in pending state") {
+          for {
+            stream <- uuid
+            group  <- uuid
+            second <- uuid
+            _      <- xGroupCreate(stream, group, "$", mkStream = true)
+            id     <- xAdd(stream, "*", "a" -> "b")
+            result <- xClaim(stream, group, second, 0.millis)(id)
+          } yield assert(result)(isEmpty)
+        },
+        testM("with non-existent group") {
+          for {
+            stream   <- uuid
+            group    <- uuid
+            consumer <- uuid
+            result   <- xClaim(stream, group, consumer, 0.millis)("1-0").either
+          } yield assert(result)(isLeft(isSubtype[NoGroup](anything)))
+        },
+        testM("with positive min idle time") {
+          for {
+            stream <- uuid
+            group  <- uuid
+            first  <- uuid
+            second <- uuid
+            _      <- xGroupCreate(stream, group, "$", mkStream = true)
+            id     <- xAdd(stream, "*", "a" -> "b")
+            _      <- xReadGroup(group, first)(stream -> ">")
+            result <- xClaim(stream, group, second, 360000.millis)(id)
+          } yield assert(result)(isEmpty)
+        },
+        testM("with negative min idle time") {
+          for {
+            stream <- uuid
+            group  <- uuid
+            first  <- uuid
+            second <- uuid
+            _      <- xGroupCreate(stream, group, "$", mkStream = true)
+            id     <- xAdd(stream, "*", "a" -> "b")
+            _      <- xReadGroup(group, first)(stream -> ">")
+            result <- xClaim(stream, group, second, (-360000).millis)(id)
+          } yield assert(result)(equalTo(Map(id -> Map("a" -> "b"))))
+        },
+        testM("with positive idle time") {
+          for {
+            stream <- uuid
+            group  <- uuid
+            first  <- uuid
+            second <- uuid
+            _      <- xGroupCreate(stream, group, "$", mkStream = true)
+            id     <- xAdd(stream, "*", "a" -> "b")
+            _      <- xReadGroup(group, first)(stream -> ">")
+            result <- xClaim(stream, group, second, 0.millis, Some(360000.millis))(id)
+          } yield assert(result)(equalTo(Map(id -> Map("a" -> "b"))))
+        },
+        testM("with negative idle time") {
+          for {
+            stream <- uuid
+            group  <- uuid
+            first  <- uuid
+            second <- uuid
+            _      <- xGroupCreate(stream, group, "$", mkStream = true)
+            id     <- xAdd(stream, "*", "a" -> "b")
+            _      <- xReadGroup(group, first)(stream -> ">")
+            result <- xClaim(stream, group, second, 0.millis, Some((-360000).millis))(id)
+          } yield assert(result)(equalTo(Map(id -> Map("a" -> "b"))))
+        },
+        testM("with positive time") {
+          for {
+            stream <- uuid
+            group  <- uuid
+            first  <- uuid
+            second <- uuid
+            _      <- xGroupCreate(stream, group, "$", mkStream = true)
+            id     <- xAdd(stream, "*", "a" -> "b")
+            _      <- xReadGroup(group, first)(stream -> ">")
+            result <- xClaim(stream, group, second, 0.millis, time = Some(360000.millis))(id)
+          } yield assert(result)(equalTo(Map(id -> Map("a" -> "b"))))
+        },
+        testM("with negative time") {
+          for {
+            stream <- uuid
+            group  <- uuid
+            first  <- uuid
+            second <- uuid
+            _      <- xGroupCreate(stream, group, "$", mkStream = true)
+            id     <- xAdd(stream, "*", "a" -> "b")
+            _      <- xReadGroup(group, first)(stream -> ">")
+            result <- xClaim(stream, group, second, 0.millis, time = Some((-360000).millis))(id)
+          } yield assert(result)(equalTo(Map(id -> Map("a" -> "b"))))
+        },
+        testM("with positive retry count") {
+          for {
+            stream <- uuid
+            group  <- uuid
+            first  <- uuid
+            second <- uuid
+            _      <- xGroupCreate(stream, group, "$", mkStream = true)
+            id     <- xAdd(stream, "*", "a" -> "b")
+            _      <- xReadGroup(group, first)(stream -> ">")
+            result <- xClaim(stream, group, second, 0.millis, retryCount = Some(3))(id)
+          } yield assert(result)(equalTo(Map(id -> Map("a" -> "b"))))
+        },
+        testM("with negative retry count") {
+          for {
+            stream <- uuid
+            group  <- uuid
+            first  <- uuid
+            second <- uuid
+            _      <- xGroupCreate(stream, group, "$", mkStream = true)
+            id     <- xAdd(stream, "*", "a" -> "b")
+            _      <- xReadGroup(group, first)(stream -> ">")
+            result <- xClaim(stream, group, second, 0.millis, retryCount = Some(-3))(id)
+          } yield assert(result)(equalTo(Map(id -> Map("a" -> "b"))))
+        },
+        testM("with force when message is not in the pending state") {
+          for {
+            stream   <- uuid
+            group    <- uuid
+            consumer <- uuid
+            _        <- xGroupCreate(stream, group, "$", mkStream = true)
+            id       <- xAdd(stream, "*", "a" -> "b")
+            result   <- xClaim(stream, group, consumer, 0.millis, force = true)(id)
+          } yield assert(result)(equalTo(Map(id -> Map("a" -> "b"))))
+        },
+        testM("when not stream") {
+          for {
+            stream   <- uuid
+            group    <- uuid
+            consumer <- uuid
+            _        <- set(stream, "value")
+            result   <- xClaim(stream, group, consumer, 0.millis, force = true)("1-0").either
+          } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
+        }
+      ),
+      suite("xClaimWithJustId")(
+        testM("one pending message") {
+          for {
+            stream <- uuid
+            group  <- uuid
+            first  <- uuid
+            second <- uuid
+            _      <- xGroupCreate(stream, group, "$", mkStream = true)
+            id     <- xAdd(stream, "*", "a" -> "b")
+            _      <- xReadGroup(group, first)(stream -> ">")
+            result <- xClaimWithJustId(stream, group, second, 0.millis)(id)
+          } yield assert(result)(hasSameElements(Chunk.single(id)))
+        },
+        testM("multiple pending messages") {
+          for {
+            stream <- uuid
+            group  <- uuid
+            first  <- uuid
+            second <- uuid
+            _      <- xGroupCreate(stream, group, "$", mkStream = true)
+            id     <- xAdd(stream, "*", "a" -> "b")
+            id1    <- xAdd(stream, "*", "c" -> "d", "e" -> "f")
+            _      <- xReadGroup(group, first)(stream -> ">")
+            result <- xClaimWithJustId(stream, group, second, 0.millis)(id, id1)
+          } yield assert(result)(hasSameElements(Chunk(id, id1)))
+        },
+        testM("non-existent message") {
+          for {
+            stream   <- uuid
+            group    <- uuid
+            consumer <- uuid
+            _        <- xGroupCreate(stream, group, "$", mkStream = true)
+            result   <- xClaimWithJustId(stream, group, consumer, 0.millis)("1-0")
+          } yield assert(result)(isEmpty)
+        },
+        testM("existing message that is not in pending state") {
+          for {
+            stream <- uuid
+            group  <- uuid
+            second <- uuid
+            _      <- xGroupCreate(stream, group, "$", mkStream = true)
+            id     <- xAdd(stream, "*", "a" -> "b")
+            result <- xClaimWithJustId(stream, group, second, 0.millis)(id)
+          } yield assert(result)(isEmpty)
+        },
+        testM("with non-existent group") {
+          for {
+            stream   <- uuid
+            group    <- uuid
+            consumer <- uuid
+            result   <- xClaimWithJustId(stream, group, consumer, 0.millis)("1-0").either
+          } yield assert(result)(isLeft(isSubtype[NoGroup](anything)))
+        },
+        testM("with positive min idle time") {
+          for {
+            stream <- uuid
+            group  <- uuid
+            first  <- uuid
+            second <- uuid
+            _      <- xGroupCreate(stream, group, "$", mkStream = true)
+            id     <- xAdd(stream, "*", "a" -> "b")
+            _      <- xReadGroup(group, first)(stream -> ">")
+            result <- xClaimWithJustId(stream, group, second, 360000.millis)(id)
+          } yield assert(result)(isEmpty)
+        },
+        testM("with negative min idle time") {
+          for {
+            stream <- uuid
+            group  <- uuid
+            first  <- uuid
+            second <- uuid
+            _      <- xGroupCreate(stream, group, "$", mkStream = true)
+            id     <- xAdd(stream, "*", "a" -> "b")
+            _      <- xReadGroup(group, first)(stream -> ">")
+            result <- xClaimWithJustId(stream, group, second, (-360000).millis)(id)
+          } yield assert(result)(hasSameElements(Chunk.single(id)))
+        },
+        testM("with positive idle time") {
+          for {
+            stream <- uuid
+            group  <- uuid
+            first  <- uuid
+            second <- uuid
+            _      <- xGroupCreate(stream, group, "$", mkStream = true)
+            id     <- xAdd(stream, "*", "a" -> "b")
+            _      <- xReadGroup(group, first)(stream -> ">")
+            result <- xClaimWithJustId(stream, group, second, 0.millis, Some(360000.millis))(id)
+          } yield assert(result)(hasSameElements(Chunk.single(id)))
+        },
+        testM("with negative idle time") {
+          for {
+            stream <- uuid
+            group  <- uuid
+            first  <- uuid
+            second <- uuid
+            _      <- xGroupCreate(stream, group, "$", mkStream = true)
+            id     <- xAdd(stream, "*", "a" -> "b")
+            _      <- xReadGroup(group, first)(stream -> ">")
+            result <- xClaimWithJustId(stream, group, second, 0.millis, Some((-360000).millis))(id)
+          } yield assert(result)(hasSameElements(Chunk.single(id)))
+        },
+        testM("with positive time") {
+          for {
+            stream <- uuid
+            group  <- uuid
+            first  <- uuid
+            second <- uuid
+            _      <- xGroupCreate(stream, group, "$", mkStream = true)
+            id     <- xAdd(stream, "*", "a" -> "b")
+            _      <- xReadGroup(group, first)(stream -> ">")
+            result <- xClaimWithJustId(stream, group, second, 0.millis, time = Some(360000.millis))(id)
+          } yield assert(result)(hasSameElements(Chunk.single(id)))
+        },
+        testM("with negative time") {
+          for {
+            stream <- uuid
+            group  <- uuid
+            first  <- uuid
+            second <- uuid
+            _      <- xGroupCreate(stream, group, "$", mkStream = true)
+            id     <- xAdd(stream, "*", "a" -> "b")
+            _      <- xReadGroup(group, first)(stream -> ">")
+            result <- xClaimWithJustId(stream, group, second, 0.millis, time = Some((-360000).millis))(id)
+          } yield assert(result)(hasSameElements(Chunk.single(id)))
+        },
+        testM("with positive retry count") {
+          for {
+            stream <- uuid
+            group  <- uuid
+            first  <- uuid
+            second <- uuid
+            _      <- xGroupCreate(stream, group, "$", mkStream = true)
+            id     <- xAdd(stream, "*", "a" -> "b")
+            _      <- xReadGroup(group, first)(stream -> ">")
+            result <- xClaimWithJustId(stream, group, second, 0.millis, retryCount = Some(3))(id)
+          } yield assert(result)(hasSameElements(Chunk.single(id)))
+        },
+        testM("with negative retry count") {
+          for {
+            stream <- uuid
+            group  <- uuid
+            first  <- uuid
+            second <- uuid
+            _      <- xGroupCreate(stream, group, "$", mkStream = true)
+            id     <- xAdd(stream, "*", "a" -> "b")
+            _      <- xReadGroup(group, first)(stream -> ">")
+            result <- xClaimWithJustId(stream, group, second, 0.millis, retryCount = Some(-3))(id)
+          } yield assert(result)(hasSameElements(Chunk.single(id)))
+        },
+        testM("with force when message is not in the pending state") {
+          for {
+            stream   <- uuid
+            group    <- uuid
+            consumer <- uuid
+            _        <- xGroupCreate(stream, group, "$", mkStream = true)
+            id       <- xAdd(stream, "*", "a" -> "b")
+            result   <- xClaimWithJustId(stream, group, consumer, 0.millis, force = true)(id)
+          } yield assert(result)(hasSameElements(Chunk.single(id)))
+        },
+        testM("when not stream") {
+          for {
+            stream   <- uuid
+            group    <- uuid
+            consumer <- uuid
+            _        <- set(stream, "value")
+            result   <- xClaimWithJustId(stream, group, consumer, 0.millis, force = true)("1-0").either
+          } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
         }
       )
     )

--- a/redis/src/test/scala/zio/redis/StreamsSpec.scala
+++ b/redis/src/test/scala/zio/redis/StreamsSpec.scala
@@ -484,6 +484,35 @@ trait StreamsSpec extends BaseSpec {
             result   <- xClaimWithJustId(stream, group, consumer, 0.millis, force = true)("1-0").either
           } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
         }
+      ),
+      suite("xDel")(
+        testM("an existing message") {
+          for {
+            stream <- uuid
+            id     <- xAdd(stream, "*", "a" -> "b")
+            result <- xDel(stream, id)
+          } yield assert(result)(equalTo(1L))
+        },
+        testM("non-existent message") {
+          for {
+            stream <- uuid
+            result <- xDel(stream, "1-0")
+          } yield assert(result)(equalTo(0L))
+        },
+        testM("with an invalid message id") {
+          for {
+            stream <- uuid
+            id     <- uuid
+            result <- xDel(stream, id)
+          } yield assert(result)(equalTo(0L))
+        },
+        testM("error when not stream") {
+          for {
+            stream <- uuid
+            _      <- set(stream, "value")
+            result <- xDel(stream, "1-0").either
+          } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/StreamsSpec.scala
+++ b/redis/src/test/scala/zio/redis/StreamsSpec.scala
@@ -114,6 +114,36 @@ trait StreamsSpec extends BaseSpec {
             result    <- xAdd(nonStream, id, "name" -> "Sara").either
           } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
         }
+      ),
+      suite("xAddWithMaxLen")(
+        testM("with positive count and without approximate") {
+          for {
+            stream <- uuid
+            id      = "1-0"
+            result <- xAddWithMaxLen(stream, id, 10)("name" -> "Sara")
+          } yield assert(result)(equalTo(id))
+        },
+        testM("with positive count and with approximate") {
+          for {
+            stream <- uuid
+            id      = "1-0"
+            result <- xAddWithMaxLen(stream, id, 10, approximate = true)("name" -> "Sara")
+          } yield assert(result)(equalTo(id))
+        },
+        testM("error with negative count and without approximate") {
+          for {
+            stream <- uuid
+            id      = "1-0"
+            result <- xAddWithMaxLen(stream, id, -10)("name" -> "Sara").either
+          } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
+        },
+        testM("error with negative count and with approximate") {
+          for {
+            stream <- uuid
+            id      = "1-0"
+            result <- xAddWithMaxLen(stream, id, -10, approximate = true)("name" -> "Sara").either
+          } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/StreamsSpec.scala
+++ b/redis/src/test/scala/zio/redis/StreamsSpec.scala
@@ -710,6 +710,30 @@ trait StreamsSpec extends BaseSpec {
             result   <- xGroupDelConsumer(stream, group, consumer).either
           } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
         }
+      ),
+      suite("xLen")(
+        testM("empty stream") {
+          for {
+            stream <- uuid
+            group  <- uuid
+            _      <- xGroupCreate(stream, group, "$", mkStream = true)
+            result <- xLen(stream)
+          } yield assert(result)(equalTo(0L))
+        },
+        testM("non-empty stream") {
+          for {
+            stream <- uuid
+            _      <- xAdd(stream, "*", "a" -> "b")
+            result <- xLen(stream)
+          } yield assert(result)(equalTo(1L))
+        },
+        testM("error when not stream") {
+          for {
+            stream <- uuid
+            _      <- set(stream, "value")
+            result <- xLen(stream).either
+          } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
+        }
       )
     )
 }


### PR DESCRIPTION
This PR resolves part of issue #157.

**Summary:**
1. Add tests for all of the commands except `XINFO`,
1. Add scaladoc comments for all of the commands.

**Note:** Some of the tests are written for the Redis version `6.2` so they are ignored for now.