### PR TITLE
Remove leftovers from transducer refactoring

### DIFF
--- a/redis/src/main/scala/zio/redis/Output.scala
+++ b/redis/src/main/scala/zio/redis/Output.scala
@@ -100,7 +100,7 @@ object Output {
     protected def tryDecode(respValue: RespValue): Option[A] =
       respValue match {
         case RespValue.Null => None
-        case other               => Some(output.tryDecode(other))
+        case other          => Some(output.tryDecode(other))
       }
   }
 
@@ -185,7 +185,7 @@ object Output {
         case RespValue.Array(elements) =>
           elements.map {
             case s @ RespValue.BulkString(_) => Some(s.asString)
-            case RespValue.Null         => None
+            case RespValue.Null              => None
             case other                       => throw ProtocolError(s"$other isn't null or a bulk string")
           }
         case other => throw ProtocolError(s"$other isn't an array")
@@ -198,7 +198,7 @@ object Output {
         case RespValue.Array(elements) =>
           elements.map {
             case RespValue.Integer(element) => Some(element)
-            case RespValue.Null        => None
+            case RespValue.Null             => None
             case other                      => throw ProtocolError(s"$other isn't an integer")
           }
         case other => throw ProtocolError(s"$other isn't an array")
@@ -326,7 +326,7 @@ object Output {
 
           val pairs = ps match {
             case RespValue.Array(value) => value
-            case RespValue.Null    => Chunk.empty
+            case RespValue.Null         => Chunk.empty
             case other                  => throw ProtocolError(s"$other isn't an array")
           }
 
@@ -397,7 +397,7 @@ object Output {
   case object SetOutput extends Output[Boolean] {
     protected def tryDecode(respValue: RespValue): Boolean =
       respValue match {
-        case RespValue.Null       => false
+        case RespValue.Null            => false
         case RespValue.SimpleString(_) => true
         case other                     => throw ProtocolError(s"$other isn't a valid set response")
       }

--- a/redis/src/main/scala/zio/redis/Output.scala
+++ b/redis/src/main/scala/zio/redis/Output.scala
@@ -99,7 +99,7 @@ object Output {
   final case class OptionalOutput[+A](output: Output[A]) extends Output[Option[A]] {
     protected def tryDecode(respValue: RespValue): Option[A] =
       respValue match {
-        case RespValue.NullValue => None
+        case RespValue.Null => None
         case other               => Some(output.tryDecode(other))
       }
   }
@@ -121,7 +121,7 @@ object Output {
   case object KeyElemOutput extends Output[Option[(String, String)]] {
     protected def tryDecode(respValue: RespValue): Option[(String, String)] =
       respValue match {
-        case RespValue.NullValue =>
+        case RespValue.Null =>
           None
         case RespValue.ArrayValues(a @ RespValue.BulkString(_), b @ RespValue.BulkString(_)) =>
           Some((a.asString, b.asString))
@@ -165,7 +165,7 @@ object Output {
   case object MultiStringChunkOutput extends Output[Chunk[String]] {
     protected def tryDecode(respValue: RespValue): Chunk[String] =
       respValue match {
-        case RespValue.NullValue =>
+        case RespValue.Null =>
           Chunk.empty
         case s @ RespValue.BulkString(_) =>
           Chunk.single(s.asString)
@@ -181,11 +181,11 @@ object Output {
   case object ChunkOptionalMultiStringOutput extends Output[Chunk[Option[String]]] {
     protected def tryDecode(respValue: RespValue): Chunk[Option[String]] =
       respValue match {
-        case RespValue.NullValue => Chunk.empty
+        case RespValue.Null => Chunk.empty
         case RespValue.Array(elements) =>
           elements.map {
             case s @ RespValue.BulkString(_) => Some(s.asString)
-            case RespValue.NullValue         => None
+            case RespValue.Null         => None
             case other                       => throw ProtocolError(s"$other isn't null or a bulk string")
           }
         case other => throw ProtocolError(s"$other isn't an array")
@@ -198,7 +198,7 @@ object Output {
         case RespValue.Array(elements) =>
           elements.map {
             case RespValue.Integer(element) => Some(element)
-            case RespValue.NullValue        => None
+            case RespValue.Null        => None
             case other                      => throw ProtocolError(s"$other isn't an integer")
           }
         case other => throw ProtocolError(s"$other isn't an array")
@@ -233,11 +233,11 @@ object Output {
           elements.map {
             case RespValue.ArrayValues(RespValue.BulkString(long), RespValue.BulkString(lat)) =>
               Some(LongLat(decodeDouble(long), decodeDouble(lat)))
-            case RespValue.NullValue => None
+            case RespValue.Null => None
             case other =>
               throw ProtocolError(s"$other was not a longitude,latitude pair")
           }
-        case RespValue.NullValue =>
+        case RespValue.Null =>
           Chunk.empty
         case other =>
           throw ProtocolError(s"$other isn't geo output")
@@ -311,7 +311,7 @@ object Output {
 
           output.toMap
 
-        case RespValue.NullValue => Map.empty[String, Map[String, String]]
+        case RespValue.Null => Map.empty[String, Map[String, String]]
 
         case other => throw ProtocolError(s"$other isn't an array")
       }
@@ -326,7 +326,7 @@ object Output {
 
           val pairs = ps match {
             case RespValue.Array(value) => value
-            case RespValue.NullValue    => Chunk.empty
+            case RespValue.Null    => Chunk.empty
             case other                  => throw ProtocolError(s"$other isn't an array")
           }
 
@@ -386,7 +386,7 @@ object Output {
 
           output.toMap
 
-        case RespValue.NullValue =>
+        case RespValue.Null =>
           Map.empty[String, Map[String, Map[String, String]]]
 
         case other =>
@@ -397,7 +397,7 @@ object Output {
   case object SetOutput extends Output[Boolean] {
     protected def tryDecode(respValue: RespValue): Boolean =
       respValue match {
-        case RespValue.NullValue       => false
+        case RespValue.Null       => false
         case RespValue.SimpleString(_) => true
         case other                     => throw ProtocolError(s"$other isn't a valid set response")
       }

--- a/redis/src/main/scala/zio/redis/RespValue.scala
+++ b/redis/src/main/scala/zio/redis/RespValue.scala
@@ -109,10 +109,10 @@ object RespValue {
             line.head match {
               case Headers.SimpleString => Done(SimpleString(line.tail))
               case Headers.Error        => Done(Error(line.tail))
-              case Headers.Integer      => Done(Integer(unsafeReadLong(line, 0)))
+              case Headers.Integer      => Done(Integer(unsafeReadLong(line, 1)))
               case Headers.BulkString   => ExpectingBulk
               case Headers.Array =>
-                val size = unsafeReadLong(line, 0).toInt
+                val size = unsafeReadLong(line, 1).toInt
 
                 if (size > 0)
                   CollectingArray(size, Chunk.empty, Start.feed)

--- a/redis/src/main/scala/zio/redis/RespValue.scala
+++ b/redis/src/main/scala/zio/redis/RespValue.scala
@@ -11,7 +11,7 @@ sealed trait RespValue extends Product with Serializable { self =>
 
   final def serialize: Chunk[Byte] =
     self match {
-      case Null       => NullString
+      case Null            => NullString
       case SimpleString(s) => Headers.SimpleString +: encode(s)
       case Error(s)        => Headers.Error +: encode(s)
       case Integer(i)      => Headers.Integer +: encode(i.toString)

--- a/redis/src/main/scala/zio/redis/RespValue.scala
+++ b/redis/src/main/scala/zio/redis/RespValue.scala
@@ -11,7 +11,7 @@ sealed trait RespValue extends Product with Serializable { self =>
 
   final def serialize: Chunk[Byte] =
     self match {
-      case NullValue       => NullString
+      case Null       => NullString
       case SimpleString(s) => Headers.SimpleString +: encode(s)
       case Error(s)        => Headers.Error +: encode(s)
       case Integer(i)      => Headers.Integer +: encode(i.toString)
@@ -43,7 +43,7 @@ object RespValue {
 
   final case class Array(values: Chunk[RespValue]) extends RespValue
 
-  case object NullValue extends RespValue
+  case object Null extends RespValue
 
   object ArrayValues {
     def unapplySeq(v: RespValue): Option[Seq[RespValue]] =
@@ -88,8 +88,8 @@ object RespValue {
     }
 
     final val CrLf: Chunk[Byte]       = Chunk(Cr, Lf)
-    final val Null: String            = "$-1"
     final val NullArray: String       = "*-1"
+    final val NullValue: String       = "$-1"
     final val NullString: Chunk[Byte] = Chunk.fromArray("$-1\r\n".getBytes(StandardCharsets.US_ASCII))
 
     sealed trait State { self =>
@@ -103,7 +103,7 @@ object RespValue {
 
       final def feed(line: String): State =
         self match {
-          case Start if line == Null || line == NullArray => Done(NullValue)
+          case Start if line == NullValue || line == NullArray => Done(Null)
 
           case Start if line.nonEmpty =>
             line.head match {

--- a/redis/src/main/scala/zio/redis/RespValue.scala
+++ b/redis/src/main/scala/zio/redis/RespValue.scala
@@ -36,9 +36,9 @@ object RespValue {
   final case class Integer(value: Long) extends RespValue
 
   final case class BulkString(value: Chunk[Byte]) extends RespValue {
-    def asString: String = decodeString(value)
+    private[redis] def asString: String = decodeString(value)
 
-    def asLong: Long = {
+    private[redis] def asLong: Long = {
       val text = asString
       val len  = value.length
 

--- a/redis/src/main/scala/zio/redis/TestExecutor.scala
+++ b/redis/src/main/scala/zio/redis/TestExecutor.scala
@@ -155,12 +155,12 @@ private[redis] final class TestExecutor private (
               res <- maybeCount match {
                        case None =>
                          selectOne[String](asVector, randomPick).map(maybeValue =>
-                           maybeValue.map(RespValue.bulkString).getOrElse(RespValue.NullValue)
+                           maybeValue.map(RespValue.bulkString).getOrElse(RespValue.Null)
                          )
                        case Some(n) if n > 0 => selectN(asVector, n, randomPick).map(Replies.array)
                        case Some(n) if n < 0 =>
                          selectNWithReplacement(asVector, -1 * n, randomPick).map(Replies.array)
-                       case Some(0) => STM.succeedNow(RespValue.NullValue)
+                       case Some(0) => STM.succeedNow(RespValue.Null)
                      }
             } yield res
           },

--- a/redis/src/test/scala/zio/redis/OutputSpec.scala
+++ b/redis/src/test/scala/zio/redis/OutputSpec.scala
@@ -117,7 +117,7 @@ object OutputSpec extends BaseSpec {
       suite("optional")(
         testM("extract None") {
           for {
-            res <- Task(OptionalOutput(UnitOutput).unsafeDecode(RespValue.NullValue))
+            res <- Task(OptionalOutput(UnitOutput).unsafeDecode(RespValue.Null))
           } yield assert(res)(isNone)
         },
         testM("extract some") {
@@ -154,7 +154,7 @@ object OutputSpec extends BaseSpec {
       suite("keyElem")(
         testM("extract none") {
           for {
-            res <- Task(KeyElemOutput.unsafeDecode(RespValue.NullValue))
+            res <- Task(KeyElemOutput.unsafeDecode(RespValue.Null))
           } yield assert(res)(isNone)
         },
         testM("extract key and element") {
@@ -173,7 +173,7 @@ object OutputSpec extends BaseSpec {
       suite("multiStringChunk")(
         testM("extract one empty value") {
           for {
-            res <- Task(MultiStringChunkOutput.unsafeDecode(RespValue.NullValue))
+            res <- Task(MultiStringChunkOutput.unsafeDecode(RespValue.Null))
           } yield assert(res)(isEmpty)
         },
         testM("extract one multi-string value") {
@@ -191,7 +191,7 @@ object OutputSpec extends BaseSpec {
       suite("chunkOptionalMultiString")(
         testM("extract one empty value") {
           for {
-            res <- Task(ChunkOptionalMultiStringOutput.unsafeDecode(RespValue.NullValue))
+            res <- Task(ChunkOptionalMultiStringOutput.unsafeDecode(RespValue.Null))
           } yield assert(res)(isEmpty)
         },
         testM("extract array with one non-empty element") {
@@ -206,7 +206,7 @@ object OutputSpec extends BaseSpec {
           } yield assert(res)(equalTo(Chunk(Some("1"), Some("2"), Some("3"))))
         },
         testM("extract array with empty and non-empty elements") {
-          val input = RespValue.array(RespValue.bulkString("1"), RespValue.NullValue, RespValue.bulkString("3"))
+          val input = RespValue.array(RespValue.bulkString("1"), RespValue.Null, RespValue.bulkString("3"))
           for {
             res <- Task(ChunkOptionalMultiStringOutput.unsafeDecode(input))
           } yield assert(res)(equalTo(Chunk(Some("1"), None, Some("3"))))
@@ -221,7 +221,7 @@ object OutputSpec extends BaseSpec {
         testM("extract array with empty and non-empty elements") {
           val input = RespValue.array(
             RespValue.Integer(1L),
-            RespValue.NullValue,
+            RespValue.Null,
             RespValue.Integer(2L),
             RespValue.Integer(3L)
           )
@@ -260,7 +260,7 @@ object OutputSpec extends BaseSpec {
             RespValue.array(
               RespValue.bulkString("id"),
               RespValue.array(RespValue.bulkString("field"), RespValue.bulkString("value")),
-              RespValue.NullValue
+              RespValue.Null
             )
           )
 
@@ -294,7 +294,7 @@ object OutputSpec extends BaseSpec {
         testM("extract when the smallest ID is null") {
           val input = RespValue.array(
             RespValue.Integer(1),
-            RespValue.NullValue,
+            RespValue.Null,
             RespValue.bulkString("b"),
             RespValue.array(
               RespValue.array(RespValue.bulkString("consumer1"), RespValue.bulkString("1")),
@@ -308,7 +308,7 @@ object OutputSpec extends BaseSpec {
           val input = RespValue.array(
             RespValue.Integer(1),
             RespValue.bulkString("a"),
-            RespValue.NullValue,
+            RespValue.Null,
             RespValue.array(
               RespValue.array(RespValue.bulkString("consumer1"), RespValue.bulkString("1")),
               RespValue.array(RespValue.bulkString("consumer2"), RespValue.bulkString("2"))
@@ -320,9 +320,9 @@ object OutputSpec extends BaseSpec {
         testM("extract when total number of pending messages is zero") {
           val input = RespValue.array(
             RespValue.Integer(0),
-            RespValue.NullValue,
-            RespValue.NullValue,
-            RespValue.NullValue
+            RespValue.Null,
+            RespValue.Null,
+            RespValue.Null
           )
           Task(XPendingOutput.unsafeDecode(input))
             .map(assert(_)(equalTo(PendingInfo(0L, None, None, Map.empty))))
@@ -375,7 +375,7 @@ object OutputSpec extends BaseSpec {
               RespValue.bulkString("consumer"),
               RespValue.Integer(100),
               RespValue.Integer(10),
-              RespValue.NullValue
+              RespValue.Null
             ),
             RespValue.array(
               RespValue.bulkString("id1"),

--- a/redis/src/test/scala/zio/redis/RespValueSpec.scala
+++ b/redis/src/test/scala/zio/redis/RespValueSpec.scala
@@ -13,7 +13,7 @@ object RespValueSpec extends BaseSpec {
       suite("serialization")(
         test("array") {
           val expected = Chunk.fromArray("*3\r\n$3\r\nabc\r\n:123\r\n$-1\r\n".getBytes(StandardCharsets.UTF_8))
-          val v        = RespValue.array(RespValue.bulkString("abc"), RespValue.Integer(123), RespValue.NullValue)
+          val v        = RespValue.array(RespValue.bulkString("abc"), RespValue.Integer(123), RespValue.Null)
           assert(v.serialize)(equalTo(expected))
         }
       ),
@@ -24,12 +24,12 @@ object RespValueSpec extends BaseSpec {
           RespValue.array(
             RespValue.bulkString("test1"),
             RespValue.Integer(42L),
-            RespValue.NullValue,
+            RespValue.Null,
             RespValue.array(RespValue.SimpleString("a"), RespValue.Integer(0L)),
             RespValue.bulkString("in array"),
             RespValue.SimpleString("test2")
           ),
-          RespValue.NullValue
+          RespValue.Null
         )
 
         Stream


### PR DESCRIPTION
### Summary

- Renamed `NullValue` to `Null`.
- "merge" number extraction helpers.
- Reduce `BulkString` methods visibility.