### PR TITLE
Improve array serialization

### DIFF
--- a/benchmarks/src/main/scala/zio/redis/SMembersBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/SMembersBenchmarks.scala
@@ -6,15 +6,6 @@ import org.openjdk.jmh.annotations._
 
 import zio.ZIO
 
-/*
- * Baseline:
- * 
- * Benchmark                      (size)   Mode  Cnt  Score   Error  Units
- * SMembersBenchmarks.laserdisc      500  thrpt   15  1.534 ± 0.060  ops/s
- * SMembersBenchmarks.rediculous     500  thrpt   15  3.141 ± 0.013  ops/s
- * SMembersBenchmarks.redis4cats     500  thrpt   15  4.766 ± 0.064  ops/s
- * SMembersBenchmarks.zio            500  thrpt   15  3.401 ± 0.616  ops/s
- */
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)

--- a/benchmarks/src/main/scala/zio/redis/SMembersBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/SMembersBenchmarks.scala
@@ -1,0 +1,64 @@
+package zio.redis
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import zio.ZIO
+
+/*
+ * Baseline:
+ * 
+ * Benchmark                      (size)   Mode  Cnt  Score   Error  Units
+ * SMembersBenchmarks.laserdisc      500  thrpt   15  1.534 ± 0.060  ops/s
+ * SMembersBenchmarks.rediculous     500  thrpt   15  3.141 ± 0.013  ops/s
+ * SMembersBenchmarks.redis4cats     500  thrpt   15  4.766 ± 0.064  ops/s
+ * SMembersBenchmarks.zio            500  thrpt   15  3.401 ± 0.616  ops/s
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 15)
+@Warmup(iterations = 15)
+@Fork(2)
+class SMembersBenchmarks extends BenchmarkRuntime {
+  @Param(Array("500"))
+  private var size: Int = _
+
+  private var items: List[String] = _
+
+  private val key = "test-set"
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    items = (0 to size).toList.map(_.toString)
+    zioUnsafeRun(sAdd(key, items.head, items.tail: _*).unit)
+  }
+
+  @Benchmark
+  def laserdisc(): Unit = {
+    import _root_.laserdisc.fs2._
+    import _root_.laserdisc.{ all => cmd, _ }
+    import cats.instances.list._
+    import cats.syntax.foldable._
+
+    unsafeRun[LaserDiscClient](c => items.traverse_(_ => c.send(cmd.smembers(Key.unsafeFrom(key)))))
+  }
+
+  @Benchmark
+  def rediculous(): Unit = {
+    import cats.implicits._
+    import io.chrisdavenport.rediculous._
+    unsafeRun[RediculousClient](c => items.traverse_(_ => RedisCommands.smembers[RedisIO](key).run(c)))
+  }
+
+  @Benchmark
+  def redis4cats(): Unit = {
+    import cats.instances.list._
+    import cats.syntax.foldable._
+    unsafeRun[Redis4CatsClient[String]](c => items.traverse_(_ => c.sMembers(key)))
+  }
+
+  @Benchmark
+  def zio(): Unit = zioUnsafeRun(ZIO.foreach_(items)(_ => sMembers(key)))
+}

--- a/redis/src/main/scala/zio/redis/Output.scala
+++ b/redis/src/main/scala/zio/redis/Output.scala
@@ -396,7 +396,7 @@ object Output {
   }
 
   private def decodeDouble(bytes: Chunk[Byte]): Double = {
-    val text = RespValue.decodeString(bytes)
+    val text = RespValue.decode(bytes)
     try text.toDouble
     catch {
       case _: NumberFormatException => throw ProtocolError(s"'$text' isn't a double.")

--- a/redis/src/main/scala/zio/redis/Output.scala
+++ b/redis/src/main/scala/zio/redis/Output.scala
@@ -36,14 +36,6 @@ object Output {
 
   import RedisError._
 
-  private def decodeDouble(bytes: Chunk[Byte]): Double = {
-    val text = RespValue.decodeString(bytes)
-    try text.toDouble
-    catch {
-      case _: NumberFormatException => throw ProtocolError(s"'$text' isn't a double.")
-    }
-  }
-
   case object BoolOutput extends Output[Boolean] {
     protected def tryDecode(respValue: RespValue): Boolean =
       respValue match {
@@ -401,5 +393,13 @@ object Output {
         case RespValue.SimpleString(_) => true
         case other                     => throw ProtocolError(s"$other isn't a valid set response")
       }
+  }
+
+  private def decodeDouble(bytes: Chunk[Byte]): Double = {
+    val text = RespValue.decodeString(bytes)
+    try text.toDouble
+    catch {
+      case _: NumberFormatException => throw ProtocolError(s"'$text' isn't a double.")
+    }
   }
 }

--- a/redis/src/main/scala/zio/redis/RedisExecutor.scala
+++ b/redis/src/main/scala/zio/redis/RedisExecutor.scala
@@ -82,7 +82,7 @@ object RedisExecutor {
     private def receive: IO[RedisError, Unit] =
       byteStream.read
         .mapError(RedisError.IOError)
-        .transduce(RespValue.Deserializer)
+        .transduce(RespValue.Decoder)
         .foreach(response => resQueue.take.flatMap(_.succeed(response)))
 
   }

--- a/redis/src/main/scala/zio/redis/RespValue.scala
+++ b/redis/src/main/scala/zio/redis/RespValue.scala
@@ -53,10 +53,6 @@ object RespValue {
       }
   }
 
-  private[redis] final val Cr: Byte = '\r'
-
-  private[redis] final val Lf: Byte = '\n'
-
   private[redis] final val Deserializer: Transducer[RedisError.ProtocolError, Byte, RespValue] = {
     import internal.State
 
@@ -87,7 +83,7 @@ object RespValue {
       final val Array: Byte        = '*'
     }
 
-    final val CrLf: Chunk[Byte]       = Chunk(Cr, Lf)
+    final val CrLf: Chunk[Byte]       = Chunk('\r', '\n')
     final val NullArray: String       = "*-1"
     final val NullValue: String       = "$-1"
     final val NullString: Chunk[Byte] = Chunk.fromArray("$-1\r\n".getBytes(StandardCharsets.US_ASCII))

--- a/redis/src/main/scala/zio/redis/RespValue.scala
+++ b/redis/src/main/scala/zio/redis/RespValue.scala
@@ -36,7 +36,7 @@ object RespValue {
   final case class Integer(value: Long) extends RespValue
 
   final case class BulkString(value: Chunk[Byte]) extends RespValue {
-    private[redis] def asString: String = decodeString(value)
+    private[redis] def asString: String = decode(value)
 
     private[redis] def asLong: Long = internal.unsafeReadLong(asString, 0)
   }
@@ -76,7 +76,7 @@ object RespValue {
 
   private[redis] def bulkString(s: String): BulkString = BulkString(Chunk.fromArray(s.getBytes(StandardCharsets.UTF_8)))
 
-  private[redis] def decodeString(bytes: Chunk[Byte]): String = new String(bytes.toArray, StandardCharsets.UTF_8)
+  private[redis] def decode(bytes: Chunk[Byte]): String = new String(bytes.toArray, StandardCharsets.UTF_8)
 
   private object internal {
     object Headers {

--- a/redis/src/main/scala/zio/redis/RespValue.scala
+++ b/redis/src/main/scala/zio/redis/RespValue.scala
@@ -53,12 +53,6 @@ object RespValue {
       }
   }
 
-  def array(values: RespValue*): Array = Array(Chunk.fromIterable(values))
-
-  def bulkString(s: String): BulkString = BulkString(Chunk.fromArray(s.getBytes(StandardCharsets.UTF_8)))
-
-  def decodeString(bytes: Chunk[Byte]): String = new String(bytes.toArray, StandardCharsets.UTF_8)
-
   private[redis] final val Cr: Byte = '\r'
 
   private[redis] final val Lf: Byte = '\n'
@@ -77,6 +71,12 @@ object RespValue {
 
     Transducer.utf8Decode >>> Transducer.splitLines >>> processLine
   }
+
+  private[redis] def array(values: RespValue*): Array = Array(Chunk.fromIterable(values))
+
+  private[redis] def bulkString(s: String): BulkString = BulkString(Chunk.fromArray(s.getBytes(StandardCharsets.UTF_8)))
+
+  private[redis] def decodeString(bytes: Chunk[Byte]): String = new String(bytes.toArray, StandardCharsets.UTF_8)
 
   private object internal {
     object Headers {

--- a/redis/src/main/scala/zio/redis/RespValue.scala
+++ b/redis/src/main/scala/zio/redis/RespValue.scala
@@ -53,7 +53,7 @@ object RespValue {
       }
   }
 
-  private[redis] final val Deserializer: Transducer[RedisError.ProtocolError, Byte, RespValue] = {
+  private[redis] final val Decoder: Transducer[RedisError.ProtocolError, Byte, RespValue] = {
     import internal.State
 
     val processLine =

--- a/redis/src/test/scala/zio/redis/RespValueSpec.scala
+++ b/redis/src/test/scala/zio/redis/RespValueSpec.scala
@@ -35,7 +35,7 @@ object RespValueSpec extends BaseSpec {
         Stream
           .fromChunk(values)
           .mapConcat(_.serialize)
-          .transduce(RespValue.Deserializer)
+          .transduce(RespValue.Decoder)
           .runCollect
           .map(assert(_)(equalTo(values)))
       }


### PR DESCRIPTION
### Benchmark results

#### Before 

```
Benchmark                      (size)   Mode  Cnt  Score   Error  Units
SMembersBenchmarks.laserdisc      500  thrpt   15  1.534 ± 0.060  ops/s
SMembersBenchmarks.rediculous     500  thrpt   15  3.141 ± 0.013  ops/s
SMembersBenchmarks.redis4cats     500  thrpt   15  4.766 ± 0.064  ops/s
SMembersBenchmarks.zio            500  thrpt   15  3.401 ± 0.616  ops/
```

#### After

```
Benchmark               (size)   Mode  Cnt  Score   Error  Units
SMembersBenchmarks.zio     500  thrpt   15  4.074 ± 0.051  ops/s
```