### PR TITLE
Benchmark for hash api

### DIFF
--- a/benchmarks/src/main/scala/zio/redis/hash/HDelBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/hash/HDelBenchmarks.scala
@@ -1,0 +1,55 @@
+package zio.redis.hash
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import zio.ZIO
+import zio.redis.{ BenchmarkRuntime, hDel, hSet }
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 15)
+@Warmup(iterations = 15)
+@Fork(2)
+class HDelBenchmarks extends BenchmarkRuntime {
+  @Param(Array("500"))
+  private var size: Int = _
+
+  private var items: List[(String, String)] = _
+
+  private val key = "test-hash"
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    items = (0 to size).map(e => e.toString -> e.toString).toList
+    zioUnsafeRun(hSet(key, items.head, items.tail: _*).unit)
+  }
+
+  @Benchmark
+  def laserdisc(): Unit = {
+    import _root_.laserdisc.fs2._
+    import _root_.laserdisc.{ all => cmd, _ }
+    import cats.implicits.toFoldableOps
+    import cats.instances.list._
+    unsafeRun[LaserDiscClient](c => items.traverse_(it => c.send(cmd.hdel(Key.unsafeFrom(key), Key.unsafeFrom(it._1)))))
+  }
+
+  @Benchmark
+  def rediculous(): Unit = {
+    import cats.implicits._
+    import io.chrisdavenport.rediculous._
+    unsafeRun[RediculousClient](c => items.traverse_(it => RedisCommands.hdel[RedisIO](key, List(it._1)).run(c)))
+  }
+
+  @Benchmark
+  def redis4cats(): Unit = {
+    import cats.instances.list._
+    import cats.syntax.foldable._
+    unsafeRun[Redis4CatsClient[String]](c => items.traverse_(it => c.hDel(key, it._1)))
+  }
+
+  @Benchmark
+  def zio(): Unit = zioUnsafeRun(ZIO.foreach_(items)(it => hDel(key, it._1)))
+}

--- a/benchmarks/src/main/scala/zio/redis/hash/HExistsBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/hash/HExistsBenchmarks.scala
@@ -1,0 +1,57 @@
+package zio.redis.hash
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import zio.ZIO
+import zio.redis.{ BenchmarkRuntime, hExists, hSet }
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 15)
+@Warmup(iterations = 15)
+@Fork(2)
+class HExistsBenchmarks extends BenchmarkRuntime {
+  @Param(Array("500"))
+  private var size: Int = _
+
+  private var items: List[(String, String)] = _
+
+  private val key = "test-hash"
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    items = (0 to size).map(e => e.toString -> e.toString).toList
+    zioUnsafeRun(hSet(key, items.head, items.tail: _*).unit)
+  }
+
+  @Benchmark
+  def laserdisc(): Unit = {
+    import _root_.laserdisc.fs2._
+    import _root_.laserdisc.{ all => cmd, _ }
+    import cats.implicits.toFoldableOps
+    import cats.instances.list._
+    unsafeRun[LaserDiscClient](c =>
+      items.traverse_(it => c.send(cmd.hexists(Key.unsafeFrom(key), Key.unsafeFrom(it._1))))
+    )
+  }
+
+  @Benchmark
+  def rediculous(): Unit = {
+    import cats.implicits._
+    import io.chrisdavenport.rediculous._
+    unsafeRun[RediculousClient](c => items.traverse_(it => RedisCommands.hexists[RedisIO](key, it._1).run(c)))
+  }
+
+  @Benchmark
+  def redis4cats(): Unit = {
+    import cats.instances.list._
+    import cats.syntax.foldable._
+    unsafeRun[Redis4CatsClient[String]](c => items.traverse_(it => c.hExists(key, it._1)))
+  }
+
+  @Benchmark
+  def zio(): Unit = zioUnsafeRun(ZIO.foreach_(items)(it => hExists(key, it._1)))
+}

--- a/benchmarks/src/main/scala/zio/redis/hash/HGetAllBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/hash/HGetAllBenchmarks.scala
@@ -1,0 +1,55 @@
+package zio.redis.hash
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import zio.ZIO
+import zio.redis.{ BenchmarkRuntime, hGetAll, hSet }
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 15)
+@Warmup(iterations = 15)
+@Fork(2)
+class HGetAllBenchmarks extends BenchmarkRuntime {
+  @Param(Array("500"))
+  private var size: Int = _
+
+  private var items: List[(String, String)] = _
+
+  private val key = "test-hash"
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    items = (0 to size).map(e => e.toString -> e.toString).toList
+    zioUnsafeRun(hSet(key, items.head, items.tail: _*).unit)
+  }
+
+  @Benchmark
+  def laserdisc(): Unit = {
+    import _root_.laserdisc.fs2._
+    import _root_.laserdisc.{ all => cmd, _ }
+    import cats.implicits.toFoldableOps
+    import cats.instances.list._
+    unsafeRun[LaserDiscClient](c => items.traverse_(_ => c.send(cmd.hgetall(Key.unsafeFrom(key)))))
+  }
+
+  @Benchmark
+  def rediculous(): Unit = {
+    import cats.implicits._
+    import io.chrisdavenport.rediculous._
+    unsafeRun[RediculousClient](c => items.traverse_(_ => RedisCommands.hgetall[RedisIO](key).run(c)))
+  }
+
+  @Benchmark
+  def redis4cats(): Unit = {
+    import cats.instances.list._
+    import cats.syntax.foldable._
+    unsafeRun[Redis4CatsClient[String]](c => items.traverse_(_ => c.hGetAll(key)))
+  }
+
+  @Benchmark
+  def zio(): Unit = zioUnsafeRun(ZIO.foreach_(items)(_ => hGetAll(key)))
+}

--- a/benchmarks/src/main/scala/zio/redis/hash/HGetBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/hash/HGetBenchmarks.scala
@@ -1,0 +1,56 @@
+package zio.redis.hash
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import zio.ZIO
+import zio.redis.{ BenchmarkRuntime, hGet, hSet }
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 15)
+@Warmup(iterations = 15)
+@Fork(2)
+class HGetBenchmarks extends BenchmarkRuntime {
+  @Param(Array("500"))
+  private var size: Int = _
+
+  private var items: List[(String, String)] = _
+
+  private val key = "test-hash"
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    items = (0 to size).map(e => e.toString -> e.toString).toList
+    zioUnsafeRun(hSet(key, items.head, items.tail: _*).unit)
+  }
+
+  @Benchmark
+  def laserdisc(): Unit = {
+    import _root_.laserdisc.fs2._
+    import _root_.laserdisc.{ all => cmd, _ }
+    import cats.implicits.toFoldableOps
+    import cats.instances.list._
+    unsafeRun[LaserDiscClient](c =>
+      items.traverse_(it => c.send(cmd.hget[String](Key.unsafeFrom(key), Key.unsafeFrom(it._1))))
+    )
+  }
+
+  @Benchmark
+  def rediculous(): Unit = {
+    import cats.implicits._
+    import io.chrisdavenport.rediculous._
+    unsafeRun[RediculousClient](c => items.traverse_(it => RedisCommands.hget[RedisIO](key, it._1).run(c)))
+  }
+
+  @Benchmark
+  def redis4cats(): Unit = {
+    import cats.syntax.foldable._
+    unsafeRun[Redis4CatsClient[String]](c => items.traverse_(it => c.hGet(key, it._1)))
+  }
+
+  @Benchmark
+  def zio(): Unit = zioUnsafeRun(ZIO.foreach_(items)(it => hGet(key, it._1)))
+}

--- a/benchmarks/src/main/scala/zio/redis/hash/HIncrbyBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/hash/HIncrbyBenchmarks.scala
@@ -1,0 +1,63 @@
+package zio.redis.hash
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import zio.ZIO
+import zio.redis.{ BenchmarkRuntime, hIncrBy, hSet }
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 15)
+@Warmup(iterations = 15)
+@Fork(2)
+class HIncrbyBenchmarks extends BenchmarkRuntime {
+  @Param(Array("500"))
+  private var size: Int = _
+
+  @Param(Array("1"))
+  private var increment: Long = _
+
+  private var items: List[(String, String)] = _
+
+  private val key = "test-hash"
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    items = (0 to size).map(e => e.toString -> e.toString).toList
+    zioUnsafeRun(hSet(key, items.head, items.tail: _*).unit)
+  }
+
+  @Benchmark
+  def laserdisc(): Unit = {
+    import _root_.laserdisc.fs2._
+    import cats.implicits.toFoldableOps
+    import _root_.laserdisc.{ all => cmd, _ }
+    import cats.instances.list._
+    unsafeRun[LaserDiscClient](c =>
+      items.traverse_(it =>
+        c.send(cmd.hincrby(Key.unsafeFrom(key), Key.unsafeFrom(it._1), NonZeroLong.unsafeFrom(increment)))
+      )
+    )
+  }
+
+  @Benchmark
+  def rediculous(): Unit = {
+    import cats.implicits._
+    import io.chrisdavenport.rediculous._
+    unsafeRun[RediculousClient](c =>
+      items.traverse_(it => RedisCommands.hincrby[RedisIO](key, it._1, increment).run(c))
+    )
+  }
+
+  @Benchmark
+  def redis4cats(): Unit = {
+    import cats.syntax.foldable._
+    unsafeRun[Redis4CatsClient[Long]](c => items.traverse_(it => c.hIncrBy(key, it._1, increment)))
+  }
+
+  @Benchmark
+  def zio(): Unit = zioUnsafeRun(ZIO.foreach_(items)(it => hIncrBy(key, it._1, increment)))
+}

--- a/benchmarks/src/main/scala/zio/redis/hash/HIncrbyFloatBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/hash/HIncrbyFloatBenchmarks.scala
@@ -1,0 +1,62 @@
+package zio.redis.hash
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import zio.ZIO
+import zio.redis.{ BenchmarkRuntime, hIncrByFloat, hSet }
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 15)
+@Warmup(iterations = 15)
+@Fork(2)
+class HIncrbyFloatBenchmarks extends BenchmarkRuntime {
+  @Param(Array("500"))
+  private var size: Int = _
+  @Param(Array("1.0"))
+  private var increment: Double = _
+
+  private var items: List[(String, String)] = _
+
+  private val key = "test-hash"
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    items = (0 to size).map(e => e.toString -> e.toString).toList
+    zioUnsafeRun(hSet(key, items.head, items.tail: _*).unit)
+  }
+
+  @Benchmark
+  def laserdisc(): Unit = {
+    import _root_.laserdisc.fs2._
+    import _root_.laserdisc.{ all => cmd, _ }
+    import cats.implicits.toFoldableOps
+    import cats.instances.list._
+    unsafeRun[LaserDiscClient](c =>
+      items.traverse_(it =>
+        c.send(cmd.hincrby(Key.unsafeFrom(key), Key.unsafeFrom(it._1), NonZeroDouble.unsafeFrom(increment)))
+      )
+    )
+  }
+
+  @Benchmark
+  def rediculous(): Unit = {
+    import cats.implicits._
+    import io.chrisdavenport.rediculous._
+    unsafeRun[RediculousClient](c =>
+      items.traverse_(it => RedisCommands.hincrbyfloat[RedisIO](key, it._1, increment).run(c))
+    )
+  }
+
+  @Benchmark
+  def redis4cats(): Unit = {
+    import cats.syntax.foldable._
+    unsafeRun[Redis4CatsClient[Long]](c => items.traverse_(it => c.hIncrByFloat(key, it._1, increment)))
+  }
+
+  @Benchmark
+  def zio(): Unit = zioUnsafeRun(ZIO.foreach_(items)(it => hIncrByFloat(key, it._1, increment)))
+}

--- a/benchmarks/src/main/scala/zio/redis/hash/HKeysBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/hash/HKeysBenchmarks.scala
@@ -1,0 +1,55 @@
+package zio.redis.hash
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import zio.ZIO
+import zio.redis.{ BenchmarkRuntime, hKeys, hSet }
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 15)
+@Warmup(iterations = 15)
+@Fork(2)
+class HKeysBenchmarks extends BenchmarkRuntime {
+  @Param(Array("500"))
+  private var size: Int = _
+
+  private var items: List[(String, String)] = _
+
+  private val key = "test-hash"
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    items = (0 to size).map(e => e.toString -> e.toString).toList
+    zioUnsafeRun(hSet(key, items.head, items.tail: _*).unit)
+  }
+
+  @Benchmark
+  def laserdisc(): Unit = {
+    import _root_.laserdisc.fs2._
+    import _root_.laserdisc.{ all => cmd, _ }
+    import cats.implicits.toFoldableOps
+    import cats.instances.list._
+    unsafeRun[LaserDiscClient](c => items.traverse_(_ => c.send(cmd.hkeys(Key.unsafeFrom(key)))))
+  }
+
+  @Benchmark
+  def rediculous(): Unit = {
+    import cats.implicits._
+    import io.chrisdavenport.rediculous._
+    unsafeRun[RediculousClient](c => items.traverse_(_ => RedisCommands.hkeys[RedisIO](key).run(c)))
+  }
+
+  @Benchmark
+  def redis4cats(): Unit = {
+    import cats.instances.list._
+    import cats.syntax.foldable._
+    unsafeRun[Redis4CatsClient[String]](c => items.traverse_(_ => c.hKeys(key)))
+  }
+
+  @Benchmark
+  def zio(): Unit = zioUnsafeRun(ZIO.foreach_(items)(_ => hKeys(key)))
+}

--- a/benchmarks/src/main/scala/zio/redis/hash/HLenBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/hash/HLenBenchmarks.scala
@@ -1,0 +1,55 @@
+package zio.redis.hash
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import zio.ZIO
+import zio.redis.{ BenchmarkRuntime, hLen, hSet }
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 15)
+@Warmup(iterations = 15)
+@Fork(2)
+class HLenBenchmarks extends BenchmarkRuntime {
+  @Param(Array("500"))
+  private var size: Int = _
+
+  private var items: List[(String, String)] = _
+
+  private val key = "test-hash"
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    items = (0 to size).map(e => e.toString -> e.toString).toList
+    zioUnsafeRun(hSet(key, items.head, items.tail: _*).unit)
+  }
+
+  @Benchmark
+  def laserdisc(): Unit = {
+    import _root_.laserdisc.fs2._
+    import _root_.laserdisc.{ all => cmd, _ }
+    import cats.implicits.toFoldableOps
+    import cats.instances.list._
+    unsafeRun[LaserDiscClient](c => items.traverse_(_ => c.send(cmd.hlen(Key.unsafeFrom(key)))))
+  }
+
+  @Benchmark
+  def rediculous(): Unit = {
+    import cats.implicits._
+    import io.chrisdavenport.rediculous._
+    unsafeRun[RediculousClient](c => items.traverse_(_ => RedisCommands.hlen[RedisIO](key).run(c)))
+  }
+
+  @Benchmark
+  def redis4cats(): Unit = {
+    import cats.instances.list._
+    import cats.syntax.foldable._
+    unsafeRun[Redis4CatsClient[String]](c => items.traverse_(_ => c.hLen(key)))
+  }
+
+  @Benchmark
+  def zio(): Unit = zioUnsafeRun(ZIO.foreach_(items)(_ => hLen(key)))
+}

--- a/benchmarks/src/main/scala/zio/redis/hash/HMGetBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/hash/HMGetBenchmarks.scala
@@ -1,0 +1,56 @@
+package zio.redis.hash
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import zio.ZIO
+import zio.redis.{ BenchmarkRuntime, hSet, hmGet }
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 15)
+@Warmup(iterations = 15)
+@Fork(2)
+class HMGetBenchmarks extends BenchmarkRuntime {
+  @Param(Array("500"))
+  private var size: Int = _
+
+  private var items: List[(String, String)] = _
+
+  private val key = "test-hash"
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    items = (0 to size).map(e => e.toString -> e.toString).toList
+    zioUnsafeRun(hSet(key, items.head, items.tail: _*).unit)
+  }
+
+  @Benchmark
+  def laserdisc(): Unit = {
+    import _root_.laserdisc.fs2._
+    import _root_.laserdisc.{ all => cmd, _ }
+    import cats.implicits.toFoldableOps
+    import cats.instances.list._
+    unsafeRun[LaserDiscClient](c =>
+      items.traverse_(it => c.send(cmd.hmget[String](Key.unsafeFrom(key), Key.unsafeFrom(it._1))))
+    )
+  }
+
+  @Benchmark
+  def rediculous(): Unit = {
+    import cats.implicits._
+    import io.chrisdavenport.rediculous._
+    unsafeRun[RediculousClient](c => items.traverse_(it => RedisCommands.hmget[RedisIO](key, List(it._1)).run(c)))
+  }
+
+  @Benchmark
+  def redis4cats(): Unit = {
+    import cats.syntax.foldable._
+    unsafeRun[Redis4CatsClient[String]](c => items.traverse_(it => c.hmGet(key, it._1)))
+  }
+
+  @Benchmark
+  def zio(): Unit = zioUnsafeRun(ZIO.foreach_(items)(it => hmGet(key, it._1)))
+}

--- a/benchmarks/src/main/scala/zio/redis/hash/HMSetBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/hash/HMSetBenchmarks.scala
@@ -1,0 +1,55 @@
+package zio.redis.hash
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import zio.ZIO
+import zio.redis.{ BenchmarkRuntime, hmSet }
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 15)
+@Warmup(iterations = 15)
+@Fork(2)
+class HMSetBenchmarks extends BenchmarkRuntime {
+  @Param(Array("500"))
+  private var size: Int = _
+
+  private var items: List[(String, String)] = _
+
+  private val key = "test-hash"
+
+  @Setup(Level.Trial)
+  def setup(): Unit =
+    items = (0 to size).map(e => e.toString -> e.toString).toList
+//    zioUnsafeRun(hSet(key, items.head, items.tail: _*).unit)
+
+  @Benchmark
+  def laserdisc(): Unit = {
+    import _root_.laserdisc.fs2._
+    import _root_.laserdisc.{ all => cmd, _ }
+    import cats.implicits.toFoldableOps
+    import cats.instances.list._
+    unsafeRun[LaserDiscClient](c =>
+      items.traverse_(it => c.send(cmd.hmset[String](Key.unsafeFrom(key), Key.unsafeFrom(it._1), it._2)))
+    )
+  }
+
+  @Benchmark
+  def rediculous(): Unit = {
+    import cats.implicits._
+    import io.chrisdavenport.rediculous._
+    unsafeRun[RediculousClient](c => items.traverse_(it => RedisCommands.hmset[RedisIO](key, List(it)).run(c)))
+  }
+
+  @Benchmark
+  def redis4cats(): Unit = {
+    import cats.syntax.foldable._
+    unsafeRun[Redis4CatsClient[String]](c => items.traverse_(it => c.hmSet(key, Map(it._1 -> it._2))))
+  }
+
+  @Benchmark
+  def zio(): Unit = zioUnsafeRun(ZIO.foreach_(items)(it => hmSet(key, it)))
+}

--- a/benchmarks/src/main/scala/zio/redis/hash/HSetBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/hash/HSetBenchmarks.scala
@@ -1,0 +1,55 @@
+package zio.redis.hash
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import zio.ZIO
+import zio.redis.{ BenchmarkRuntime, hSet }
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 15)
+@Warmup(iterations = 15)
+@Fork(2)
+class HSetBenchmarks extends BenchmarkRuntime {
+  @Param(Array("500"))
+  private var size: Int = _
+
+  private var items: List[(String, String)] = _
+
+  private val key = "test-hash"
+
+  @Setup(Level.Trial)
+  def setup(): Unit =
+    items = (0 to size).map(e => e.toString -> e.toString).toList
+  //    zioUnsafeRun(hSet(key, items.head, items.tail: _*).unit)
+
+  @Benchmark
+  def laserdisc(): Unit = {
+    import _root_.laserdisc.fs2._
+    import _root_.laserdisc.{ all => cmd, _ }
+    import cats.implicits.toFoldableOps
+    import cats.instances.list._
+    unsafeRun[LaserDiscClient](c =>
+      items.traverse_(it => c.send(cmd.hset[String](Key.unsafeFrom(key), Key.unsafeFrom(it._1), it._2)))
+    )
+  }
+
+  @Benchmark
+  def rediculous(): Unit = {
+    import cats.implicits._
+    import io.chrisdavenport.rediculous._
+    unsafeRun[RediculousClient](c => items.traverse_(it => RedisCommands.hset[RedisIO](key, it._1, it._2).run(c)))
+  }
+
+  @Benchmark
+  def redis4cats(): Unit = {
+    import cats.syntax.foldable._
+    unsafeRun[Redis4CatsClient[String]](c => items.traverse_(it => c.hSet(key, it._1, it._2)))
+  }
+
+  @Benchmark
+  def zio(): Unit = zioUnsafeRun(ZIO.foreach_(items)(it => hSet(key, it)))
+}

--- a/benchmarks/src/main/scala/zio/redis/hash/HSetNxBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/hash/HSetNxBenchmarks.scala
@@ -1,0 +1,55 @@
+package zio.redis.hash
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import zio.ZIO
+import zio.redis.{ BenchmarkRuntime, hSetNx }
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 15)
+@Warmup(iterations = 15)
+@Fork(2)
+class HSetNxBenchmarks extends BenchmarkRuntime {
+  @Param(Array("500"))
+  private var size: Int = _
+
+  private var items: List[(String, String)] = _
+
+  private val key = "test-hash"
+
+  @Setup(Level.Trial)
+  def setup(): Unit =
+    items = (0 to size).map(e => e.toString -> e.toString).toList
+  //    zioUnsafeRun(hSet(key, items.head, items.tail: _*).unit)
+
+  @Benchmark
+  def laserdisc(): Unit = {
+    import _root_.laserdisc.fs2._
+    import _root_.laserdisc.{ all => cmd, _ }
+    import cats.implicits.toFoldableOps
+    import cats.instances.list._
+    unsafeRun[LaserDiscClient](c =>
+      items.traverse_(it => c.send(cmd.hsetnx[String](Key.unsafeFrom(key), Key.unsafeFrom(it._1), it._2)))
+    )
+  }
+
+  @Benchmark
+  def rediculous(): Unit = {
+    import cats.implicits._
+    import io.chrisdavenport.rediculous._
+    unsafeRun[RediculousClient](c => items.traverse_(it => RedisCommands.hsetnx[RedisIO](key, it._1, it._2).run(c)))
+  }
+
+  @Benchmark
+  def redis4cats(): Unit = {
+    import cats.syntax.foldable._
+    unsafeRun[Redis4CatsClient[String]](c => items.traverse_(it => c.hSetNx(key, it._1, it._2)))
+  }
+
+  @Benchmark
+  def zio(): Unit = zioUnsafeRun(ZIO.foreach_(items)(it => hSetNx(key, it._1, it._2)))
+}

--- a/benchmarks/src/main/scala/zio/redis/hash/HStrLenBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/hash/HStrLenBenchmarks.scala
@@ -1,0 +1,54 @@
+package zio.redis.hash
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import zio.ZIO
+import zio.redis.{ BenchmarkRuntime, hSet, hStrLen }
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 15)
+@Warmup(iterations = 15)
+@Fork(2)
+class HStrLenBenchmarks extends BenchmarkRuntime {
+  @Param(Array("500"))
+  private var size: Int = _
+
+  private var items: List[(String, String)] = _
+
+  private val key = "test-hash"
+
+  def setup(): Unit = {
+    items = (0 to size).map(e => e.toString -> e.toString).toList
+    zioUnsafeRun(hSet(key, items.head, items.tail: _*).unit)
+  }
+  @Benchmark
+  def laserdisc(): Unit = {
+    import _root_.laserdisc.fs2._
+    import _root_.laserdisc.{ all => cmd, _ }
+    import cats.implicits.toFoldableOps
+    import cats.instances.list._
+    unsafeRun[LaserDiscClient](c =>
+      items.traverse_(it => c.send(cmd.hstrlen(Key.unsafeFrom(key), Key.unsafeFrom(it._1))))
+    )
+  }
+
+  @Benchmark
+  def rediculous(): Unit = {
+    import cats.implicits._
+    import io.chrisdavenport.rediculous._
+    unsafeRun[RediculousClient](c => items.traverse_(it => RedisCommands.hstrlen[RedisIO](key, it._1).run(c)))
+  }
+
+  @Benchmark
+  def redis4cats(): Unit = {
+    import cats.syntax.foldable._
+    unsafeRun[Redis4CatsClient[String]](c => items.traverse_(it => c.hStrLen(key, it._1)))
+  }
+
+  @Benchmark
+  def zio(): Unit = zioUnsafeRun(ZIO.foreach_(items)(it => hStrLen(key, it._1)))
+}

--- a/benchmarks/src/main/scala/zio/redis/hash/HValsBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/hash/HValsBenchmarks.scala
@@ -1,0 +1,55 @@
+package zio.redis.hash
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import zio.ZIO
+import zio.redis.{ BenchmarkRuntime, hSet, hVals }
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 15)
+@Warmup(iterations = 15)
+@Fork(2)
+class HValsBenchmarks extends BenchmarkRuntime {
+  @Param(Array("500"))
+  private var size: Int = _
+
+  private var items: List[(String, String)] = _
+
+  private val key = "test-hash"
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    items = (0 to size).map(e => e.toString -> e.toString).toList
+    zioUnsafeRun(hSet(key, items.head, items.tail: _*).unit)
+  }
+
+  @Benchmark
+  def laserdisc(): Unit = {
+    import _root_.laserdisc.fs2._
+    import _root_.laserdisc.{ all => cmd, _ }
+    import cats.implicits.toFoldableOps
+    import cats.instances.list._
+    unsafeRun[LaserDiscClient](c => items.traverse_(_ => c.send(cmd.hvals(Key.unsafeFrom(key)))))
+  }
+
+  @Benchmark
+  def rediculous(): Unit = {
+    import cats.implicits._
+    import io.chrisdavenport.rediculous._
+    unsafeRun[RediculousClient](c => items.traverse_(_ => RedisCommands.hvals[RedisIO](key).run(c)))
+  }
+
+  @Benchmark
+  def redis4cats(): Unit = {
+    import cats.instances.list._
+    import cats.syntax.foldable._
+    unsafeRun[Redis4CatsClient[String]](c => items.traverse_(_ => c.hVals(key)))
+  }
+
+  @Benchmark
+  def zio(): Unit = zioUnsafeRun(ZIO.foreach_(items)(_ => hVals(key)))
+}


### PR DESCRIPTION
Closes #167 

`Hscan`is not implemented in all libraries, so it was not tested.

The parameters of some commands provided by the `io.chrisdavenport.rediculous` and `dev.profunktor.redis4cats` library are List/Map rather than variable length parameters, which may lead to inaccurate pressure measurement, because we have to construct the list object.

Benchmark machine and redis version.
```
JDK 11.0.7, OpenJDK 64-Bit Server VM, 11.0.7+10
Redis 6.0.6
MacBook Pro (13-inch, 2019, Two Thunderbolt 3 ports) 
CPU 1.4 GHz Four core Intel Core i5 
Memory 8 GB 2133 MHz LPDDR3
```


hDel
```
Benchmark                  (size)   Mode  Cnt   Score   Error  Units
HDelBenchmarks.laserdisc      500  thrpt   30  10.184 ± 0.662  ops/s
HDelBenchmarks.rediculous     500  thrpt   30   9.499 ± 0.336  ops/s
HDelBenchmarks.redis4cats     500  thrpt   30  25.732 ± 0.166  ops/s
HDelBenchmarks.zio            500  thrpt   30  25.525 ± 0.964  ops/s
```

hExists
```
Benchmark                     (size)   Mode  Cnt   Score   Error  Units
HExistsBenchmarks.laserdisc      500  thrpt   30  10.031 ± 0.249  ops/s
HExistsBenchmarks.rediculous     500  thrpt   30   8.262 ± 0.517  ops/s
HExistsBenchmarks.redis4cats     500  thrpt   30  21.486 ± 0.810  ops/s
HExistsBenchmarks.zio            500  thrpt   30  19.018 ± 1.788  ops/s
```

hGetAll
```
Benchmark                     (size)   Mode  Cnt  Score   Error  Units
HGetAllBenchmarks.laserdisc      500  thrpt   30  0.981 ± 0.093  ops/s
HGetAllBenchmarks.rediculous     500  thrpt   30  2.259 ± 0.040  ops/s
HGetAllBenchmarks.redis4cats     500  thrpt   30  5.154 ± 0.030  ops/s
HGetAllBenchmarks.zio            500  thrpt   30  3.384 ± 0.009  ops/s
```

hGet
```
Benchmark                  (size)   Mode  Cnt   Score   Error  Units
HGetBenchmarks.laserdisc      500  thrpt   30  10.050 ± 0.237  ops/s
HGetBenchmarks.rediculous     500  thrpt   30   9.445 ± 0.193  ops/s
HGetBenchmarks.redis4cats     500  thrpt   30  24.090 ± 0.573  ops/s
HGetBenchmarks.zio            500  thrpt   30  23.476 ± 0.254  ops/s
```

hIncrBy
```
Benchmark                     (increment)  (size)   Mode  Cnt   Score   Error  Units
HIncrbyBenchmarks.laserdisc             1     500  thrpt   30   9.485 ± 0.418  ops/s
HIncrbyBenchmarks.rediculous            1     500  thrpt   30   8.491 ± 0.356  ops/s
HIncrbyBenchmarks.redis4cats            1     500  thrpt   30  23.164 ± 0.066  ops/s
HIncrbyBenchmarks.zio                   1     500  thrpt   30  22.115 ± 0.314  ops/s
```

hIncrByFloat
```
Benchmark                          (increment)  (size)   Mode  Cnt   Score   Error  Units
HIncrbyFloatBenchmarks.laserdisc           1.0     500  thrpt   30   9.008 ± 0.575  ops/s
HIncrbyFloatBenchmarks.rediculous          1.0     500  thrpt   30   8.920 ± 0.059  ops/s
HIncrbyFloatBenchmarks.redis4cats          1.0     500  thrpt   30  22.434 ± 0.256  ops/s
HIncrbyFloatBenchmarks.zio                 1.0     500  thrpt   30  21.107 ± 0.624  ops/s
```

hKeys
```
Benchmark                   (size)   Mode  Cnt   Score   Error  Units
HKeysBenchmarks.laserdisc      500  thrpt   30   1.752 ± 0.055  ops/s
HKeysBenchmarks.rediculous     500  thrpt   30   4.280 ± 0.036  ops/s
HKeysBenchmarks.redis4cats     500  thrpt   30  10.095 ± 0.049  ops/s
HKeysBenchmarks.zio            500  thrpt   30   6.743 ± 0.097  ops/s
```

hLen
```
Benchmark                  (size)   Mode  Cnt   Score   Error  Units
HLenBenchmarks.laserdisc      500  thrpt   30  10.796 ± 0.428  ops/s
HLenBenchmarks.rediculous     500  thrpt   30   8.650 ± 0.353  ops/s
HLenBenchmarks.redis4cats     500  thrpt   30  23.581 ± 1.248  ops/s
HLenBenchmarks.zio            500  thrpt   30  25.980 ± 0.297  ops/s
```

hmGet
```
Benchmark                   (size)   Mode  Cnt   Score   Error  Units
HMGetBenchmarks.laserdisc      500  thrpt   30  10.440 ± 0.342  ops/s
HMGetBenchmarks.rediculous     500  thrpt   30   9.359 ± 0.540  ops/s
HMGetBenchmarks.redis4cats     500  thrpt   30  24.697 ± 0.120  ops/s
HMGetBenchmarks.zio            500  thrpt   30  24.267 ± 0.174  ops/s
```

hmSet
```
Benchmark                   (size)   Mode  Cnt   Score   Error  Units
HMSetBenchmarks.laserdisc      500  thrpt   30  10.806 ± 0.155  ops/s
HMSetBenchmarks.rediculous     500  thrpt   30   9.738 ± 0.099  ops/s
HMSetBenchmarks.redis4cats     500  thrpt   30  24.428 ± 0.303  ops/s
HMSetBenchmarks.zio            500  thrpt   30  19.743 ± 3.444  ops/s
```

hSet
```
Benchmark                  (size)   Mode  Cnt   Score   Error  Units
HSetBenchmarks.laserdisc      500  thrpt   30  10.371 ± 0.164  ops/s
HSetBenchmarks.rediculous     500  thrpt   30   9.063 ± 0.582  ops/s
HSetBenchmarks.redis4cats     500  thrpt   30  24.504 ± 0.436  ops/s
HSetBenchmarks.zio            500  thrpt   30  23.313 ± 0.114  ops/s
```

hSetNx
```
Benchmark                    (size)   Mode  Cnt   Score   Error  Units
HSetNxBenchmarks.laserdisc      500  thrpt   30  10.667 ± 0.116  ops/s
HSetNxBenchmarks.rediculous     500  thrpt   30   9.799 ± 0.127  ops/s
HSetNxBenchmarks.redis4cats     500  thrpt   30  24.955 ± 0.226  ops/s
HSetNxBenchmarks.zio            500  thrpt   30  23.467 ± 0.544  ops/s
```


hStrLen
```
Benchmark                     (size)   Mode  Cnt   Score   Error  Units
HStrLenBenchmarks.laserdisc      500  thrpt   30   9.820 ± 0.349  ops/s
HStrLenBenchmarks.rediculous     500  thrpt   30   9.783 ± 0.326  ops/s
HStrLenBenchmarks.redis4cats     500  thrpt   30  24.690 ± 0.194  ops/s
HStrLenBenchmarks.zio            500  thrpt   30  24.409 ± 0.146  ops/s
```

hVals
```
Benchmark                   (size)   Mode  Cnt  Score   Error  Units
HValsBenchmarks.laserdisc      500  thrpt   30  1.691 ± 0.010  ops/s
HValsBenchmarks.rediculous     500  thrpt   30  4.176 ± 0.107  ops/s
HValsBenchmarks.redis4cats     500  thrpt   30  9.886 ± 0.084  ops/s
HValsBenchmarks.zio            500  thrpt   30  6.739 ± 0.055  ops/s
```