### PR TITLE
Add support for the XINFO command

### DIFF
--- a/redis/src/main/scala/zio/redis/Input.scala
+++ b/redis/src/main/scala/zio/redis/Input.scala
@@ -268,6 +268,21 @@ object Input {
       Chunk(encodeString("DELCONSUMER"), encodeString(data.key), encodeString(data.group), encodeString(data.consumer))
   }
 
+  case object XInfoGroupInput extends Input[XInfoCommand.Group] {
+    def encode(data: XInfoCommand.Group): Chunk[RespValue.BulkString] =
+      Chunk(encodeString("GROUPS"), encodeString(data.key))
+  }
+
+  case object XInfoStreamInput extends Input[XInfoCommand.Stream] {
+    def encode(data: XInfoCommand.Stream): Chunk[RespValue.BulkString] =
+      Chunk(encodeString("STREAM"), encodeString(data.key))
+  }
+
+  case object XInfoConsumerInput extends Input[XInfoCommand.Consumer] {
+    def encode(data: XInfoCommand.Consumer): Chunk[RespValue.BulkString] =
+      Chunk(encodeString("CONSUMERS"), encodeString(data.key), encodeString(data.group))
+  }
+
   case object BlockInput extends Input[Duration] {
     def encode(data: Duration): Chunk[RespValue.BulkString] =
       Chunk(encodeString("BLOCK"), encodeString(data.toMillis.toString))

--- a/redis/src/main/scala/zio/redis/api/Streams.scala
+++ b/redis/src/main/scala/zio/redis/api/Streams.scala
@@ -40,6 +40,38 @@ trait Streams {
     XAdd.run((key, None, id, (pair, pairs.toList)))
 
   /**
+   * An introspection command used in order to retrieve different information about the group.
+   *
+   * @param key ID of the stream
+   * @return The result of introspection.
+   */
+  final def xInfoGroup(
+    key: String
+  ): ZIO[RedisExecutor, RedisError, Chunk[StreamGroupInfo]] = XInfoGroups.run(XInfoCommand.Group(key))
+
+  /**
+   * An introspection command used in order to retrieve different information about the consumers.
+   *
+   * @param key ID of the stream
+   * @param group ID of the consumer group
+   * @return The result of consumers introspection.
+   */
+  final def xInfoConsumers(
+    key: String,
+    group: String
+  ): ZIO[RedisExecutor, RedisError, Chunk[StreamConsumerInfo]] = XInfoConsumers.run(XInfoCommand.Consumer(key, group))
+
+  /**
+   * An introspection command used in order to retrieve different information about the stream.
+   *
+   * @param key ID of the stream
+   * @return The result of introspection.
+   */
+  final def xInfoStream(
+    key: String
+  ): ZIO[RedisExecutor, RedisError, StreamInfo] = XInfoStream.run(XInfoCommand.Stream(key))
+
+  /**
    * Appends the specified stream entry to the stream at the specified key while limiting the size of the stream.
    *
    * @param key ID of the stream
@@ -381,6 +413,9 @@ trait Streams {
 
 private object Streams {
 
+  import zio.redis.Input.XInfoConsumerInput
+  import zio.redis.Output.StreamGroupInfoOutput
+
   final val XAck: RedisCommand[(String, String, (String, List[String])), Long] =
     RedisCommand("XACK", Tuple3(StringInput, StringInput, NonEmptyList(StringInput)), LongOutput)
 
@@ -468,7 +503,15 @@ private object Streams {
   final val XGroupDelConsumer: RedisCommand[XGroupCommand.DelConsumer, Long] =
     RedisCommand("XGROUP", XGroupDelConsumerInput, LongOutput)
 
-  // TODO: implement XINFO command
+  //TODO XINFO FULL and HELP
+  final val XInfoGroups: RedisCommand[XInfoCommand.Group, Chunk[StreamGroupInfo]] =
+    RedisCommand("XINFO", XInfoGroupInput, StreamGroupInfoOutput)
+
+  final val XInfoStream: RedisCommand[XInfoCommand.Stream, StreamInfo] =
+    RedisCommand("XINFO", XInfoStreamInput, StreamInfoOutput)
+
+  final val XInfoConsumers: RedisCommand[XInfoCommand.Consumer, Chunk[StreamConsumerInfo]] =
+    RedisCommand("XINFO", XInfoConsumerInput, StreamConsumersInfoOutput)
 
   final val XLen: RedisCommand[String, Long] = RedisCommand("XLEN", StringInput, LongOutput)
 

--- a/redis/src/main/scala/zio/redis/api/Streams.scala
+++ b/redis/src/main/scala/zio/redis/api/Streams.scala
@@ -1,8 +1,8 @@
 package zio.redis.api
 
 import zio.duration._
-import zio.redis.Input._
-import zio.redis.Output._
+import zio.redis.Input.{ XInfoConsumerInput, _ }
+import zio.redis.Output.{ StreamGroupInfoOutput, _ }
 import zio.redis._
 import zio.{ Chunk, ZIO }
 
@@ -43,7 +43,7 @@ trait Streams {
    * An introspection command used in order to retrieve different information about the group.
    *
    * @param key ID of the stream
-   * @return The result of introspection.
+   * @return List of consumer groups associated with the stream stored at the specified key.
    */
   final def xInfoGroup(
     key: String
@@ -54,7 +54,7 @@ trait Streams {
    *
    * @param key ID of the stream
    * @param group ID of the consumer group
-   * @return The result of consumers introspection.
+   * @return List of every consumer in a specific consumer group.
    */
   final def xInfoConsumers(
     key: String,
@@ -65,7 +65,7 @@ trait Streams {
    * An introspection command used in order to retrieve different information about the stream.
    *
    * @param key ID of the stream
-   * @return The result of introspection.
+   * @return General information about the stream stored at the specified key.
    */
   final def xInfoStream(
     key: String
@@ -413,9 +413,6 @@ trait Streams {
 
 private object Streams {
 
-  import zio.redis.Input.XInfoConsumerInput
-  import zio.redis.Output.StreamGroupInfoOutput
-
   final val XAck: RedisCommand[(String, String, (String, List[String])), Long] =
     RedisCommand("XACK", Tuple3(StringInput, StringInput, NonEmptyList(StringInput)), LongOutput)
 
@@ -503,7 +500,6 @@ private object Streams {
   final val XGroupDelConsumer: RedisCommand[XGroupCommand.DelConsumer, Long] =
     RedisCommand("XGROUP", XGroupDelConsumerInput, LongOutput)
 
-  //TODO XINFO FULL and HELP
   final val XInfoGroups: RedisCommand[XInfoCommand.Group, Chunk[StreamGroupInfo]] =
     RedisCommand("XINFO", XInfoGroupInput, StreamGroupInfoOutput)
 
@@ -511,7 +507,7 @@ private object Streams {
     RedisCommand("XINFO", XInfoStreamInput, StreamInfoOutput)
 
   final val XInfoConsumers: RedisCommand[XInfoCommand.Consumer, Chunk[StreamConsumerInfo]] =
-    RedisCommand("XINFO", XInfoConsumerInput, StreamConsumersInfoOutput)
+    RedisCommand("XINFO", XInfoConsumerInput, StreamConsumerInfoOutput)
 
   final val XLen: RedisCommand[String, Long] = RedisCommand("XLEN", StringInput, LongOutput)
 

--- a/redis/src/main/scala/zio/redis/options/Streams.scala
+++ b/redis/src/main/scala/zio/redis/options/Streams.scala
@@ -3,6 +3,7 @@ package zio.redis.options
 import zio.duration._
 
 trait Streams {
+
   case object WithForce {
     private[redis] def stringify = "FORCE"
   }
@@ -18,11 +19,29 @@ trait Streams {
   sealed trait XGroupCommand
 
   object XGroupCommand {
+
     case class Create(key: String, group: String, id: String, mkStream: Boolean) extends XGroupCommand
-    case class SetId(key: String, group: String, id: String)                     extends XGroupCommand
-    case class Destroy(key: String, group: String)                               extends XGroupCommand
-    case class CreateConsumer(key: String, group: String, consumer: String)      extends XGroupCommand
-    case class DelConsumer(key: String, group: String, consumer: String)         extends XGroupCommand
+
+    case class SetId(key: String, group: String, id: String) extends XGroupCommand
+
+    case class Destroy(key: String, group: String) extends XGroupCommand
+
+    case class CreateConsumer(key: String, group: String, consumer: String) extends XGroupCommand
+
+    case class DelConsumer(key: String, group: String, consumer: String) extends XGroupCommand
+
+  }
+
+  sealed trait XInfoCommand
+
+  object XInfoCommand {
+
+    case class Group(key: String) extends XInfoCommand
+
+    case class Stream(key: String) extends XInfoCommand
+
+    case class Consumer(key: String, group: String) extends XInfoCommand
+
   }
 
   case object MkStream {
@@ -54,4 +73,21 @@ trait Streams {
   type NoAck = NoAck.type
 
   case class MaxLen(approximate: Boolean, count: Long)
+
+  case class StreamEntry(id: String, fields: Map[String, String])
+
+  case class StreamInfo(
+    length: Long,
+    radixTreeKeys: Long,
+    radixTreeNodes: Long,
+    groups: Long,
+    lastGeneratedId: String,
+    firstEntry: StreamEntry,
+    lastEntry: StreamEntry
+  )
+
+  case class StreamGroupInfo(name: String, consumers: Long, pending: Long, lastDeliveredId: String)
+
+  case class StreamConsumerInfo(name: String, idle: Long, pending: Long)
+
 }

--- a/redis/src/main/scala/zio/redis/options/Streams.scala
+++ b/redis/src/main/scala/zio/redis/options/Streams.scala
@@ -41,7 +41,6 @@ trait Streams {
     case class Stream(key: String) extends XInfoCommand
 
     case class Consumer(key: String, group: String) extends XInfoCommand
-
   }
 
   case object MkStream {
@@ -77,17 +76,59 @@ trait Streams {
   case class StreamEntry(id: String, fields: Map[String, String])
 
   case class StreamInfo(
-    length: Long,
-    radixTreeKeys: Long,
-    radixTreeNodes: Long,
-    groups: Long,
-    lastGeneratedId: String,
-    firstEntry: StreamEntry,
-    lastEntry: StreamEntry
+    length: Option[Long],
+    radixTreeKeys: Option[Long],
+    radixTreeNodes: Option[Long],
+    groups: Option[Long],
+    lastGeneratedId: Option[String],
+    firstEntry: Option[StreamEntry],
+    lastEntry: Option[StreamEntry]
   )
 
-  case class StreamGroupInfo(name: String, consumers: Long, pending: Long, lastDeliveredId: String)
+  object StreamInfo {
+    def empty: StreamInfo = StreamInfo(None, None, None, None, None, None, None)
+  }
 
-  case class StreamConsumerInfo(name: String, idle: Long, pending: Long)
+  case class StreamGroupInfo(
+    name: Option[String],
+    consumers: Option[Long],
+    pending: Option[Long],
+    lastDeliveredId: Option[String]
+  )
+
+  object StreamGroupInfo {
+    def empty: StreamGroupInfo = StreamGroupInfo(None, None, None, None)
+  }
+
+  case class StreamConsumerInfo(
+    name: Option[String],
+    idle: Option[Long],
+    pending: Option[Long]
+  )
+
+  object StreamConsumerInfo {
+    def empty: StreamConsumerInfo = StreamConsumerInfo(None, None, None)
+  }
+
+  private[redis] object XInfoFields {
+    val Name: String    = "name"
+    val Idle: String    = "idle"
+    val Pending: String = "pending"
+
+    val Consumers: String     = "consumers"
+    val LastDelivered: String = "last-delivered-id"
+
+    val Length: String          = "length"
+    val RadixTreeKeys: String   = "radix-tree-keys"
+    val RadixTreeNodes: String  = "radix-tree-nodes"
+    val Groups: String          = "groups"
+    val LastGeneratedId: String = "last-generated-id"
+    val FirstEntry: String      = "first-entry"
+    val LastEntry: String       = "last-entry"
+
+    val Entries: String  = "entries"
+    val PelCount: String = "pel-count"
+    val SeenTime: String = "seen-time"
+  }
 
 }

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -926,6 +926,20 @@ object InputSpec extends BaseSpec {
             .map(assert(_)(equalTo(respArgs("STREAMS", "a", "c", "b", "d"))))
         }
       ),
+      suite("XInfo")(
+        testM("stream info") {
+          Task(XInfoStreamInput.encode(XInfoCommand.Stream("key")))
+            .map(assert(_)(equalTo(respArgs("STREAM", "key"))))
+        },
+        testM("group info") {
+          Task(XInfoGroupInput.encode(XInfoCommand.Group("key")))
+            .map(assert(_)(equalTo(respArgs("GROUPS", "key"))))
+        },
+        testM("consumer info") {
+          Task(XInfoConsumerInput.encode(XInfoCommand.Consumer("key", "group")))
+            .map(assert(_)(equalTo(respArgs("CONSUMERS", "key", "group"))))
+        }
+      ),
       suite("Group")(
         testM("valid value") {
           Task(GroupInput.encode(Group("group", "consumer")))


### PR DESCRIPTION
https://github.com/zio/zio-redis/issues/233
Refer to the design of [jedis](https://github.com/redis/jedis).It provide three method(sub command) as follows:
```java
  void xinfoStream (String key);

  void xinfoGroup (String key);

  void xinfoConsumers (String key, String group);
```
The`full` option are not included.

Redis documents tell us that we can't rely on the number and order of returned fields, and we should record undefined fields. This is different from the implementation of jedis, in which all the original records are stored in a `Map[String, Object]`.

Use `undefined` to record potentially unsupported fields.