### PR TITLE
Support SORT command in Keys API

### DIFF
--- a/redis/src/main/scala/zio/redis/Input.scala
+++ b/redis/src/main/scala/zio/redis/Input.scala
@@ -138,11 +138,6 @@ object Input {
       Chunk(encodeString("LIMIT"), encodeString(data.offset.toString), encodeString(data.count.toString))
   }
 
-  final case class ListInput[-A](input: Input[A]) extends Input[List[A]] {
-    override private[redis] def encode(data: List[A]): Chunk[RespValue.BulkString] =
-      Chunk.fromIterable(data).flatMap(input.encode)
-  }
-
   case object LongInput extends Input[Long] {
     def encode(data: Long): Chunk[RespValue.BulkString] = Chunk.single(encodeString(data.toString))
   }

--- a/redis/src/main/scala/zio/redis/Input.scala
+++ b/redis/src/main/scala/zio/redis/Input.scala
@@ -26,20 +26,16 @@ object Input {
       Chunk(encodeString("AGGREGATE"), encodeString(data.stringify))
   }
 
+  case object AlphaInput extends Input[Alpha] {
+    def encode(data: Alpha): Chunk[RespValue.BulkString] = Chunk.single(encodeString(data.stringify))
+  }
+
   case object AuthInput extends Input[Auth] {
     def encode(data: Auth): Chunk[RespValue.BulkString] = Chunk(encodeString("AUTH"), encodeString(data.password))
   }
 
   case object BoolInput extends Input[Boolean] {
     def encode(data: Boolean): Chunk[RespValue.BulkString] = Chunk.single(encodeString(if (data) "1" else "0"))
-  }
-
-  case object ByInput extends Input[String] {
-    def encode(data: String): Chunk[RespValue.BulkString] = Chunk(encodeString("BY"), encodeString(data))
-  }
-
-  case object GetInput extends Input[String] {
-    def encode(data: String): Chunk[RespValue.BulkString] = Chunk(encodeString("GET"), encodeString(data))
   }
 
   case object BitFieldCommandInput extends Input[BitFieldCommand] {
@@ -68,6 +64,10 @@ object Input {
     }
   }
 
+  case object ByInput extends Input[String] {
+    def encode(data: String): Chunk[RespValue.BulkString] = Chunk(encodeString("BY"), encodeString(data))
+  }
+
   case object ChangedInput extends Input[Changed] {
     def encode(data: Changed): Chunk[RespValue.BulkString] = Chunk.single(encodeString(data.stringify))
   }
@@ -79,6 +79,10 @@ object Input {
   case object CountInput extends Input[Count] {
     def encode(data: Count): Chunk[RespValue.BulkString] =
       Chunk(encodeString("COUNT"), encodeString(data.count.toString))
+  }
+
+  case object GetInput extends Input[String] {
+    def encode(data: String): Chunk[RespValue.BulkString] = Chunk(encodeString("GET"), encodeString(data))
   }
 
   case object PositionInput extends Input[Position] {
@@ -134,6 +138,11 @@ object Input {
       Chunk(encodeString("LIMIT"), encodeString(data.offset.toString), encodeString(data.count.toString))
   }
 
+  final case class ListInput[-A](input: Input[A]) extends Input[List[A]] {
+    override private[redis] def encode(data: List[A]): Chunk[RespValue.BulkString] =
+      data.foldLeft(Chunk.empty: Chunk[RespValue.BulkString])((acc, a) => acc ++ input.encode(a))
+  }
+
   case object LongInput extends Input[Long] {
     def encode(data: Long): Chunk[RespValue.BulkString] = Chunk.single(encodeString(data.toString))
   }
@@ -152,11 +161,6 @@ object Input {
     def encode(data: Unit): Chunk[RespValue.BulkString] = Chunk.empty
   }
 
-  final case class ListInput[-A](input: Input[A]) extends Input[List[A]] {
-    override private[redis] def encode(data: List[A]): Chunk[RespValue.BulkString] =
-      data.foldLeft(Chunk.empty: Chunk[RespValue.BulkString])((acc, a) => acc ++ input.encode(a))
-  }
-
   final case class NonEmptyList[-A](input: Input[A]) extends Input[(A, List[A])] {
     def encode(data: (A, List[A])): Chunk[RespValue.BulkString] =
       (data._1 :: data._2).foldLeft(Chunk.empty: Chunk[RespValue.BulkString])((acc, a) => acc ++ input.encode(a))
@@ -164,10 +168,6 @@ object Input {
 
   case object OrderInput extends Input[Order] {
     def encode(data: Order): Chunk[RespValue.BulkString] = Chunk.single(encodeString(data.stringify))
-  }
-
-  case object AlphaInput extends Input[Alpha] {
-    def encode(data: Alpha): Chunk[RespValue.BulkString] = Chunk.single(encodeString(data.stringify))
   }
 
   case object RadiusUnitInput extends Input[RadiusUnit] {

--- a/redis/src/main/scala/zio/redis/Input.scala
+++ b/redis/src/main/scala/zio/redis/Input.scala
@@ -140,7 +140,7 @@ object Input {
 
   final case class ListInput[-A](input: Input[A]) extends Input[List[A]] {
     override private[redis] def encode(data: List[A]): Chunk[RespValue.BulkString] =
-      data.foldLeft(Chunk.empty: Chunk[RespValue.BulkString])((acc, a) => acc ++ input.encode(a))
+      Chunk.fromIterable(data).flatMap(input.encode)
   }
 
   case object LongInput extends Input[Long] {

--- a/redis/src/main/scala/zio/redis/RedisError.scala
+++ b/redis/src/main/scala/zio/redis/RedisError.scala
@@ -7,7 +7,9 @@ import scala.util.control.NoStackTrace
 sealed trait RedisError extends NoStackTrace
 
 object RedisError {
-  final case class ProtocolError(message: String)  extends RedisError
+  final case class ProtocolError(message: String) extends RedisError {
+    override def toString: String = s"ProtocolError: $message"
+  }
   final case class WrongType(message: String)      extends RedisError
   final case class BusyGroup(message: String)      extends RedisError
   final case class NoGroup(message: String)        extends RedisError

--- a/redis/src/main/scala/zio/redis/RedisError.scala
+++ b/redis/src/main/scala/zio/redis/RedisError.scala
@@ -7,9 +7,7 @@ import scala.util.control.NoStackTrace
 sealed trait RedisError extends NoStackTrace
 
 object RedisError {
-  final case class ProtocolError(message: String)  extends RedisError {
-    override def toString: String = message
-  }
+  final case class ProtocolError(message: String)  extends RedisError
   final case class WrongType(message: String)      extends RedisError
   final case class BusyGroup(message: String)      extends RedisError
   final case class NoGroup(message: String)        extends RedisError

--- a/redis/src/main/scala/zio/redis/RedisError.scala
+++ b/redis/src/main/scala/zio/redis/RedisError.scala
@@ -7,7 +7,9 @@ import scala.util.control.NoStackTrace
 sealed trait RedisError extends NoStackTrace
 
 object RedisError {
-  final case class ProtocolError(message: String)  extends RedisError
+  final case class ProtocolError(message: String)  extends RedisError {
+    override def toString: String = message
+  }
   final case class WrongType(message: String)      extends RedisError
   final case class BusyGroup(message: String)      extends RedisError
   final case class NoGroup(message: String)        extends RedisError

--- a/redis/src/main/scala/zio/redis/api/Keys.scala
+++ b/redis/src/main/scala/zio/redis/api/Keys.scala
@@ -313,20 +313,6 @@ trait Keys {
 }
 
 private[redis] object Keys {
-  def sortArguments(
-    by: Option[String],
-    limitOffset: Option[(Int, Int)],
-    desc: Boolean,
-    get: List[String],
-    alpha: Boolean
-  ): List[String] =
-    by.map(sortBy => List("BY", sortBy)).getOrElse(List.empty) ++
-      limitOffset.map { case (count, offset) => List("LIMIT", offset.toString, count.toString) }
-        .getOrElse(List.empty) ++
-      get.flatMap(getAt => List("GET", getAt)) ++
-      List(if (desc) "DESC" else "ASC") ++
-      (if (alpha) List("ALPHA") else List.empty)
-
   final val Del: RedisCommand[(String, List[String]), Long] = RedisCommand("DEL", NonEmptyList(StringInput), LongOutput)
 
   final val Dump: RedisCommand[String, Chunk[Byte]] = RedisCommand("DUMP", StringInput, BulkStringOutput)

--- a/redis/src/main/scala/zio/redis/api/Keys.scala
+++ b/redis/src/main/scala/zio/redis/api/Keys.scala
@@ -216,16 +216,16 @@ trait Keys {
     `type`: Option[String] = None
   ): ZIO[RedisExecutor, RedisError, (Long, Chunk[String])] = Scan.run((cursor, pattern, count, `type`))
 
-
   private def sortArguments(
-                             by: Option[String],
-                             limitOffset: Option[(Int, Int)],
-                             desc: Boolean,
-                             get: List[String],
-                             alpha: Boolean,
-                           ): List[String] =
-    by.map { sortBy => List("BY", sortBy)}.getOrElse(List.empty) ++
-      limitOffset.map { case (count, offset) => List("LIMIT", offset.toString, count.toString) }.getOrElse(List.empty) ++
+    by: Option[String],
+    limitOffset: Option[(Int, Int)],
+    desc: Boolean,
+    get: List[String],
+    alpha: Boolean
+  ): List[String] =
+    by.map(sortBy => List("BY", sortBy)).getOrElse(List.empty) ++
+      limitOffset.map { case (count, offset) => List("LIMIT", offset.toString, count.toString) }
+        .getOrElse(List.empty) ++
       get.flatMap(getAt => List("GET", getAt)) ++
       List(if (desc) "DESC" else "ASC") ++
       (if (alpha) List("ALPHA") else List.empty)
@@ -236,28 +236,25 @@ trait Keys {
     limitOffset: Option[(Int, Int)] = None,
     desc: Boolean = false,
     get: List[String] = List.empty,
-    alpha: Boolean = false,
-  ): ZIO[RedisExecutor, RedisError, Chunk[String]] =
-    {
-      val args = sortArguments(by, limitOffset, desc, get, alpha)
-      Sort.run((key, args))
-    }
-
+    alpha: Boolean = false
+  ): ZIO[RedisExecutor, RedisError, Chunk[String]] = {
+    val args = sortArguments(by, limitOffset, desc, get, alpha)
+    Sort.run((key, args))
+  }
 
   final def sortStore(
-                       key: String,
-                       storeAt: String,
-                       by: Option[String] = None,
-                       limitOffset: Option[(Int, Int)] = None,
-                       desc: Boolean = false,
-                       get: List[String] = List.empty,
-                       alpha: Boolean = false,
-                     ): ZIO[RedisExecutor, RedisError, Long] = {
+    key: String,
+    storeAt: String,
+    by: Option[String] = None,
+    limitOffset: Option[(Int, Int)] = None,
+    desc: Boolean = false,
+    get: List[String] = List.empty,
+    alpha: Boolean = false
+  ): ZIO[RedisExecutor, RedisError, Long] = {
     val args = sortArguments(by, limitOffset, desc, get, alpha) ++ List("STORE", storeAt)
 
     SortStore.run((key, args))
   }
-
 
   /**
    * Alters the last access time of a key(s). A key is ignored if it does not exist.

--- a/redis/src/main/scala/zio/redis/api/Keys.scala
+++ b/redis/src/main/scala/zio/redis/api/Keys.scala
@@ -217,22 +217,46 @@ trait Keys {
   ): ZIO[RedisExecutor, RedisError, (Long, Chunk[String])] = Scan.run((cursor, pattern, count, `type`))
 
 
+  private def sortArguments(
+                             by: Option[String],
+                             limitOffset: Option[(Int, Int)],
+                             desc: Boolean,
+                             get: List[String],
+                             alpha: Boolean,
+                           ): List[String] =
+    by.map { sortBy => List("BY", sortBy)}.getOrElse(List.empty) ++
+      limitOffset.map { case (count, offset) => List("LIMIT", offset.toString, count.toString) }.getOrElse(List.empty) ++
+      get.flatMap(getAt => List("GET", getAt)) ++
+      List(if (desc) "DESC" else "ASC") ++
+      (if (alpha) List("ALPHA") else List.empty)
+
   final def sort(
     key: String,
-    desc: Boolean = false,
-    alpha: Boolean = false,
     by: Option[String] = None,
-    get: List[String] = List.empty
+    limitOffset: Option[(Int, Int)] = None,
+    desc: Boolean = false,
+    get: List[String] = List.empty,
+    alpha: Boolean = false,
   ): ZIO[RedisExecutor, RedisError, Chunk[String]] =
     {
-      val args =
-        by.map { sortBy => List("BY", sortBy)}.getOrElse(List.empty) ++
-          get.flatMap(getAt => List("GET", getAt)) ++
-          List(if (desc) "DESC" else "ASC") ++
-          (if (alpha) List("ALPHA") else List.empty)
+      val args = sortArguments(by, limitOffset, desc, get, alpha)
       Sort.run((key, args))
     }
 
+
+  final def sortStore(
+                       key: String,
+                       storeAt: String,
+                       by: Option[String] = None,
+                       limitOffset: Option[(Int, Int)] = None,
+                       desc: Boolean = false,
+                       get: List[String] = List.empty,
+                       alpha: Boolean = false,
+                     ): ZIO[RedisExecutor, RedisError, Long] = {
+    val args = sortArguments(by, limitOffset, desc, get, alpha) ++ List("STORE", storeAt)
+
+    SortStore.run((key, args))
+  }
 
 
   /**
@@ -367,6 +391,9 @@ private[redis] object Keys {
 
   final val Sort: RedisCommand[(String, List[String]), Chunk[String]] =
     RedisCommand("SORT", NonEmptyList(StringInput), ChunkOutput)
+
+  final val SortStore: RedisCommand[(String, List[String]), Long] =
+    RedisCommand("SORT", NonEmptyList(StringInput), LongOutput)
 
   final val Touch: RedisCommand[(String, List[String]), Long] =
     RedisCommand("TOUCH", NonEmptyList(StringInput), LongOutput)

--- a/redis/src/main/scala/zio/redis/api/Keys.scala
+++ b/redis/src/main/scala/zio/redis/api/Keys.scala
@@ -221,8 +221,8 @@ trait Keys {
    *
    * @param key key
    * @param by by option, specifies a pattern to use as an external key
-   * @param limitOffset limit count and offset option, take only limit values, starting at position offset
-   * @param desc desc option, sort descending instead of ascending
+   * @param limit limit option, take only limit values, starting at position offset
+   * @param order ordering option, sort descending instead of ascending
    * @param get get option, return the values referenced by the keys generated from the get patterns
    * @param alpha alpha option, sort the values alphanumerically, instead of by interpreting the value as floating point number
    * @return the sorted values, or the values found using the get patterns
@@ -246,8 +246,8 @@ trait Keys {
    * @param key key
    * @param storeAt where to store the results
    * @param by by option, specifies a pattern to use as an external key
-   * @param limitOffset limit count and offset option, take only limit values, starting at position offset
-   * @param desc desc option, sort descending instead of ascending
+   * @param limit limit option, take only limit values, starting at position offset
+   * @param order ordering option, sort descending instead of ascending
    * @param get get option, return the values referenced by the keys generated from the get patterns
    * @param alpha alpha option, sort the values alphanumerically, instead of by interpreting the value as floating point number
    * @return the sorted values, or the values found using the get patterns

--- a/redis/src/main/scala/zio/redis/api/Keys.scala
+++ b/redis/src/main/scala/zio/redis/api/Keys.scala
@@ -232,7 +232,7 @@ trait Keys {
     by: Option[String] = None,
     limit: Option[Limit] = None,
     order: Order = Order.Ascending,
-    get: List[String] = List.empty,
+    get: Option[(String, List[String])] = None,
     alpha: Option[Alpha] = None
   ): ZIO[RedisExecutor, RedisError, Chunk[String]] =
     Sort.run((key, by, limit, get, order, alpha))
@@ -258,7 +258,7 @@ trait Keys {
     by: Option[String] = None,
     limit: Option[Limit] = None,
     order: Order = Order.Ascending,
-    get: List[String] = List.empty,
+    get: Option[(String, List[String])] = None,
     alpha: Option[Alpha] = None
   ): ZIO[RedisExecutor, RedisError, Long] =
     SortStore.run((key, by, limit, get, order, alpha, storeAt))
@@ -394,29 +394,33 @@ private[redis] object Keys {
     )
 
   final val Sort
-    : RedisCommand[(String, Option[String], Option[Limit], List[String], Order, Option[Alpha]), Chunk[String]] =
+    : RedisCommand[(String, Option[String], Option[Limit], Option[(String, List[String])], Order, Option[Alpha]), Chunk[
+      String
+    ]] =
     RedisCommand(
       "SORT",
       Tuple6(
         StringInput,
         OptionalInput(ByInput),
         OptionalInput(LimitInput),
-        ListInput(GetInput),
+        OptionalInput(NonEmptyList(GetInput)),
         OrderInput,
         OptionalInput(AlphaInput)
       ),
       ChunkOutput
     )
 
-  final val SortStore
-    : RedisCommand[(String, Option[String], Option[Limit], List[String], Order, Option[Alpha], Store), Long] =
+  final val SortStore: RedisCommand[
+    (String, Option[String], Option[Limit], Option[(String, List[String])], Order, Option[Alpha], Store),
+    Long
+  ] =
     RedisCommand(
       "SORT",
       Tuple7(
         StringInput,
         OptionalInput(ByInput),
         OptionalInput(LimitInput),
-        ListInput(GetInput),
+        OptionalInput(NonEmptyList(GetInput)),
         OrderInput,
         OptionalInput(AlphaInput),
         StoreInput

--- a/redis/src/main/scala/zio/redis/options/Geo.scala
+++ b/redis/src/main/scala/zio/redis/options/Geo.scala
@@ -6,19 +6,6 @@ trait Geo {
 
   sealed case class GeoView(member: String, dist: Option[Double], hash: Option[Long], longLat: Option[LongLat])
 
-  sealed trait Order { self =>
-    private[redis] final def stringify: String =
-      self match {
-        case Order.Ascending  => "ASC"
-        case Order.Descending => "DESC"
-      }
-  }
-
-  object Order {
-    case object Ascending  extends Order
-    case object Descending extends Order
-  }
-
   sealed trait RadiusUnit { self =>
     private[redis] final def stringify: String =
       self match {
@@ -35,8 +22,6 @@ trait Geo {
     case object Feet       extends RadiusUnit
     case object Miles      extends RadiusUnit
   }
-
-  sealed case class Store(key: String)
 
   sealed case class StoreDist(key: String)
 

--- a/redis/src/main/scala/zio/redis/options/Keys.scala
+++ b/redis/src/main/scala/zio/redis/options/Keys.scala
@@ -8,7 +8,10 @@ trait Keys {
 
   type AbsTtl = AbsTtl.type
 
-  case object Alpha
+  case object Alpha {
+    private[redis] def stringify: String = "ALPHA"
+  }
+
   type Alpha = Alpha.type
 
   sealed case class Auth(password: String)

--- a/redis/src/main/scala/zio/redis/options/Shared.scala
+++ b/redis/src/main/scala/zio/redis/options/Shared.scala
@@ -15,4 +15,21 @@ trait Shared {
   }
 
   sealed case class Count(count: Long)
+
+  sealed trait Order { self =>
+    private[redis] final def stringify: String =
+      self match {
+        case Order.Ascending  => "ASC"
+        case Order.Descending => "DESC"
+      }
+  }
+
+  object Order {
+    case object Ascending  extends Order
+    case object Descending extends Order
+  }
+
+  sealed case class Limit(offset: Long, count: Long)
+
+  sealed case class Store(key: String)
 }

--- a/redis/src/main/scala/zio/redis/options/SortedSets.scala
+++ b/redis/src/main/scala/zio/redis/options/SortedSets.scala
@@ -60,8 +60,6 @@ trait SortedSets {
 
   sealed case class LexRange(min: LexMinimum, max: LexMaximum)
 
-  sealed case class Limit(offset: Long, count: Long)
-
   sealed case class MemberScore(score: Double, member: String)
 
   sealed trait ScoreMaximum { self =>

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -41,6 +41,13 @@ object InputSpec extends BaseSpec {
           } yield assert(result)(equalTo(respArgs("AGGREGATE", "SUM")))
         }
       ),
+      suite("Alpha")(
+        testM("alpha") {
+          for {
+            result <- Task(AlphaInput.encode(Alpha))
+          } yield assert(result)(equalTo(respArgs("ALPHA")))
+        }
+      ),
       suite("Auth")(
         testM("with empty password") {
           for {
@@ -161,6 +168,13 @@ object InputSpec extends BaseSpec {
           } yield assert(result)(equalTo(respArgs("0", "1000")))
         }
       ),
+      suite("By")(
+        testM("with a pattern") {
+          for {
+            result <- Task(ByInput.encode("mykey_*"))
+          } yield assert(result)(equalTo(respArgs("BY", "mykey_*")))
+        }
+      ),
       suite("Changed")(
         testM("valid value") {
           for {
@@ -274,6 +288,13 @@ object InputSpec extends BaseSpec {
           } yield assert(result)(equalTo(respArgs("FREQ", "frequency")))
         }
       ),
+      suite("Get")(
+        testM("with a pattern") {
+          for {
+            result <- Task(GetInput.encode("mypattern_*"))
+          } yield assert(result)(equalTo(respArgs("GET", "mypattern_*")))
+        }
+      ),
       suite("IdleTime")(
         testM("0 seconds") {
           for {
@@ -362,6 +383,18 @@ object InputSpec extends BaseSpec {
           for {
             result <- Task(LimitInput.encode(Limit(0L, 0L)))
           } yield assert(result)(equalTo(respArgs("LIMIT", "0", "0")))
+        }
+      ),
+      suite("List")(
+        testM("empty") {
+          for {
+            result <- Task(ListInput(StringInput).encode(List.empty))
+          } yield assert(result)(equalTo(Chunk.empty))
+        },
+        testM("nonempty") {
+          for {
+            result <- Task(ListInput(StringInput).encode(List("one", "two", "three")))
+          } yield assert(result)(equalTo(respArgs("one", "two", "three")))
         }
       ),
       suite("Long")(

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -385,18 +385,6 @@ object InputSpec extends BaseSpec {
           } yield assert(result)(equalTo(respArgs("LIMIT", "0", "0")))
         }
       ),
-      suite("List")(
-        testM("empty") {
-          for {
-            result <- Task(ListInput(StringInput).encode(List.empty))
-          } yield assert(result)(equalTo(Chunk.empty))
-        },
-        testM("nonempty") {
-          for {
-            result <- Task(ListInput(StringInput).encode(List("one", "two", "three")))
-          } yield assert(result)(equalTo(respArgs("one", "two", "three")))
-        }
-      ),
       suite("Long")(
         testM("positive value") {
           for {

--- a/redis/src/test/scala/zio/redis/KeysSpec.scala
+++ b/redis/src/test/scala/zio/redis/KeysSpec.scala
@@ -381,7 +381,7 @@ trait KeysSpec extends BaseSpec {
             _      <- lPush(key, value)
             prefix <- uuid
             _      <- set(s"${prefix}_$value", "A")
-            sorted <- sort(key, get = List(s"${prefix}_*"), alpha = Some(Alpha))
+            sorted <- sort(key, get = Some((s"${prefix}_*", List.empty)), alpha = Some(Alpha))
           } yield assert(sorted)(equalTo(Chunk("A")))
         },
         testM("getting multiple value referenced by a key-value pair") {
@@ -393,7 +393,7 @@ trait KeysSpec extends BaseSpec {
             _       <- set(s"${prefix}_$value", "A")
             prefix2 <- uuid
             _       <- set(s"${prefix2}_$value", "0")
-            sorted  <- sort(key, get = List(s"${prefix}_*", s"${prefix2}_*"), alpha = Some(Alpha))
+            sorted  <- sort(key, get = Some((s"${prefix}_*", List(s"${prefix2}_*"))), alpha = Some(Alpha))
           } yield assert(sorted)(equalTo(Chunk("A", "0")))
         },
         testM("sort and store result") {

--- a/redis/src/test/scala/zio/redis/KeysSpec.scala
+++ b/redis/src/test/scala/zio/redis/KeysSpec.scala
@@ -345,21 +345,21 @@ trait KeysSpec extends BaseSpec {
           for {
             key    <- uuid
             _      <- lPush(key, "z", "a", "c")
-            sorted <- sort(key, alpha = true)
+            sorted <- sort(key, alpha = Some(Alpha))
           } yield assert(sorted)(equalTo(Chunk("a", "c", "z")))
         },
         testM("list of numbers, limited") {
           for {
             key    <- uuid
             _      <- lPush(key, "1", "0", "2")
-            sorted <- sort(key, limitOffset = Some((1, 1)))
+            sorted <- sort(key, limit = Some(Limit(1, 1)))
           } yield assert(sorted)(equalTo(Chunk("1")))
         },
         testM("descending sort") {
           for {
             key    <- uuid
             _      <- lPush(key, "1", "0", "2")
-            sorted <- sort(key, desc = true)
+            sorted <- sort(key, order = Order.Descending)
           } yield assert(sorted)(equalTo(Chunk("2", "1", "0")))
         },
         testM("by the value referenced by a key-value pair") {
@@ -371,7 +371,7 @@ trait KeysSpec extends BaseSpec {
             prefix <- uuid
             _      <- set(s"${prefix}_$a", "A")
             _      <- set(s"${prefix}_$b", "B")
-            sorted <- sort(key, by = Some(s"${prefix}_*"), alpha = true)
+            sorted <- sort(key, by = Some(s"${prefix}_*"), alpha = Some(Alpha))
           } yield assert(sorted)(equalTo(Chunk(a, b)))
         },
         testM("getting the value referenced by a key-value pair") {
@@ -381,7 +381,7 @@ trait KeysSpec extends BaseSpec {
             _      <- lPush(key, value)
             prefix <- uuid
             _      <- set(s"${prefix}_$value", "A")
-            sorted <- sort(key, get = List(s"${prefix}_*"), alpha = true)
+            sorted <- sort(key, get = List(s"${prefix}_*"), alpha = Some(Alpha))
           } yield assert(sorted)(equalTo(Chunk("A")))
         },
         testM("getting multiple value referenced by a key-value pair") {
@@ -393,7 +393,7 @@ trait KeysSpec extends BaseSpec {
             _       <- set(s"${prefix}_$value", "A")
             prefix2 <- uuid
             _       <- set(s"${prefix2}_$value", "0")
-            sorted  <- sort(key, get = List(s"${prefix}_*", s"${prefix2}_*"), alpha = true)
+            sorted  <- sort(key, get = List(s"${prefix}_*", s"${prefix2}_*"), alpha = Some(Alpha))
           } yield assert(sorted)(equalTo(Chunk("A", "0")))
         },
         testM("sort and store result") {
@@ -401,7 +401,7 @@ trait KeysSpec extends BaseSpec {
             key       <- uuid
             resultKey <- uuid
             _         <- lPush(key, "1", "0", "2")
-            count     <- sortStore(key, resultKey)
+            count     <- sortStore(key, Store(resultKey))
             sorted    <- lRange(resultKey, Range(0, 2))
           } yield assert(sorted)(equalTo(Chunk("0", "1", "2"))) && assert(count)(equalTo(3L))
         }

--- a/redis/src/test/scala/zio/redis/KeysSpec.scala
+++ b/redis/src/test/scala/zio/redis/KeysSpec.scala
@@ -348,6 +348,13 @@ trait KeysSpec extends BaseSpec {
             sorted <- sort(key, alpha = true)
           } yield assert(sorted)(equalTo(Chunk("a", "c", "z")))
         },
+        testM("list of numbers, limited") {
+          for {
+            key <- uuid
+            _ <- lPush(key, "1", "0", "2")
+            sorted <- sort(key, limitOffset = Some((1, 1)))
+          } yield assert(sorted)(equalTo(Chunk("1")))
+        },
         testM("descending sort") {
           for {
             key <- uuid
@@ -388,6 +395,15 @@ trait KeysSpec extends BaseSpec {
             _ <- set(s"${prefix2}_$value", "0")
             sorted <- sort(key, get = List(s"${prefix}_*", s"${prefix2}_*"), alpha = true)
           } yield assert(sorted)(equalTo(Chunk("A", "0")))
+        },
+        testM("sort and store result") {
+          for {
+            key <- uuid
+            resultKey <- uuid
+            _ <- lPush(key, "1", "0", "2")
+            count <- sortStore(key, resultKey)
+            sorted <- lRange(resultKey, Range(0, 2))
+          } yield assert(sorted)(equalTo(Chunk("0", "1", "2"))) && assert(count)(equalTo(3L))
         }
       )
     )

--- a/redis/src/test/scala/zio/redis/KeysSpec.scala
+++ b/redis/src/test/scala/zio/redis/KeysSpec.scala
@@ -336,73 +336,73 @@ trait KeysSpec extends BaseSpec {
       suite("sort")(
         testM("list of numbers") {
           for {
-            key <- uuid
-            _ <- lPush(key, "1", "0", "2")
+            key    <- uuid
+            _      <- lPush(key, "1", "0", "2")
             sorted <- sort(key)
           } yield assert(sorted)(equalTo(Chunk("0", "1", "2")))
         },
         testM("list of strings") {
           for {
-            key <- uuid
-            _ <- lPush(key, "z", "a", "c")
+            key    <- uuid
+            _      <- lPush(key, "z", "a", "c")
             sorted <- sort(key, alpha = true)
           } yield assert(sorted)(equalTo(Chunk("a", "c", "z")))
         },
         testM("list of numbers, limited") {
           for {
-            key <- uuid
-            _ <- lPush(key, "1", "0", "2")
+            key    <- uuid
+            _      <- lPush(key, "1", "0", "2")
             sorted <- sort(key, limitOffset = Some((1, 1)))
           } yield assert(sorted)(equalTo(Chunk("1")))
         },
         testM("descending sort") {
           for {
-            key <- uuid
-            _ <- lPush(key, "1", "0", "2")
+            key    <- uuid
+            _      <- lPush(key, "1", "0", "2")
             sorted <- sort(key, desc = true)
           } yield assert(sorted)(equalTo(Chunk("2", "1", "0")))
         },
         testM("by the value referenced by a key-value pair") {
           for {
-            key <- uuid
-            a <- uuid
-            b <- uuid
-            _ <- lPush(key, b, a)
+            key    <- uuid
+            a      <- uuid
+            b      <- uuid
+            _      <- lPush(key, b, a)
             prefix <- uuid
-            _ <- set(s"${prefix}_$a", "A")
-            _ <- set(s"${prefix}_$b", "B")
+            _      <- set(s"${prefix}_$a", "A")
+            _      <- set(s"${prefix}_$b", "B")
             sorted <- sort(key, by = Some(s"${prefix}_*"), alpha = true)
           } yield assert(sorted)(equalTo(Chunk(a, b)))
         },
         testM("getting the value referenced by a key-value pair") {
           for {
-            key <- uuid
-            value <- uuid
-            _ <- lPush(key, value)
+            key    <- uuid
+            value  <- uuid
+            _      <- lPush(key, value)
             prefix <- uuid
-            _ <- set(s"${prefix}_$value", "A")
+            _      <- set(s"${prefix}_$value", "A")
             sorted <- sort(key, get = List(s"${prefix}_*"), alpha = true)
           } yield assert(sorted)(equalTo(Chunk("A")))
         },
         testM("getting multiple value referenced by a key-value pair") {
           for {
-            key <- uuid
-            value <- uuid
-            _ <- lPush(key, value)
-            prefix <- uuid
-            _ <- set(s"${prefix}_$value", "A")
+            key     <- uuid
+            value   <- uuid
+            _       <- lPush(key, value)
+            prefix  <- uuid
+            _       <- set(s"${prefix}_$value", "A")
             prefix2 <- uuid
-            _ <- set(s"${prefix2}_$value", "0")
-            sorted <- sort(key, get = List(s"${prefix}_*", s"${prefix2}_*"), alpha = true)
+            _       <- set(s"${prefix2}_$value", "0")
+            sorted  <- sort(key, get = List(s"${prefix}_*", s"${prefix2}_*"), alpha = true)
           } yield assert(sorted)(equalTo(Chunk("A", "0")))
         },
         testM("sort and store result") {
           for {
-            key <- uuid
+            key       <- uuid
             resultKey <- uuid
-            _ <- lPush(key, "1", "0", "2")
-            count <- sortStore(key, resultKey)
-            sorted <- lRange(resultKey, Range(0, 2))
+            _         <- lPush(key, "1", "0", "2")
+            count     <- sortStore(key, resultKey)
+            sorted    <- lRange(resultKey, Range(0, 2))
           } yield assert(sorted)(equalTo(Chunk("0", "1", "2"))) && assert(count)(equalTo(3L))
         }
       )


### PR DESCRIPTION
Fixes #218.

SORT has two different response types:

```
SORT myKey # -> returns the sorted values in the list stored at myKey
SORT myKey STORE resultKey # -> returns the number of elements sorted, writes values to resultKey
```

This is not easily expressible in Scala, so I created two separate functions, one for `SORT ... STORE ...` and one for `SORT ...`

This is my first commit to zio-redis, please let me know if I am not following any important functional or stylistic guidelines!
