### PR TITLE
Fix scan commands

### DIFF
--- a/redis/src/main/scala/zio/redis/Input.scala
+++ b/redis/src/main/scala/zio/redis/Input.scala
@@ -3,8 +3,6 @@ package zio.redis
 import java.time.Instant
 import java.util.concurrent.TimeUnit
 
-import scala.util.matching.Regex
-
 import zio.Chunk
 import zio.duration.Duration
 
@@ -79,6 +77,16 @@ object Input {
   case object CountInput extends Input[Count] {
     def encode(data: Count): Chunk[RespValue.BulkString] =
       Chunk(encodeString("COUNT"), encodeString(data.count.toString))
+  }
+
+  case object RedisTypeInput extends Input[RedisType] {
+    def encode(data: RedisType): Chunk[RespValue.BulkString] =
+      Chunk(encodeString("TYPE"), encodeString(data.stringify))
+  }
+
+  case object PatternInput extends Input[Pattern] {
+    def encode(data: Pattern): Chunk[RespValue.BulkString] =
+      Chunk(encodeString("MATCH"), encodeString(data.pattern))
   }
 
   case object GetInput extends Input[String] {
@@ -172,10 +180,6 @@ object Input {
   case object RangeInput extends Input[Range] {
     def encode(data: Range): Chunk[RespValue.BulkString] =
       Chunk(encodeString(data.start.toString), encodeString(data.end.toString))
-  }
-
-  case object RegexInput extends Input[Regex] {
-    def encode(data: Regex): Chunk[RespValue.BulkString] = Chunk(encodeString("MATCH"), encodeString(data.regex))
   }
 
   case object ReplaceInput extends Input[Replace] {

--- a/redis/src/main/scala/zio/redis/api/Hashes.scala
+++ b/redis/src/main/scala/zio/redis/api/Hashes.scala
@@ -1,7 +1,5 @@
 package zio.redis.api
 
-import scala.util.matching.Regex
-
 import zio.redis.Input._
 import zio.redis.Output._
 import zio.redis._
@@ -115,10 +113,10 @@ trait Hashes {
   final def hScan(
     key: String,
     cursor: Long,
-    pattern: Option[Regex] = None,
-    count: Option[Long] = None,
-    `type`: Option[String] = None
-  ): ZIO[RedisExecutor, RedisError, (Long, Chunk[String])] = HScan.run((key, cursor, pattern, count, `type`))
+    pattern: Option[String] = None,
+    count: Option[Long] = None
+  ): ZIO[RedisExecutor, RedisError, (Long, Chunk[String])] =
+    HScan.run((key, cursor, pattern.map(Pattern), count.map(Count)))
 
   /**
    * Sets `field -> value` pairs in the hash stored at `key`.
@@ -188,10 +186,10 @@ private[redis] object Hashes {
       UnitOutput
     )
 
-  final val HScan: RedisCommand[(String, Long, Option[Regex], Option[Long], Option[String]), (Long, Chunk[String])] =
+  final val HScan: RedisCommand[(String, Long, Option[Pattern], Option[Count]), (Long, Chunk[String])] =
     RedisCommand(
       "HSCAN",
-      Tuple5(StringInput, LongInput, OptionalInput(RegexInput), OptionalInput(LongInput), OptionalInput(StringInput)),
+      Tuple4(StringInput, LongInput, OptionalInput(PatternInput), OptionalInput(CountInput)),
       ScanOutput
     )
 

--- a/redis/src/main/scala/zio/redis/api/Hashes.scala
+++ b/redis/src/main/scala/zio/redis/api/Hashes.scala
@@ -114,9 +114,9 @@ trait Hashes {
     key: String,
     cursor: Long,
     pattern: Option[String] = None,
-    count: Option[Long] = None
+    count: Option[Count] = None
   ): ZIO[RedisExecutor, RedisError, (Long, Chunk[String])] =
-    HScan.run((key, cursor, pattern.map(Pattern), count.map(Count)))
+    HScan.run((key, cursor, pattern.map(Pattern), count))
 
   /**
    * Sets `field -> value` pairs in the hash stored at `key`.

--- a/redis/src/main/scala/zio/redis/api/Keys.scala
+++ b/redis/src/main/scala/zio/redis/api/Keys.scala
@@ -6,7 +6,7 @@ import zio.duration._
 import zio.redis.Input._
 import zio.redis.Output._
 import zio.redis._
-import zio.{ Chunk, Task, ZIO }
+import zio.{ Chunk, ZIO }
 
 trait Keys {
   import Keys.{ Keys => _, _ }

--- a/redis/src/main/scala/zio/redis/api/Keys.scala
+++ b/redis/src/main/scala/zio/redis/api/Keys.scala
@@ -210,12 +210,9 @@ trait Keys {
   final def scan(
     cursor: Long,
     pattern: Option[String] = None,
-    count: Option[Long] = None,
-    `type`: Option[String] = None
-  ): ZIO[RedisExecutor, RedisError, (Long, Chunk[String])] =
-    Task.effect(`type`.map(RedisType.from)).refineOrDie { case e: RedisError => e } >>= (redisType =>
-      Scan.run((cursor, pattern.map(Pattern), count.map(Count), redisType))
-    )
+    count: Option[Count] = None,
+    `type`: Option[RedisType] = None
+  ): ZIO[RedisExecutor, RedisError, (Long, Chunk[String])] = Scan.run((cursor, pattern.map(Pattern), count, `type`))
 
   /**
    * Sorts the list, set, or sorted set stored at key. Returns the sorted elements.

--- a/redis/src/main/scala/zio/redis/api/Sets.scala
+++ b/redis/src/main/scala/zio/redis/api/Sets.scala
@@ -149,9 +149,9 @@ trait Sets {
     key: String,
     cursor: Long,
     pattern: Option[String] = None,
-    count: Option[Long] = None
+    count: Option[Count] = None
   ): ZIO[RedisExecutor, RedisError, (Long, Chunk[String])] =
-    SScan.run((key, cursor, pattern.map(Pattern), count.map(Count)))
+    SScan.run((key, cursor, pattern.map(Pattern), count))
 
   /**
    * Add multiple sets

--- a/redis/src/main/scala/zio/redis/api/Sets.scala
+++ b/redis/src/main/scala/zio/redis/api/Sets.scala
@@ -1,7 +1,5 @@
 package zio.redis.api
 
-import scala.util.matching.Regex
-
 import zio.redis.Input._
 import zio.redis.Output._
 import zio.redis._
@@ -143,16 +141,17 @@ trait Sets {
    *
    * @param key Key of the set to scan
    * @param cursor Cursor to use for this iteration of scan
-   * @param regex Glob-style pattern that filters which elements are returned
+   * @param pattern Glob-style pattern that filters which elements are returned
    * @param count Count of elements. Roughly this number will be returned by Redis if possible
    * @return Returns the next cursor, and items for this iteration or nothing when you reach the end, as a tuple
    */
   final def sScan(
     key: String,
     cursor: Long,
-    regex: Option[Regex] = None,
-    count: Option[Count] = None
-  ): ZIO[RedisExecutor, RedisError, (Long, Chunk[String])] = SScan.run((key, cursor, regex, count))
+    pattern: Option[String] = None,
+    count: Option[Long] = None
+  ): ZIO[RedisExecutor, RedisError, (Long, Chunk[String])] =
+    SScan.run((key, cursor, pattern.map(Pattern), count.map(Count)))
 
   /**
    * Add multiple sets
@@ -215,10 +214,10 @@ private[redis] object Sets {
   final val SRem: RedisCommand[(String, (String, List[String])), Long] =
     RedisCommand("SREM", Tuple2(StringInput, NonEmptyList(StringInput)), LongOutput)
 
-  final val SScan: RedisCommand[(String, Long, Option[Regex], Option[Count]), (Long, Chunk[String])] =
+  final val SScan: RedisCommand[(String, Long, Option[Pattern], Option[Count]), (Long, Chunk[String])] =
     RedisCommand(
       "SSCAN",
-      Tuple4(StringInput, LongInput, OptionalInput(RegexInput), OptionalInput(CountInput)),
+      Tuple4(StringInput, LongInput, OptionalInput(PatternInput), OptionalInput(CountInput)),
       ScanOutput
     )
 

--- a/redis/src/main/scala/zio/redis/api/SortedSets.scala
+++ b/redis/src/main/scala/zio/redis/api/SortedSets.scala
@@ -321,9 +321,9 @@ trait SortedSets {
     key: String,
     cursor: Long,
     pattern: Option[String] = None,
-    count: Option[Long] = None
+    count: Option[Count] = None
   ): ZIO[RedisExecutor, RedisError, (Long, Chunk[String])] =
-    ZScan.run((key, cursor, pattern.map(Pattern), count.map(Count)))
+    ZScan.run((key, cursor, pattern.map(Pattern), count))
 
   /**
    * Get the score associated with the given member in a sorted set.

--- a/redis/src/main/scala/zio/redis/api/SortedSets.scala
+++ b/redis/src/main/scala/zio/redis/api/SortedSets.scala
@@ -1,7 +1,5 @@
 package zio.redis.api
 
-import scala.util.matching.Regex
-
 import zio.duration._
 import zio.redis.Input._
 import zio.redis.Output._
@@ -315,16 +313,17 @@ trait SortedSets {
    *
    * @param key Key of the set to scan
    * @param cursor Cursor to use for this iteration of scan
-   * @param regex Glob-style pattern that filters which elements are returned
+   * @param pattern Glob-style pattern that filters which elements are returned
    * @param count Count of elements. Roughly this number will be returned by Redis if possible
    * @return Returns the items for this iteration or nothing when you reach the end
    */
   final def zScan(
     key: String,
     cursor: Long,
-    regex: Option[Regex] = None,
-    count: Option[Count] = None
-  ): ZIO[RedisExecutor, RedisError, (Long, Chunk[String])] = ZScan.run((key, cursor, regex, count))
+    pattern: Option[String] = None,
+    count: Option[Long] = None
+  ): ZIO[RedisExecutor, RedisError, (Long, Chunk[String])] =
+    ZScan.run((key, cursor, pattern.map(Pattern), count.map(Count)))
 
   /**
    * Get the score associated with the given member in a sorted set.
@@ -466,10 +465,10 @@ private[redis] object SortedSets {
   final val ZRevRank: RedisCommand[(String, String), Option[Long]] =
     RedisCommand("ZREVRANK", Tuple2(StringInput, StringInput), OptionalOutput(LongOutput))
 
-  final val ZScan: RedisCommand[(String, Long, Option[Regex], Option[Count]), (Long, Chunk[String])] =
+  final val ZScan: RedisCommand[(String, Long, Option[Pattern], Option[Count]), (Long, Chunk[String])] =
     RedisCommand(
       "ZSCAN",
-      Tuple4(StringInput, LongInput, OptionalInput(RegexInput), OptionalInput(CountInput)),
+      Tuple4(StringInput, LongInput, OptionalInput(PatternInput), OptionalInput(CountInput)),
       ScanOutput
     )
 

--- a/redis/src/main/scala/zio/redis/options/Keys.scala
+++ b/redis/src/main/scala/zio/redis/options/Keys.scala
@@ -1,5 +1,7 @@
 package zio.redis.options
 
+import zio.redis.RedisError.WrongType
+
 trait Keys {
 
   case object AbsTtl {
@@ -28,9 +30,30 @@ trait Keys {
 
   sealed case class Freq(frequency: String)
 
-  sealed trait RedisType
+  sealed trait RedisType extends Product with Serializable { self =>
+    private[redis] final def stringify: String =
+      self match {
+        case RedisType.String    => "string"
+        case RedisType.List      => "list"
+        case RedisType.Set       => "set"
+        case RedisType.SortedSet => "zset"
+        case RedisType.Hash      => "hash"
+        case RedisType.Stream    => "stream"
+      }
+  }
 
   object RedisType {
+    def from(value: String): RedisType = value match {
+      case "string" => String
+      case "list"   => List
+      case "set"    => Set
+      case "zset"   => SortedSet
+      case "hash"   => Hash
+      case "stream" => Stream
+      case _ =>
+        throw WrongType(s"$value is not a valid redis type use one of string, list, set, zset, hash and stream.")
+    }
+
     case object String    extends RedisType
     case object List      extends RedisType
     case object Set       extends RedisType

--- a/redis/src/main/scala/zio/redis/options/Keys.scala
+++ b/redis/src/main/scala/zio/redis/options/Keys.scala
@@ -1,7 +1,5 @@
 package zio.redis.options
 
-import zio.redis.RedisError.WrongType
-
 trait Keys {
 
   case object AbsTtl {
@@ -43,17 +41,6 @@ trait Keys {
   }
 
   object RedisType {
-    def from(value: String): RedisType = value match {
-      case "string" => String
-      case "list"   => List
-      case "set"    => Set
-      case "zset"   => SortedSet
-      case "hash"   => Hash
-      case "stream" => Stream
-      case _ =>
-        throw WrongType(s"$value is not a valid redis type use one of string, list, set, zset, hash and stream.")
-    }
-
     case object String    extends RedisType
     case object List      extends RedisType
     case object Set       extends RedisType
@@ -67,5 +54,4 @@ trait Keys {
   }
 
   type Replace = Replace.type
-
 }

--- a/redis/src/main/scala/zio/redis/options/Shared.scala
+++ b/redis/src/main/scala/zio/redis/options/Shared.scala
@@ -32,4 +32,6 @@ trait Shared {
   sealed case class Limit(offset: Long, count: Long)
 
   sealed case class Store(key: String)
+
+  sealed case class Pattern(pattern: String)
 }

--- a/redis/src/test/scala/zio/redis/ApiSpec.scala
+++ b/redis/src/test/scala/zio/redis/ApiSpec.scala
@@ -40,5 +40,4 @@ object ApiSpec
         .get
         .provideCustomLayerShared(RedisExecutor.test)
     )
-    
 }

--- a/redis/src/test/scala/zio/redis/ApiSpec.scala
+++ b/redis/src/test/scala/zio/redis/ApiSpec.scala
@@ -40,4 +40,5 @@ object ApiSpec
         .get
         .provideCustomLayerShared(RedisExecutor.test)
     )
+    
 }

--- a/redis/src/test/scala/zio/redis/BaseSpec.scala
+++ b/redis/src/test/scala/zio/redis/BaseSpec.scala
@@ -5,6 +5,7 @@ import java.util.UUID
 
 import zio.UIO
 import zio.duration._
+import zio.random.Random
 import zio.test.TestAspect.tag
 import zio.test._
 import zio.test.environment.Live
@@ -18,4 +19,9 @@ trait BaseSpec extends DefaultRunnableSpec {
 
   val TestExecutorUnsupportedTag                   = "test executor unsupported"
   lazy val testExecutorUnsupported: TestAspectPoly = tag(TestExecutorUnsupportedTag)
+
+  val genStringRedisTypeOption: Gen[Random, Option[RedisType]] =
+    Gen.option(Gen.constSample(Sample.noShrink(RedisType.String)))
+  val genCountOption: Gen[Random, Option[Count]]    = Gen.option(Gen.long(0, 100000).map(Count))
+  val genPatternOption: Gen[Random, Option[String]] = Gen.option(Gen.constSample(Sample.noShrink("*")))
 }

--- a/redis/src/test/scala/zio/redis/HashSpec.scala
+++ b/redis/src/test/scala/zio/redis/HashSpec.scala
@@ -257,6 +257,48 @@ trait HashSpec extends BaseSpec {
             result <- hVals(hash)
           } yield assert(result)(isEmpty)
         }
+      ),
+      suite("hScan")(
+        testM("hScan entries") {
+          for {
+            hash            <- uuid
+            field           <- uuid
+            value           <- uuid
+            _               <- hSet(hash, field -> value)
+            scan            <- hScan(hash, 0L)
+            (next, elements) = scan
+          } yield assert(next)(isGreaterThanEqualTo(0L)) && assert(elements)(isNonEmpty)
+        },
+        testM("hScan entries with match option") {
+          for {
+            hash            <- uuid
+            field           <- uuid
+            value           <- uuid
+            _               <- hSet(hash, field -> value)
+            scan            <- hScan(hash, 0L, pattern = Some("*"))
+            (next, elements) = scan
+          } yield assert(next)(isGreaterThanEqualTo(0L)) && assert(elements)(isNonEmpty)
+        },
+        testM("hScan entries with count option") {
+          for {
+            hash            <- uuid
+            field           <- uuid
+            value           <- uuid
+            _               <- hSet(hash, field -> value)
+            scan            <- hScan(hash, 0L, count = Some(100L))
+            (next, elements) = scan
+          } yield assert(next)(isGreaterThanEqualTo(0L)) && assert(elements)(isNonEmpty)
+        },
+        testM("hScan entries with match and count options") {
+          for {
+            hash            <- uuid
+            field           <- uuid
+            value           <- uuid
+            _               <- hSet(hash, field -> value)
+            scan            <- hScan(hash, 0L)
+            (next, elements) = scan
+          } yield assert(next)(isGreaterThanEqualTo(0L)) && assert(elements)(isNonEmpty)
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/HashSpec.scala
+++ b/redis/src/test/scala/zio/redis/HashSpec.scala
@@ -285,7 +285,7 @@ trait HashSpec extends BaseSpec {
             field           <- uuid
             value           <- uuid
             _               <- hSet(hash, field -> value)
-            scan            <- hScan(hash, 0L, count = Some(100L))
+            scan            <- hScan(hash, 0L, count = Some(Count(100L)))
             (next, elements) = scan
           } yield assert(next)(isGreaterThanEqualTo(0L)) && assert(elements)(isNonEmpty)
         },

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -218,6 +218,38 @@ object InputSpec extends BaseSpec {
           } yield assert(result)(equalTo(respArgs("AFTER")))
         }
       ),
+      suite("RedisType")(
+        testM("string type") {
+          for {
+            result <- Task(RedisTypeInput.encode(RedisType.String))
+          } yield assert(result)(equalTo(respArgs("TYPE", "string")))
+        },
+        testM("list type") {
+          for {
+            result <- Task(RedisTypeInput.encode(RedisType.List))
+          } yield assert(result)(equalTo(respArgs("TYPE", "list")))
+        },
+        testM("set type") {
+          for {
+            result <- Task(RedisTypeInput.encode(RedisType.Set))
+          } yield assert(result)(equalTo(respArgs("TYPE", "set")))
+        },
+        testM("sorted set type") {
+          for {
+            result <- Task(RedisTypeInput.encode(RedisType.SortedSet))
+          } yield assert(result)(equalTo(respArgs("TYPE", "zset")))
+        },
+        testM("hash type") {
+          for {
+            result <- Task(RedisTypeInput.encode(RedisType.Hash))
+          } yield assert(result)(equalTo(respArgs("TYPE", "hash")))
+        },
+        testM("stream type") {
+          for {
+            result <- Task(RedisTypeInput.encode(RedisType.Stream))
+          } yield assert(result)(equalTo(respArgs("TYPE", "stream")))
+        }
+      ),
       suite("Double")(
         testM("positive value") {
           for {
@@ -526,15 +558,15 @@ object InputSpec extends BaseSpec {
           } yield assert(result)(equalTo(respArgs("-1", "-5")))
         }
       ),
-      suite("Regex")(
+      suite("Pattern")(
         testM("with valid pattern") {
           for {
-            result <- Task(RegexInput.encode("\\d{3}".r))
-          } yield assert(result)(equalTo(respArgs("MATCH", "\\d{3}")))
+            result <- Task(PatternInput.encode(Pattern("*[ab]-*")))
+          } yield assert(result)(equalTo(respArgs("MATCH", "*[ab]-*")))
         },
         testM("with empty pattern") {
           for {
-            result <- Task(RegexInput.encode("".r))
+            result <- Task(PatternInput.encode(Pattern("")))
           } yield assert(result)(equalTo(respArgs("MATCH", "")))
         }
       ),

--- a/redis/src/test/scala/zio/redis/KeysSpec.scala
+++ b/redis/src/test/scala/zio/redis/KeysSpec.scala
@@ -92,7 +92,51 @@ trait KeysSpec extends BaseSpec {
           _               <- set(key, value)
           scan            <- scan(0L)
           (next, elements) = scan
-        } yield assert(next)(isGreaterThan(0L)) && assert(elements)(isNonEmpty)
+        } yield assert(next)(isGreaterThanEqualTo(0L)) && assert(elements)(isNonEmpty)
+      },
+      testM("scan entries with match option") {
+        for {
+          key             <- uuid
+          value           <- uuid
+          _               <- set(key, value)
+          scan            <- scan(0L, pattern = Some("*"))
+          (next, elements) = scan
+        } yield assert(next)(isGreaterThanEqualTo(0L)) && assert(elements)(isNonEmpty)
+      },
+      testM("scan entries with count option") {
+        for {
+          key             <- uuid
+          value           <- uuid
+          _               <- set(key, value)
+          scan            <- scan(0L, count = Some(100L))
+          (next, elements) = scan
+        } yield assert(next)(isGreaterThanEqualTo(0L)) && assert(elements)(isNonEmpty)
+      },
+      testM("scan entries with type option") {
+        for {
+          key             <- uuid
+          value           <- uuid
+          _               <- set(key, value)
+          scan            <- scan(0L, `type` = Some("string"))
+          (next, elements) = scan
+        } yield assert(next)(isGreaterThanEqualTo(0L)) && assert(elements)(isNonEmpty)
+      },
+      testM("scan fails with RedisError on unsupported type") {
+        for {
+          key   <- uuid
+          value <- uuid
+          _     <- set(key, value)
+          scan  <- scan(0L, `type` = Some("foobar")).run
+        } yield assert(scan)(fails(isSubtype[RedisError.WrongType](anything)))
+      },
+      testM("scan entries with match, count and type options") {
+        for {
+          key             <- uuid
+          value           <- uuid
+          _               <- set(key, value)
+          scan            <- scan(0L, pattern = Some("*"), count = Some(100), `type` = Some("zset"))
+          (next, elements) = scan
+        } yield assert(next)(isGreaterThanEqualTo(0L)) && assert(elements)(isNonEmpty)
       },
       testM("fetch random key") {
         for {

--- a/redis/src/test/scala/zio/redis/KeysSpec.scala
+++ b/redis/src/test/scala/zio/redis/KeysSpec.scala
@@ -108,7 +108,7 @@ trait KeysSpec extends BaseSpec {
           key             <- uuid
           value           <- uuid
           _               <- set(key, value)
-          scan            <- scan(0L, count = Some(100L))
+          scan            <- scan(0L, count = Some(Count(100L)))
           (next, elements) = scan
         } yield assert(next)(isGreaterThanEqualTo(0L)) && assert(elements)(isNonEmpty)
       },
@@ -117,24 +117,16 @@ trait KeysSpec extends BaseSpec {
           key             <- uuid
           value           <- uuid
           _               <- set(key, value)
-          scan            <- scan(0L, `type` = Some("string"))
+          scan            <- scan(0L, `type` = Some(RedisType.String))
           (next, elements) = scan
         } yield assert(next)(isGreaterThanEqualTo(0L)) && assert(elements)(isNonEmpty)
-      },
-      testM("scan fails with RedisError on unsupported type") {
-        for {
-          key   <- uuid
-          value <- uuid
-          _     <- set(key, value)
-          scan  <- scan(0L, `type` = Some("foobar")).run
-        } yield assert(scan)(fails(isSubtype[RedisError.WrongType](anything)))
       },
       testM("scan entries with match, count and type options") {
         for {
           key             <- uuid
           value           <- uuid
           _               <- set(key, value)
-          scan            <- scan(0L, pattern = Some("*"), count = Some(100), `type` = Some("zset"))
+          scan            <- scan(0L, pattern = Some("*"), count = Some(Count(100L)), `type` = Some(RedisType.SortedSet))
           (next, elements) = scan
         } yield assert(next)(isGreaterThanEqualTo(0L)) && assert(elements)(isNonEmpty)
       },

--- a/redis/src/test/scala/zio/redis/KeysSpec.scala
+++ b/redis/src/test/scala/zio/redis/KeysSpec.scala
@@ -3,20 +3,18 @@ package zio.redis
 import zio.clock.Clock
 import zio.duration._
 import zio.logging.Logging
+import zio.random.Random
 import zio.redis.RedisError.ProtocolError
 import zio.test.Assertion._
 import zio.test.TestAspect._
 import zio.test._
-import zio.test.environment.{ TestClock, TestConsole, TestRandom, TestSystem }
-import zio.{ Chunk, Has, ZIO, ZLayer }
+import zio.{ Chunk, ZIO, ZLayer }
 
 trait KeysSpec extends BaseSpec {
 
-  val keysSuite: Spec[Has[Clock.Service] with Has[RedisExecutor.Service] with Has[TestClock.Service] with Has[
-    TestConsole.Service
-  ] with Has[TestRandom.Service] with Has[TestSystem.Service] with Has[RedisExecutor.Service] with Has[
-    Annotations.Service
-  ], TestFailure[RedisError], TestSuccess] = {
+  val keysSuite: Spec[Annotations with RedisExecutor with Random with TestConfig with ZTestEnv with Clock, TestFailure[
+    RedisError
+  ], TestSuccess] = {
     suite("keys")(
       testM("set followed by get") {
         for {
@@ -85,51 +83,17 @@ trait KeysSpec extends BaseSpec {
           touched <- touch(key1, key2)
         } yield assert(touched)(equalTo(2L))
       },
-      testM("scan entries") {
-        for {
-          key             <- uuid
-          value           <- uuid
-          _               <- set(key, value)
-          scan            <- scan(0L)
-          (next, elements) = scan
-        } yield assert(next)(isGreaterThanEqualTo(0L)) && assert(elements)(isNonEmpty)
-      },
-      testM("scan entries with match option") {
-        for {
-          key             <- uuid
-          value           <- uuid
-          _               <- set(key, value)
-          scan            <- scan(0L, pattern = Some("*"))
-          (next, elements) = scan
-        } yield assert(next)(isGreaterThanEqualTo(0L)) && assert(elements)(isNonEmpty)
-      },
-      testM("scan entries with count option") {
-        for {
-          key             <- uuid
-          value           <- uuid
-          _               <- set(key, value)
-          scan            <- scan(0L, count = Some(Count(100L)))
-          (next, elements) = scan
-        } yield assert(next)(isGreaterThanEqualTo(0L)) && assert(elements)(isNonEmpty)
-      },
-      testM("scan entries with type option") {
-        for {
-          key             <- uuid
-          value           <- uuid
-          _               <- set(key, value)
-          scan            <- scan(0L, `type` = Some(RedisType.String))
-          (next, elements) = scan
-        } yield assert(next)(isGreaterThanEqualTo(0L)) && assert(elements)(isNonEmpty)
-      },
-      testM("scan entries with match, count and type options") {
-        for {
-          key             <- uuid
-          value           <- uuid
-          _               <- set(key, value)
-          scan            <- scan(0L, pattern = Some("*"), count = Some(Count(100L)), `type` = Some(RedisType.SortedSet))
-          (next, elements) = scan
-        } yield assert(next)(isGreaterThanEqualTo(0L)) && assert(elements)(isNonEmpty)
-      },
+      testM("scan entries with match, count and type options")(
+        checkM(genPatternOption, genCountOption, genStringRedisTypeOption) { (pattern, count, redisType) =>
+          for {
+            key             <- uuid
+            value           <- uuid
+            _               <- set(key, value)
+            scan            <- scan(0L, pattern, count, redisType)
+            (next, elements) = scan
+          } yield assert(next)(isGreaterThanEqualTo(0L)) && assert(elements)(isNonEmpty)
+        }
+      ),
       testM("fetch random key") {
         for {
           key       <- uuid
@@ -451,5 +415,4 @@ object KeysSpec {
 
   final val SecondExecutor: ZLayer[Any, RedisError.IOError, RedisExecutor] =
     (Logging.ignore ++ ZLayer.succeed(RedisConfig("localhost", 6380)) >>> RedisExecutor.live).fresh
-
 }

--- a/redis/src/test/scala/zio/redis/SetsSpec.scala
+++ b/redis/src/test/scala/zio/redis/SetsSpec.scala
@@ -762,7 +762,7 @@ trait SetsSpec extends BaseSpec {
           for {
             key     <- uuid
             _       <- sAdd(key, testData.head, testData.tail: _*)
-            members <- scanAll(key, None, Some(3L))
+            members <- scanAll(key, None, Some(Count(3L)))
           } yield assert(members.toSet)(equalTo(testData.toSet))
         },
         testM("error when not set") {
@@ -779,7 +779,7 @@ trait SetsSpec extends BaseSpec {
   private def scanAll(
     key: String,
     pattern: Option[String] = None,
-    count: Option[Long] = None
+    count: Option[Count] = None
   ): ZIO[RedisExecutor, RedisError, Chunk[String]] =
     ZStream
       .paginateChunkM(0L) { cursor =>

--- a/redis/src/test/scala/zio/redis/SetsSpec.scala
+++ b/redis/src/test/scala/zio/redis/SetsSpec.scala
@@ -1,7 +1,5 @@
 package zio.redis
 
-import scala.util.matching.Regex
-
 import zio.redis.RedisError.WrongType
 import zio.stream.ZStream
 import zio.test.Assertion._
@@ -756,7 +754,7 @@ trait SetsSpec extends BaseSpec {
           for {
             key     <- uuid
             _       <- sAdd(key, testData.head, testData.tail: _*)
-            members <- scanAll(key, Some("t[a-z]*".r))
+            members <- scanAll(key, Some("t[a-z]*"))
           } yield assert(members.toSet)(equalTo(Set("two", "three")))
         },
         testM("with count over non-empty set") {
@@ -764,7 +762,7 @@ trait SetsSpec extends BaseSpec {
           for {
             key     <- uuid
             _       <- sAdd(key, testData.head, testData.tail: _*)
-            members <- scanAll(key, None, Some(Count(3L)))
+            members <- scanAll(key, None, Some(3L))
           } yield assert(members.toSet)(equalTo(testData.toSet))
         },
         testM("error when not set") {
@@ -777,14 +775,15 @@ trait SetsSpec extends BaseSpec {
         }
       )
     )
+
   private def scanAll(
     key: String,
-    regex: Option[Regex] = None,
-    count: Option[Count] = None
+    pattern: Option[String] = None,
+    count: Option[Long] = None
   ): ZIO[RedisExecutor, RedisError, Chunk[String]] =
     ZStream
       .paginateChunkM(0L) { cursor =>
-        sScan(key, cursor, regex, count).map {
+        sScan(key, cursor, pattern, count).map {
           case (nc, nm) if nc == 0 => (nm, None)
           case (nc, nm)            => (nm, Some(nc))
         }

--- a/redis/src/test/scala/zio/redis/SortedSetsSpec.scala
+++ b/redis/src/test/scala/zio/redis/SortedSetsSpec.scala
@@ -821,7 +821,7 @@ trait SortedSetsSpec extends BaseSpec {
                    MemberScore(4d, "d"),
                    MemberScore(5d, "e")
                  )
-            members <- scanAll(key, count = Some(3L))
+            members <- scanAll(key, count = Some(Count(3L)))
           } yield assert(members)(isNonEmpty)
         },
         testM("match with count over non-empty set") {
@@ -834,7 +834,7 @@ trait SortedSetsSpec extends BaseSpec {
                    MemberScore(4d, "testd"),
                    MemberScore(5d, "teste")
                  )
-            members <- scanAll(key, Some("t[a-z]*"), Some(3L))
+            members <- scanAll(key, pattern = Some("t[a-z]*"), count = Some(Count(3L)))
           } yield assert(members)(isNonEmpty)
         },
         testM("error when not set") {
@@ -994,7 +994,7 @@ trait SortedSetsSpec extends BaseSpec {
   private def scanAll(
     key: String,
     pattern: Option[String] = None,
-    count: Option[Long] = None
+    count: Option[Count] = None
   ): ZIO[RedisExecutor, RedisError, Chunk[String]] =
     ZStream
       .paginateChunkM(0L) { cursor =>

--- a/redis/src/test/scala/zio/redis/SortedSetsSpec.scala
+++ b/redis/src/test/scala/zio/redis/SortedSetsSpec.scala
@@ -1,7 +1,5 @@
 package zio.redis
 
-import scala.util.matching.Regex
-
 import zio.redis.RedisError.{ ProtocolError, WrongType }
 import zio.stream.ZStream
 import zio.test.Assertion._
@@ -810,7 +808,7 @@ trait SortedSetsSpec extends BaseSpec {
           for {
             key     <- uuid
             _       <- zAdd(key)(MemberScore(1d, "one"), MemberScore(2d, "two"), MemberScore(3d, "three"))
-            members <- scanAll(key, Some("t[a-z]*".r))
+            members <- scanAll(key, Some("t[a-z]*"))
           } yield assert(members)(equalTo((Chunk("two", "2", "three", "3"))))
         },
         testM("with count over non-empty set") {
@@ -823,7 +821,7 @@ trait SortedSetsSpec extends BaseSpec {
                    MemberScore(4d, "d"),
                    MemberScore(5d, "e")
                  )
-            members <- scanAll(key, count = Some(Count(3L)))
+            members <- scanAll(key, count = Some(3L))
           } yield assert(members)(isNonEmpty)
         },
         testM("match with count over non-empty set") {
@@ -836,7 +834,7 @@ trait SortedSetsSpec extends BaseSpec {
                    MemberScore(4d, "testd"),
                    MemberScore(5d, "teste")
                  )
-            members <- scanAll(key, Some("t[a-z]*".r), Some(Count(3L)))
+            members <- scanAll(key, Some("t[a-z]*"), Some(3L))
           } yield assert(members)(isNonEmpty)
         },
         testM("error when not set") {
@@ -992,14 +990,15 @@ trait SortedSetsSpec extends BaseSpec {
         }
       )
     )
+
   private def scanAll(
     key: String,
-    regex: Option[Regex] = None,
-    count: Option[Count] = None
+    pattern: Option[String] = None,
+    count: Option[Long] = None
   ): ZIO[RedisExecutor, RedisError, Chunk[String]] =
     ZStream
       .paginateChunkM(0L) { cursor =>
-        zScan(key, cursor, regex, count).map {
+        zScan(key, cursor, pattern, count).map {
           case (nc, nm) if nc == 0 => (nm, None)
           case (nc, nm)            => (nm, Some(nc))
         }

--- a/redis/src/test/scala/zio/redis/SortedSetsSpec.scala
+++ b/redis/src/test/scala/zio/redis/SortedSetsSpec.scala
@@ -1004,4 +1004,5 @@ trait SortedSetsSpec extends BaseSpec {
         }
       }
       .runCollect
+
 }


### PR DESCRIPTION
Closes: #320 

Fix all scan functions scan, sscan, hscan and zscan to properly support `Pattern`, `Count` and `Type` options.