### PR TITLE
Add full to xinfo stream

### DIFF
--- a/redis/src/main/scala/zio/redis/Input.scala
+++ b/redis/src/main/scala/zio/redis/Input.scala
@@ -286,9 +286,18 @@ object Input {
 
   case object XInfoStreamInput extends Input[XInfoCommand.Stream] {
     def encode(data: XInfoCommand.Stream): Chunk[RespValue.BulkString] =
-      Chunk(encodeString("STREAM"), encodeString(data.key))
+      data.full.fold(Chunk(encodeString("STREAM"), encodeString(data.key))) { f =>
+        f.count.fold(Chunk(encodeString("STREAM"), encodeString(data.key), encodeString("FULL"))) { c =>
+          Chunk(
+            encodeString("STREAM"),
+            encodeString(data.key),
+            encodeString("FULL"),
+            encodeString("COUNT"),
+            encodeString(c.toString)
+          )
+        }
+      }
   }
-
   case object XInfoGroupsInput extends Input[XInfoCommand.Groups] {
     def encode(data: XInfoCommand.Groups): Chunk[RespValue.BulkString] =
       Chunk(encodeString("GROUPS"), encodeString(data.key))

--- a/redis/src/main/scala/zio/redis/Output.scala
+++ b/redis/src/main/scala/zio/redis/Output.scala
@@ -443,7 +443,7 @@ object Output {
               case (key @ RespValue.BulkString(_), RespValue.Array(value)) =>
                 // Get the consumer list of the current group.
                 if (key.asString == XInfoFields.Consumers) {
-                  readyGroup = readyGroup.copy(consumers = Chunk.fromIterable(extractXInfoFullConsumers(value)))
+                  readyGroup = readyGroup.copy(consumers = extractXInfoFullConsumers(value))
                 } else if (key.asString == XInfoFields.Pending) {
                   // Get the pel list of the current group.
                   var groupPelList: Chunk[StreamInfoWithFull.GroupPel] = Chunk.empty

--- a/redis/src/main/scala/zio/redis/Output.scala
+++ b/redis/src/main/scala/zio/redis/Output.scala
@@ -1,9 +1,9 @@
 package zio.redis
 
+import scala.collection.mutable.ListBuffer
+
 import zio.Chunk
 import zio.duration._
-
-import scala.collection.mutable.ListBuffer
 
 sealed trait Output[+A] {
 
@@ -390,96 +390,32 @@ object Output {
   case object StreamInfoFullOutput extends Output[XInfoFullStream.StreamFullInfo] {
     override protected def tryDecode(respValue: RespValue): XInfoFullStream.StreamFullInfo = {
       var streamInfoFull: XInfoFullStream.StreamFullInfo = XInfoFullStream.StreamFullInfo.empty
-      val groupList = ListBuffer.empty[XInfoFullStream.ConsumerGroups]
       respValue match {
         // Note that you should not rely on the fields exact position. see https://redis.io/commands/xinfo
         case RespValue.Array(elements) if elements.length % 2 == 0 =>
           var pos = 0
           while (pos < elements.length) {
             (elements(pos), elements(pos + 1)) match {
-              // 1 Get the basic information of the outermost stream.
-              case (key@RespValue.BulkString(_), value@RespValue.Integer(_)) =>
+              // Get the basic information of the outermost stream.
+              case (key @ RespValue.BulkString(_), value @ RespValue.Integer(_)) =>
                 if (key.asString == XInfoFields.Length) streamInfoFull = streamInfoFull.copy(length = value.value)
-                else if (key.asString == XInfoFields.RadixTreeNodes) streamInfoFull = streamInfoFull.copy(radixTreeNodes = value.value)
-                else if (key.asString == XInfoFields.RadixTreeKeys) streamInfoFull = streamInfoFull.copy(radixTreeKeys = value.value)
-              case (key@RespValue.BulkString(_), value@RespValue.BulkString(_)) if key.asString == XInfoFields.LastGeneratedId => streamInfoFull = streamInfoFull.copy(lastGeneratedId = value.asString)
-              case (key@RespValue.BulkString(_), value@RespValue.Array(_)) if key.asString == XInfoFields.Entries => streamInfoFull = streamInfoFull.copy(entries = Some(extractStreamEntry(value)))
-              case (key@RespValue.BulkString(_), RespValue.Array(values)) if key.asString == XInfoFields.Groups =>
-                // 2 Get the group list of the stream.
-                values.foreach { group: RespValue =>
-                  var readyGroup = XInfoFullStream.ConsumerGroups.empty
-                  val consumerList = ListBuffer[XInfoFullStream.Consumers]()
-                  group match {
-                    case RespValue.Array(groups) if groups.length % 2 == 0 =>
-                      var groupPos = 0
-                      while (groupPos < groups.length) {
-                        (groups(groupPos), groups(groupPos + 1)) match {
-                          // 2.1 Get the basic information of the current group.
-                          case (key@RespValue.BulkString(_), value@RespValue.BulkString(_)) =>
-                            if (key.asString == XInfoFields.LastGeneratedId) readyGroup = readyGroup.copy(lastDeliveredId = value.asString)
-                            else if (key.asString == XInfoFields.Name) readyGroup = readyGroup.copy(name = value.asString)
-                          case (key@RespValue.BulkString(_), value@RespValue.Integer(_)) if XInfoFields.PelCount == key.asString => readyGroup = readyGroup.copy(pelCount = value.value)
-                          case (key@RespValue.BulkString(_), RespValue.Array(groupPending)) if key.asString == XInfoFields.Pending =>
-                            // 2.2 Get the pel list of the current group.
-                          val groupPelInfo = ListBuffer[XInfoFullStream.GroupPel]()
-                            groupPending.foreach {
-                              case RespValue.Array(Seq(entryId@RespValue.BulkString(_), consumerName@RespValue.BulkString(_), deliveryTime@RespValue.Integer(_), deliveryCount@RespValue.Integer(_))) =>
-                                groupPelInfo.append(XInfoFullStream.GroupPel(entryId.asString, consumerName.asString, deliveryTime.value.millis, deliveryCount.value))
-                              case other => throw ProtocolError(s"$other isn't a valid array")
-                            }
-                            readyGroup = readyGroup.copy(pending = groupPelInfo.toSeq)
-                          // 3.1 Get the consumer list of the current group.
-                          case (key@RespValue.BulkString(_), RespValue.Array(consumers)) if key.asString == XInfoFields.Consumers =>
-                              consumers.foreach {consumer =>
-                                var readyConsumer = XInfoFullStream.Consumers.empty
-                                consumer match {
-                                  case RespValue.Array(consers) if consers.length % 2 == 0 =>
-                                    var consumerPos = 0
-                                    while (consumerPos < consers.length) {
-                                      (consers(consumerPos), consers(consumerPos + 1)) match {
-                                        // 3.1.1 Get the basic information of the current consumer.
-                                        case (key@RespValue.BulkString(_), value@RespValue.BulkString(_)) if key.asString == XInfoFields.Name => readyConsumer = readyConsumer.copy(name = value.asString)
-                                        case (key@RespValue.BulkString(_), value@RespValue.Integer(_)) =>
-                                          if (XInfoFields.PelCount == key.asString)  readyConsumer = readyConsumer.copy(pelCount = value.value)
-                                          else if (XInfoFields.SeenTime == key.asString)  readyConsumer = readyConsumer.copy(seenTime = value.value.millis)
-                                        // 3.1.2 Get the pel list of the current consumer.
-                                        case (key@RespValue.BulkString(_), RespValue.Array(consumerPending)) if key.asString == XInfoFields.Pending =>
-                                          val consumerPelInfo = ListBuffer[XInfoFullStream.ConsumerPel]()
-                                          consumerPending.foreach {
-                                            case RespValue.Array(Seq(entryId@RespValue.BulkString(_), deliveryTime@RespValue.Integer(_), deliveryCount@RespValue.Integer(_))) =>
-                                              consumerPelInfo.append(XInfoFullStream.ConsumerPel(entryId.asString, deliveryTime.value.millis, deliveryCount.value))
-                                            case other => throw ProtocolError(s"$other isn't a valid array")
-                                          }
-                                          readyConsumer = readyConsumer.copy(pending = consumerPelInfo.toSeq)
-                                        case _ =>
-                                      }
-                                      consumerPos += 2
-                                    }
-                                  case array @ RespValue.Array(_) =>
-                                    throw ProtocolError(s"$array doesn't have an even number of elements")
-                                  case other =>
-                                    throw ProtocolError(s"$other isn't an array")
-                                }
-                                consumerList.append(readyConsumer)
-                              }
-
-                          case _ =>
-                        }
-                        groupPos += 2
-                      }
-                    case array @ RespValue.Array(_) =>
-                      throw ProtocolError(s"$array doesn't have an even number of elements")
-                    case other =>
-                      throw ProtocolError(s"$other isn't an array")
-                  }
-                  groupList.append(readyGroup.copy(consumers = consumerList.toSeq))
-                }
-                streamInfoFull = streamInfoFull.copy(groups = groupList.toSeq)
+                else if (key.asString == XInfoFields.RadixTreeNodes)
+                  streamInfoFull = streamInfoFull.copy(radixTreeNodes = value.value)
+                else if (key.asString == XInfoFields.RadixTreeKeys)
+                  streamInfoFull = streamInfoFull.copy(radixTreeKeys = value.value)
+              case (key @ RespValue.BulkString(_), value @ RespValue.BulkString(_))
+                  if key.asString == XInfoFields.LastGeneratedId =>
+                streamInfoFull = streamInfoFull.copy(lastGeneratedId = value.asString)
+              case (key @ RespValue.BulkString(_), value @ RespValue.Array(_)) if key.asString == XInfoFields.Entries =>
+                streamInfoFull = streamInfoFull.copy(entries = Some(extractStreamEntry(value)))
+              case (key @ RespValue.BulkString(_), RespValue.Array(value)) if key.asString == XInfoFields.Groups =>
+                // Get the group list of the stream.
+                streamInfoFull = streamInfoFull.copy(groups = extractXInfoFullGroups(value).toSeq)
               case _ =>
             }
-            pos +=2
+            pos += 2
           }
-          streamInfoFull.copy(groups = groupList.toSeq)
+          streamInfoFull
         case array @ RespValue.Array(_) =>
           throw ProtocolError(s"$array doesn't have an even number of elements")
         case other =>
@@ -487,6 +423,115 @@ object Output {
       }
     }
   }
+
+  private def extractXInfoFullGroups(groupValue: Chunk[RespValue]): ListBuffer[XInfoFullStream.ConsumerGroups] = {
+    val groupList = ListBuffer.empty[XInfoFullStream.ConsumerGroups]
+    groupValue.foreach { group: RespValue =>
+      var readyGroup = XInfoFullStream.ConsumerGroups.empty
+      group match {
+        case RespValue.Array(groupElements) if groupElements.length % 2 == 0 =>
+          var groupElementPos = 0
+          while (groupElementPos < groupElements.length) {
+            (groupElements(groupElementPos), groupElements(groupElementPos + 1)) match {
+              // Get the basic information of the current group.
+              case (key @ RespValue.BulkString(_), value @ RespValue.BulkString(_)) =>
+                if (key.asString == XInfoFields.LastGeneratedId)
+                  readyGroup = readyGroup.copy(lastDeliveredId = value.asString)
+                else if (key.asString == XInfoFields.Name) readyGroup = readyGroup.copy(name = value.asString)
+              case (key @ RespValue.BulkString(_), value @ RespValue.Integer(_))
+                  if XInfoFields.PelCount == key.asString =>
+                readyGroup = readyGroup.copy(pelCount = value.value)
+              case (key @ RespValue.BulkString(_), RespValue.Array(value)) =>
+                // Get the consumer list of the current group.
+                if (key.asString == XInfoFields.Consumers) {
+                  readyGroup = readyGroup.copy(consumers = extractXInfoFullConsumers(value).toSeq)
+                } else if (key.asString == XInfoFields.Pending) {
+                  // Get the pel list of the current group.
+                  val groupPelList = ListBuffer[XInfoFullStream.GroupPel]()
+                  value.foreach {
+                    case RespValue.Array(
+                          Seq(
+                            entryId @ RespValue.BulkString(_),
+                            consumerName @ RespValue.BulkString(_),
+                            deliveryTime @ RespValue.Integer(_),
+                            deliveryCount @ RespValue.Integer(_)
+                          )
+                        ) =>
+                      groupPelList.append(
+                        XInfoFullStream.GroupPel(
+                          entryId.asString,
+                          consumerName.asString,
+                          deliveryTime.value.millis,
+                          deliveryCount.value
+                        )
+                      )
+                    case other => throw ProtocolError(s"$other isn't a valid array")
+                  }
+                  readyGroup = readyGroup.copy(pending = groupPelList.toSeq)
+                }
+              case _ =>
+            }
+            groupElementPos += 2
+          }
+        case array @ RespValue.Array(_) =>
+          throw ProtocolError(s"$array doesn't have an even number of elements")
+        case other =>
+          throw ProtocolError(s"$other isn't an array")
+      }
+      groupList.append(readyGroup)
+    }
+    groupList
+  }
+
+  private def extractXInfoFullConsumers(consumerValue: Chunk[RespValue]): ListBuffer[XInfoFullStream.Consumers] = {
+    val consumerList = ListBuffer[XInfoFullStream.Consumers]()
+    consumerValue.foreach { consumer =>
+      var readyConsumer = XInfoFullStream.Consumers.empty
+      consumer match {
+        case RespValue.Array(consumerElements) if consumerElements.length % 2 == 0 =>
+          var consumerElementPos = 0
+          while (consumerElementPos < consumerElements.length) {
+            (consumerElements(consumerElementPos), consumerElements(consumerElementPos + 1)) match {
+              // Get the basic information of the current consumer.
+              case (key @ RespValue.BulkString(_), value @ RespValue.BulkString(_))
+                  if key.asString == XInfoFields.Name =>
+                readyConsumer = readyConsumer.copy(name = value.asString)
+              case (key @ RespValue.BulkString(_), value @ RespValue.Integer(_)) =>
+                if (XInfoFields.PelCount == key.asString) readyConsumer = readyConsumer.copy(pelCount = value.value)
+                else if (XInfoFields.SeenTime == key.asString)
+                  readyConsumer = readyConsumer.copy(seenTime = value.value.millis)
+              // Get the pel list of the current consumer.
+              case (key @ RespValue.BulkString(_), RespValue.Array(consumerPendingValue))
+                  if key.asString == XInfoFields.Pending =>
+                val consumerPelList = ListBuffer[XInfoFullStream.ConsumerPel]()
+                consumerPendingValue.foreach {
+                  case RespValue.Array(
+                        Seq(
+                          entryId @ RespValue.BulkString(_),
+                          deliveryTime @ RespValue.Integer(_),
+                          deliveryCount @ RespValue.Integer(_)
+                        )
+                      ) =>
+                    consumerPelList.append(
+                      XInfoFullStream.ConsumerPel(entryId.asString, deliveryTime.value.millis, deliveryCount.value)
+                    )
+                  case other => throw ProtocolError(s"$other isn't a valid array")
+                }
+                readyConsumer = readyConsumer.copy(pending = consumerPelList.toSeq)
+              case _ =>
+            }
+            consumerElementPos += 2
+          }
+        case array @ RespValue.Array(_) =>
+          throw ProtocolError(s"$array doesn't have an even number of elements")
+        case other =>
+          throw ProtocolError(s"$other isn't an array")
+      }
+      consumerList.append(readyConsumer)
+    }
+    consumerList
+  }
+
   case object StreamInfoOutput extends Output[StreamInfo] {
     override protected def tryDecode(respValue: RespValue): StreamInfo = {
       var streamInfo: StreamInfo = StreamInfo.empty

--- a/redis/src/main/scala/zio/redis/api/Streams.scala
+++ b/redis/src/main/scala/zio/redis/api/Streams.scala
@@ -58,7 +58,7 @@ trait Streams {
   final def xInfoStreamFull(
     key: String,
     count: Option[Long] = None
-  ): ZIO[RedisExecutor, RedisError, XInfoFullStream.StreamFullInfo] =
+  ): ZIO[RedisExecutor, RedisError, StreamInfoWithFull.FullStreamInfo] =
     XInfoStreamFull.run(XInfoCommand.Stream(key, Some(XInfoCommand.Full(count))))
 
   /**
@@ -509,7 +509,7 @@ private object Streams {
   final val XGroupDelConsumer: RedisCommand[XGroupCommand.DelConsumer, Long] =
     RedisCommand("XGROUP", XGroupDelConsumerInput, LongOutput)
 
-  final val XInfoStreamFull: RedisCommand[XInfoCommand.Stream, XInfoFullStream.StreamFullInfo] =
+  final val XInfoStreamFull: RedisCommand[XInfoCommand.Stream, StreamInfoWithFull.FullStreamInfo] =
     RedisCommand("XINFO", XInfoStreamInput, StreamInfoFullOutput)
 
   final val XInfoStream: RedisCommand[XInfoCommand.Stream, StreamInfo] =

--- a/redis/src/main/scala/zio/redis/api/Streams.scala
+++ b/redis/src/main/scala/zio/redis/api/Streams.scala
@@ -49,6 +49,19 @@ trait Streams {
     XInfoStream.run(XInfoCommand.Stream(key))
 
   /**
+   * Returns the entire state of the stream, including entries, groups, consumers and PELs.
+   *
+   * @param key ID of the stream
+   * @param count limit the amount of stream/PEL entries that are returned (The first <count> entries are returned).
+   * @return General information about the stream stored at the specified key.
+   */
+  final def xInfoStreamFull(
+    key: String,
+    count: Option[Long] = None
+  ): ZIO[RedisExecutor, RedisError, XInfoFullStream.StreamFullInfo] =
+    XInfoStreamFull.run(XInfoCommand.Stream(key, Some(XInfoCommand.Full(count))))
+
+  /**
    * An introspection command used in order to retrieve different information about the group.
    *
    * @param key ID of the stream
@@ -495,6 +508,9 @@ private object Streams {
 
   final val XGroupDelConsumer: RedisCommand[XGroupCommand.DelConsumer, Long] =
     RedisCommand("XGROUP", XGroupDelConsumerInput, LongOutput)
+
+  final val XInfoStreamFull: RedisCommand[XInfoCommand.Stream, XInfoFullStream.StreamFullInfo] =
+    RedisCommand("XINFO", XInfoStreamInput, StreamInfoFullOutput)
 
   final val XInfoStream: RedisCommand[XInfoCommand.Stream, StreamInfo] =
     RedisCommand("XINFO", XInfoStreamInput, StreamInfoOutput)

--- a/redis/src/main/scala/zio/redis/api/Streams.scala
+++ b/redis/src/main/scala/zio/redis/api/Streams.scala
@@ -52,14 +52,25 @@ trait Streams {
    * Returns the entire state of the stream, including entries, groups, consumers and PELs.
    *
    * @param key ID of the stream
+   * @return General information about the stream stored at the specified key.
+   */
+  final def xInfoStreamFull(
+    key: String
+  ): ZIO[RedisExecutor, RedisError, StreamInfoWithFull.FullStreamInfo] =
+    XInfoStreamFull.run(XInfoCommand.Stream(key, Some(XInfoCommand.Full(None))))
+
+  /**
+   * Returns the entire state of the stream, including entries, groups, consumers and PELs.
+   *
+   * @param key ID of the stream
    * @param count limit the amount of stream/PEL entries that are returned (The first <count> entries are returned).
    * @return General information about the stream stored at the specified key.
    */
   final def xInfoStreamFull(
     key: String,
-    count: Option[Long] = None
+    count: Long
   ): ZIO[RedisExecutor, RedisError, StreamInfoWithFull.FullStreamInfo] =
-    XInfoStreamFull.run(XInfoCommand.Stream(key, Some(XInfoCommand.Full(count))))
+    XInfoStreamFull.run(XInfoCommand.Stream(key, Some(XInfoCommand.Full(Some(count)))))
 
   /**
    * An introspection command used in order to retrieve different information about the group.

--- a/redis/src/main/scala/zio/redis/options/Streams.scala
+++ b/redis/src/main/scala/zio/redis/options/Streams.scala
@@ -36,11 +36,14 @@ trait Streams {
 
   object XInfoCommand {
 
-    case class Stream(key: String) extends XInfoCommand
+    case class Stream(key: String, full: Option[Full] = None) extends XInfoCommand
+
+    case class Full(count: Option[Long])
 
     case class Groups(key: String) extends XInfoCommand
 
     case class Consumers(key: String, group: String) extends XInfoCommand
+
   }
 
   case object MkStream {
@@ -108,6 +111,45 @@ trait Streams {
 
   object StreamConsumersInfo {
     def empty: StreamConsumersInfo = StreamConsumersInfo("", 0, 0.millis)
+  }
+
+  object XInfoFullStream {
+
+    case class StreamFullInfo(
+      length: Long,
+      radixTreeKeys: Long,
+      radixTreeNodes: Long,
+      lastGeneratedId: String,
+      entries: Option[StreamEntry],
+      groups: Seq[ConsumerGroups]
+    )
+
+    object StreamFullInfo {
+      def empty: StreamFullInfo = StreamFullInfo(0, 0, 0, "", None, Nil)
+    }
+
+    case class ConsumerGroups(
+      name: String,
+      lastDeliveredId: String,
+      pelCount: Long,
+      pending: Seq[GroupPel],
+      consumers: Seq[Consumers]
+    )
+
+    object ConsumerGroups {
+      def empty: ConsumerGroups = ConsumerGroups("", "", 0, Nil, Nil)
+    }
+
+    case class GroupPel(entryId: String, consumerName: String, deliveryTime: Duration, deliveryCount: Long)
+
+    case class Consumers(name: String, seenTime: Duration, pelCount: Long, pending: Seq[ConsumerPel])
+
+    object Consumers {
+      def empty: Consumers = Consumers("", 0.millis, 0, Nil)
+    }
+
+    case class ConsumerPel(entryId: String, deliveryTime: Duration, deliveryCount: Long)
+
   }
 
   private[redis] object XInfoFields {

--- a/redis/src/main/scala/zio/redis/options/Streams.scala
+++ b/redis/src/main/scala/zio/redis/options/Streams.scala
@@ -1,5 +1,6 @@
 package zio.redis.options
 
+import zio.Chunk
 import zio.duration._
 
 trait Streams {
@@ -113,39 +114,39 @@ trait Streams {
     def empty: StreamConsumersInfo = StreamConsumersInfo("", 0, 0.millis)
   }
 
-  object XInfoFullStream {
+  object StreamInfoWithFull {
 
-    case class StreamFullInfo(
+    case class FullStreamInfo(
       length: Long,
       radixTreeKeys: Long,
       radixTreeNodes: Long,
       lastGeneratedId: String,
-      entries: Option[StreamEntry],
-      groups: Seq[ConsumerGroups]
+      entries: Chunk[StreamEntry],
+      groups: Chunk[ConsumerGroups]
     )
 
-    object StreamFullInfo {
-      def empty: StreamFullInfo = StreamFullInfo(0, 0, 0, "", None, Nil)
+    object FullStreamInfo {
+      def empty: FullStreamInfo = FullStreamInfo(0, 0, 0, "", Chunk.empty, Chunk.empty)
     }
 
     case class ConsumerGroups(
       name: String,
       lastDeliveredId: String,
       pelCount: Long,
-      pending: Seq[GroupPel],
-      consumers: Seq[Consumers]
+      pending: Chunk[GroupPel],
+      consumers: Chunk[Consumers]
     )
 
     object ConsumerGroups {
-      def empty: ConsumerGroups = ConsumerGroups("", "", 0, Nil, Nil)
+      def empty: ConsumerGroups = ConsumerGroups("", "", 0, Chunk.empty, Chunk.empty)
     }
 
     case class GroupPel(entryId: String, consumerName: String, deliveryTime: Duration, deliveryCount: Long)
 
-    case class Consumers(name: String, seenTime: Duration, pelCount: Long, pending: Seq[ConsumerPel])
+    case class Consumers(name: String, seenTime: Duration, pelCount: Long, pending: Chunk[ConsumerPel])
 
     object Consumers {
-      def empty: Consumers = Consumers("", 0.millis, 0, Nil)
+      def empty: Consumers = Consumers("", 0.millis, 0, Chunk.empty)
     }
 
     case class ConsumerPel(entryId: String, deliveryTime: Duration, deliveryCount: Long)
@@ -157,8 +158,8 @@ trait Streams {
     val Idle: String    = "idle"
     val Pending: String = "pending"
 
-    val Consumers: String     = "consumers"
-    val LastDelivered: String = "last-delivered-id"
+    val Consumers: String       = "consumers"
+    val LastDeliveredId: String = "last-delivered-id"
 
     val Length: String          = "length"
     val RadixTreeKeys: String   = "radix-tree-keys"

--- a/redis/src/test/scala/zio/redis/ApiSpec.scala
+++ b/redis/src/test/scala/zio/redis/ApiSpec.scala
@@ -21,21 +21,21 @@ object ApiSpec
     // scalafix:on
     suite("Redis commands")(
       suite("Live Executor")(
-        connectionSuite,
-        keysSuite,
-        listSuite,
-        setsSuite,
-        sortedSetsSuite,
-        stringsSuite,
-        geoSuite,
-        hyperLogLogSuite,
-        hashSuite,
+//        connectionSuite,
+//        keysSuite,
+//        listSuite,
+//        setsSuite,
+//        sortedSetsSuite,
+//        stringsSuite,
+//        geoSuite,
+//        hyperLogLogSuite,
+//        hashSuite,
         streamsSuite
       ).provideCustomLayerShared((Logging.ignore >>> RedisExecutor.local.orDie) ++ Clock.live),
       suite("Test Executor")(
-        connectionSuite,
-        setsSuite,
-        hyperLogLogSuite
+//        connectionSuite,
+//        setsSuite,
+//        hyperLogLogSuite
       ).filterAnnotations(TestAnnotation.tagged)(t => !t.contains(TestExecutorUnsupportedTag))
         .get
         .provideCustomLayerShared(RedisExecutor.test)

--- a/redis/src/test/scala/zio/redis/ApiSpec.scala
+++ b/redis/src/test/scala/zio/redis/ApiSpec.scala
@@ -21,21 +21,21 @@ object ApiSpec
     // scalafix:on
     suite("Redis commands")(
       suite("Live Executor")(
-//        connectionSuite,
-//        keysSuite,
-//        listSuite,
-//        setsSuite,
-//        sortedSetsSuite,
-//        stringsSuite,
-//        geoSuite,
-//        hyperLogLogSuite,
-//        hashSuite,
+        connectionSuite,
+        keysSuite,
+        listSuite,
+        setsSuite,
+        sortedSetsSuite,
+        stringsSuite,
+        geoSuite,
+        hyperLogLogSuite,
+        hashSuite,
         streamsSuite
       ).provideCustomLayerShared((Logging.ignore >>> RedisExecutor.local.orDie) ++ Clock.live),
       suite("Test Executor")(
-//        connectionSuite,
-//        setsSuite,
-//        hyperLogLogSuite
+        connectionSuite,
+        setsSuite,
+        hyperLogLogSuite
       ).filterAnnotations(TestAnnotation.tagged)(t => !t.contains(TestExecutorUnsupportedTag))
         .get
         .provideCustomLayerShared(RedisExecutor.test)

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -986,7 +986,7 @@ object InputSpec extends BaseSpec {
           )
         }
       ),
-      suite("XInfoStream FULL")(
+      suite("XInfoStreamFull")(
         testM("valid value") {
           assertM(Task(XInfoStreamInput.encode(XInfoCommand.Stream("key", Some(XInfoCommand.Full(Some(10)))))))(
             equalTo(respArgs("STREAM", "key", "FULL", "COUNT", "10"))

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -986,6 +986,13 @@ object InputSpec extends BaseSpec {
           )
         }
       ),
+      suite("XInfoStream FULL")(
+        testM("valid value") {
+          assertM(Task(XInfoStreamInput.encode(XInfoCommand.Stream("key",Some(XInfoCommand.Full(Some(10)))))))(
+            equalTo( respArgs("STREAM", "key", "FULL", "COUNT", "10"))
+          )
+        }
+      ),
       suite("XInfoGroups")(
         testM("valid value") {
           assertM(Task(XInfoGroupsInput.encode(XInfoCommand.Groups("key"))))(

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -988,8 +988,8 @@ object InputSpec extends BaseSpec {
       ),
       suite("XInfoStream FULL")(
         testM("valid value") {
-          assertM(Task(XInfoStreamInput.encode(XInfoCommand.Stream("key",Some(XInfoCommand.Full(Some(10)))))))(
-            equalTo( respArgs("STREAM", "key", "FULL", "COUNT", "10"))
+          assertM(Task(XInfoStreamInput.encode(XInfoCommand.Stream("key", Some(XInfoCommand.Full(Some(10)))))))(
+            equalTo(respArgs("STREAM", "key", "FULL", "COUNT", "10"))
           )
         }
       ),

--- a/redis/src/test/scala/zio/redis/OutputSpec.scala
+++ b/redis/src/test/scala/zio/redis/OutputSpec.scala
@@ -514,7 +514,6 @@ object OutputSpec extends BaseSpec {
               RespValue.bulkString("2-0"),
               RespValue.bulkString("first-entry"),
               RespValue.array(
-                RespValue.bulkString("id"),
                 RespValue.bulkString("1-0"),
                 RespValue.array(
                   RespValue.bulkString("key1"),
@@ -523,7 +522,6 @@ object OutputSpec extends BaseSpec {
               ),
               RespValue.bulkString("last-entry"),
               RespValue.array(
-                RespValue.bulkString("id"),
                 RespValue.bulkString("2-0"),
                 RespValue.array(
                   RespValue.bulkString("key2"),
@@ -639,6 +637,178 @@ object OutputSpec extends BaseSpec {
             val resp = RespValue.array()
 
             assertM(Task(StreamConsumersInfoOutput.unsafeDecode(resp)))(isEmpty)
+          }
+        ),
+        suite("xInfoStreamFull")(
+          testM("extract a valid value without groups") {
+            val resp = RespValue.array(
+              RespValue.bulkString("length"),
+              RespValue.Integer(1),
+              RespValue.bulkString("radix-tree-keys"),
+              RespValue.Integer(2),
+              RespValue.bulkString("radix-tree-nodes"),
+              RespValue.Integer(3),
+              RespValue.bulkString("last-generated-id"),
+              RespValue.bulkString("0-0"),
+              RespValue.bulkString("entries"),
+              RespValue.array(
+                RespValue.array(
+                  RespValue.bulkString("3-0"),
+                  RespValue.array(
+                    RespValue.bulkString("key1"),
+                    RespValue.bulkString("value1")
+                  )
+                ),
+                RespValue.array(
+                  RespValue.bulkString("4-0"),
+                  RespValue.array(
+                    RespValue.bulkString("key1"),
+                    RespValue.bulkString("value1")
+                  )
+                )
+              )
+            )
+
+            assertM(Task(StreamInfoFullOutput.unsafeDecode(resp)))(
+              equalTo(
+                StreamInfoWithFull.FullStreamInfo(
+                  1,
+                  2,
+                  3,
+                  "0-0",
+                  Chunk(StreamEntry("3-0", Map("key1" -> "value1")), StreamEntry("4-0", Map("key1" -> "value1"))),
+                  Chunk.empty
+                )
+              )
+            )
+          },
+          testM("extract a valid value without groups and entries") {
+            val resp = RespValue.array(
+              RespValue.bulkString("length"),
+              RespValue.Integer(1),
+              RespValue.bulkString("radix-tree-keys"),
+              RespValue.Integer(2),
+              RespValue.bulkString("radix-tree-nodes"),
+              RespValue.Integer(3),
+              RespValue.bulkString("last-generated-id"),
+              RespValue.bulkString("0-0")
+            )
+            assertM(Task(StreamInfoFullOutput.unsafeDecode(resp)))(
+              equalTo(
+                StreamInfoWithFull.FullStreamInfo(1, 2, 3, "0-0", Chunk.empty, Chunk.empty)
+              )
+            )
+          },
+          testM("extract an empty array") {
+            val resp = RespValue.array()
+            assertM(Task(StreamConsumersInfoOutput.unsafeDecode(resp)))(isEmpty)
+          },
+          testM("extract a valid value with groups") {
+            val resp = RespValue.array(
+              RespValue.bulkString("length"),
+              RespValue.Integer(1),
+              RespValue.bulkString("radix-tree-keys"),
+              RespValue.Integer(2),
+              RespValue.bulkString("radix-tree-nodes"),
+              RespValue.Integer(3),
+              RespValue.bulkString("last-generated-id"),
+              RespValue.bulkString("0-0"),
+              RespValue.bulkString("entries"),
+              RespValue.array(
+                RespValue.array(
+                  RespValue.bulkString("3-0"),
+                  RespValue.array(
+                    RespValue.bulkString("key1"),
+                    RespValue.bulkString("value1")
+                  )
+                ),
+                RespValue.array(
+                  RespValue.bulkString("4-0"),
+                  RespValue.array(
+                    RespValue.bulkString("key1"),
+                    RespValue.bulkString("value1")
+                  )
+                )
+              ),
+              RespValue.bulkString("groups"),
+              RespValue.array(
+                RespValue.array(
+                  RespValue.bulkString("name"),
+                  RespValue.bulkString("name1"),
+                  RespValue.bulkString("last-delivered-id"),
+                  RespValue.bulkString("lastDeliveredId"),
+                  RespValue.bulkString("pel-count"),
+                  RespValue.Integer(1),
+                  RespValue.bulkString("pending"),
+                  RespValue.array(
+                    RespValue.array(
+                      RespValue.bulkString("entryId1"),
+                      RespValue.bulkString("consumerName1"),
+                      RespValue.Integer(1588152520299L),
+                      RespValue.Integer(1)
+                    ),
+                    RespValue.array(
+                      RespValue.bulkString("entryId2"),
+                      RespValue.bulkString("consumerName2"),
+                      RespValue.Integer(1588152520299L),
+                      RespValue.Integer(1)
+                    )
+                  ),
+                  RespValue.bulkString("consumers"),
+                  RespValue.array(
+                    RespValue.array(
+                      RespValue.bulkString("name"),
+                      RespValue.bulkString("Alice"),
+                      RespValue.bulkString("seen-time"),
+                      RespValue.Integer(1588152520299L),
+                      RespValue.bulkString("pel-count"),
+                      RespValue.Integer(1),
+                      RespValue.bulkString("pending"),
+                      RespValue.array(
+                        RespValue.array(
+                          RespValue.bulkString("entryId3"),
+                          RespValue.Integer(1588152520299L),
+                          RespValue.Integer(1)
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+
+            assertM(Task(StreamInfoFullOutput.unsafeDecode(resp)))(
+              equalTo(
+                StreamInfoWithFull.FullStreamInfo(
+                  1,
+                  2,
+                  3,
+                  "0-0",
+                  Chunk(StreamEntry("3-0", Map("key1" -> "value1")), StreamEntry("4-0", Map("key1" -> "value1"))),
+                  Chunk(
+                    StreamInfoWithFull.ConsumerGroups(
+                      "name1",
+                      "lastDeliveredId",
+                      1,
+                      Chunk(
+                        StreamInfoWithFull.GroupPel("entryId1", "consumerName1", 1588152520299L.millis, 1L),
+                        StreamInfoWithFull.GroupPel("entryId2", "consumerName2", 1588152520299L.millis, 1L)
+                      ),
+                      Chunk(
+                        StreamInfoWithFull.Consumers(
+                          "Alice",
+                          1588152520299L.millis,
+                          1,
+                          Chunk(
+                            StreamInfoWithFull.ConsumerPel("entryId3", 1588152520299L.millis, 1)
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
           }
         )
       )


### PR DESCRIPTION
#312

The internal structure naming references to [redis/redis](https://github.com/redis/redis/blob/6da2bc96e210dba081328d9b24f466cea6047826/src/t_stream.c#L3332), but external naming such as `FullStreamInfo`,`xInfoStreamFull ` may need to be modified and need more testing.