### PR TITLE
add zMScore

### DIFF
--- a/redis/src/main/scala/zio/redis/api/SortedSets.scala
+++ b/redis/src/main/scala/zio/redis/api/SortedSets.scala
@@ -620,6 +620,21 @@ trait SortedSets {
     )
     command.run((destination, inputKeysNum, (key, keys.toList), weights, aggregate))
   }
+
+  /**
+   * Returns the scores associated with the specified members in the sorted set stored at key.
+   *
+   * @param key Key of the set
+   * @param keys Keys of the rest sets
+   * @return list of scores or None associated with the specified member values (a double precision floating point number)
+   */
+  final def zMScore[K: Schema](
+    key: K,
+    keys: K*
+  ): ZIO[RedisExecutor, RedisError, Chunk[Option[Double]]] = {
+    val command = RedisCommand(Zmscore, NonEmptyList(ArbitraryInput[K]()), ChunkOutput(OptionalOutput(DoubleOutput)))
+    command.run((key, keys.toList))
+  }
 }
 
 private[redis] object SortedSets {
@@ -648,4 +663,5 @@ private[redis] object SortedSets {
   final val ZScan            = "ZSCAN"
   final val ZScore           = "ZSCORE"
   final val ZUnionStore      = "ZUNIONSTORE"
+  final val Zmscore          = "ZMSCORE"
 }

--- a/redis/src/test/scala/zio/redis/SortedSetsSpec.scala
+++ b/redis/src/test/scala/zio/redis/SortedSetsSpec.scala
@@ -986,6 +986,27 @@ trait SortedSetsSpec extends BaseSpec {
           } yield assert(result)(isNone)
         }
       ),
+      suite("zMScore")(
+        testM("non-empty set") {
+          for {
+            key <- uuid
+            _ <- zAdd(key)(
+                   MemberScore(10d, "Delhi"),
+                   MemberScore(20d, "Mumbai"),
+                   MemberScore(30d, "Hyderabad"),
+                   MemberScore(40d, "Kolkata"),
+                   MemberScore(50d, "Chennai")
+                 )
+            result <- zMScore(key, "Delhi", "Mumbai")
+          } yield assert(result)(equalTo(Chunk(Some(10d), Some(20d))))
+        },
+        testM("empty set") {
+          for {
+            key    <- uuid
+            result <- zMScore(key, "Hyderabad")
+          } yield assert(result)(equalTo(Chunk(None)))
+        }
+      ),
       suite("zUnionStore")(
         testM("two non-empty sets") {
           for {

--- a/redis/src/test/scala/zio/redis/SortedSetsSpec.scala
+++ b/redis/src/test/scala/zio/redis/SortedSetsSpec.scala
@@ -997,8 +997,8 @@ trait SortedSetsSpec extends BaseSpec {
                    MemberScore(40d, "Kolkata"),
                    MemberScore(50d, "Chennai")
                  )
-            result <- zMScore(key, "Delhi", "Mumbai")
-          } yield assert(result)(equalTo(Chunk(Some(10d), Some(20d))))
+            result <- zMScore(key, "Delhi", "Mumbai", "notFound")
+          } yield assert(result)(equalTo(Chunk(Some(10d), Some(20d), None)))
         },
         testM("empty set") {
           for {


### PR DESCRIPTION
close #351

Redis doc is `Array reply: list of scores or nil associated with the specified member values (a double precision floating point number), represented as strings.`
`Chunk[Option[Double]]]` is used, but I don't think it's the most suitable one. Does anyone have a better proposal?