### PR TITLE
Set explicit container version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,12 +3,12 @@ version: "3.2"
 services:
   redis1:
     container_name: test_redis_1
-    image: redis:6-alpine
+    image: redis:6.2-alpine
     ports:
       - "6379:6379"
 
   redis2:
     container_name: test_redis_2
-    image: redis:6-alpine
+    image: redis:6.2-alpine
     ports:
       - "6380:6379"


### PR DESCRIPTION
In order to test new commands introduced in Redis 6.2, upgrade our test container versions.