### PR TITLE
Implement ZINTER command (#350) 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,12 +3,12 @@ version: "3.2"
 services:
   redis1:
     container_name: test_redis_1
-    image: redis:6-alpine
+    image: redis:6.2-alpine
     ports:
       - "6379:6379"
 
   redis2:
     container_name: test_redis_2
-    image: redis:6-alpine
+    image: redis:6.2-alpine
     ports:
       - "6380:6379"

--- a/redis/src/main/scala/zio/redis/api/SortedSets.scala
+++ b/redis/src/main/scala/zio/redis/api/SortedSets.scala
@@ -164,6 +164,36 @@ trait SortedSets {
   }
 
   /**
+   * Intersect multiple sorted sets and return members.
+   *
+   * @param inputKeysNum Number of input keys
+   * @param key Key of a sorted set
+   * @param keys Keys of the rest sorted sets
+   * @param aggregate With the AGGREGATE option, it is possible to specify how the results of the union are aggregated
+   * @param weights Represents WEIGHTS option, it is possible to specify a multiplication factor for each input sorted
+   *                set. This means that the score of every element in every input sorted set is multiplied by this
+   *                factor before being passed to the aggregation function. When WEIGHTS is not given, the
+   *                multiplication factors default to 1
+   * @return Chunk containing the intersection of members.
+   */
+  final def zInter[K: Schema, M: Schema](inputKeysNum: Long, key: K, keys: K*)(
+    aggregate: Option[Aggregate] = None,
+    weights: Option[::[Double]] = None
+  ): ZIO[RedisExecutor, RedisError, Chunk[M]] = {
+    val command = RedisCommand(
+      ZInter,
+      Tuple4(
+        LongInput,
+        NonEmptyList(ArbitraryInput[K]()),
+        OptionalInput(AggregateInput),
+        OptionalInput(WeightsInput)
+      ),
+      ChunkOutput(ArbitraryOutput[M]())
+    )
+    command.run((inputKeysNum, (key, keys.toList), aggregate, weights))
+  }
+
+  /**
    * Intersect multiple sorted sets and store the resulting sorted set in a new key.
    *
    * @param destination Key of the output

--- a/redis/src/main/scala/zio/redis/api/SortedSets.scala
+++ b/redis/src/main/scala/zio/redis/api/SortedSets.scala
@@ -194,6 +194,38 @@ trait SortedSets {
   }
 
   /**
+   * Intersect multiple sorted sets and return members and their associated score.
+   *
+   * @param inputKeysNum Number of input keys
+   * @param key Key of a sorted set
+   * @param keys Keys of the rest sorted sets
+   * @param aggregate With the AGGREGATE option, it is possible to specify how the results of the union are aggregated
+   * @param weights Represents WEIGHTS option, it is possible to specify a multiplication factor for each input sorted
+   *                set. This means that the score of every element in every input sorted set is multiplied by this
+   *                factor before being passed to the aggregation function. When WEIGHTS is not given, the
+   *                multiplication factors default to 1
+   * @return Chunk containing the intersection of members with their score.
+   */
+  final def zInterWithScores[K: Schema, M: Schema](inputKeysNum: Long, key: K, keys: K*)(
+    aggregate: Option[Aggregate] = None,
+    weights: Option[::[Double]] = None
+  ): ZIO[RedisExecutor, RedisError, Chunk[MemberScore[M]]] = {
+    val command = RedisCommand(
+      ZInter,
+      Tuple5(
+        LongInput,
+        NonEmptyList(ArbitraryInput[K]()),
+        OptionalInput(AggregateInput),
+        OptionalInput(WeightsInput),
+        ArbitraryInput[String]()
+      ),
+      ChunkTuple2Output(ArbitraryOutput[M](), DoubleOutput)
+        .map(_.map { case (m, s) => MemberScore(s, m) })
+    )
+    command.run((inputKeysNum, (key, keys.toList), aggregate, weights, WithScores.stringify))
+  }
+
+  /**
    * Intersect multiple sorted sets and store the resulting sorted set in a new key.
    *
    * @param destination Key of the output
@@ -687,6 +719,7 @@ private[redis] object SortedSets {
   final val ZCard            = "ZCARD"
   final val ZCount           = "ZCOUNT"
   final val ZIncrBy          = "ZINCRBY"
+  final val ZInter           = "ZINTER"
   final val ZInterStore      = "ZINTERSTORE"
   final val ZLexCount        = "ZLEXCOUNT"
   final val ZPopMax          = "ZPOPMAX"

--- a/redis/src/test/scala/zio/redis/SortedSetsSpec.scala
+++ b/redis/src/test/scala/zio/redis/SortedSetsSpec.scala
@@ -236,6 +236,119 @@ trait SortedSetsSpec extends BaseSpec {
           } yield assert(count)(equalTo(0L)) && assert(incrRes)(equalTo(10.0))
         }
       ),
+      suite("zInter")(
+        testM("two non-empty sets") {
+          for {
+            first   <- uuid
+            second  <- uuid
+            _       <- zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
+            _       <- zAdd(second)(MemberScore(1d, "a"), MemberScore(3d, "c"), MemberScore(5d, "e"))
+            members <- zInter[String, String](2, first, second)()
+          } yield assert(members)(equalTo(Chunk("a", "c")))
+        },
+        testM("empty when one of the sets is empty") {
+          for {
+            nonEmpty <- uuid
+            empty    <- uuid
+            _        <- zAdd(nonEmpty)(MemberScore(1d, "a"), MemberScore(2d, "b"))
+            members  <- zInter[String, String](2, nonEmpty, empty)()
+          } yield assert(members)(isEmpty)
+        },
+        testM("empty when both sets are empty") {
+          for {
+            first   <- uuid
+            second  <- uuid
+            members <- zInter[String, String](2, first, second)()
+          } yield assert(members)(isEmpty)
+        },
+        testM("non-empty set with multiple non-empty sets") {
+          for {
+            first   <- uuid
+            second  <- uuid
+            third   <- uuid
+            _       <- zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
+            _       <- zAdd(second)(MemberScore(2d, "b"), MemberScore(2d, "b"), MemberScore(4d, "d"))
+            _       <- zAdd(third)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"))
+            members <- zInter[String, String](3, first, second, third)()
+          } yield assert(members)(
+            equalTo(Chunk("b"))
+          )
+        },
+        testM("error when first parameter is not set") {
+          for {
+            first   <- uuid
+            second  <- uuid
+            value   <- uuid
+            _       <- set(first, value)
+            members <- zInter[String, String](2, first, second)().either
+          } yield assert(members)(isLeft(isSubtype[WrongType](anything)))
+        },
+        testM("error with empty first set and second parameter is not set") {
+          for {
+            first   <- uuid
+            second  <- uuid
+            value   <- uuid
+            _       <- set(second, value)
+            members <- zInter[String, String](2, first, second)().either
+          } yield assert(members)(isLeft(isSubtype[WrongType](anything)))
+        },
+        testM("error with non-empty first set and second parameter is not set") {
+          for {
+            first   <- uuid
+            second  <- uuid
+            value   <- uuid
+            _       <- zAdd(first)(MemberScore(1d, "a"))
+            _       <- set(second, value)
+            members <- zInter[String, String](2, first, second)().either
+          } yield assert(members)(isLeft(isSubtype[WrongType](anything)))
+        },
+        testM("parameter weights provided") {
+          for {
+            first   <- uuid
+            second  <- uuid
+            _       <- zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
+            _       <- zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
+            members <- zInter[String, String](2, first, second)(weights = Some(::(2.0, 3.0 :: Nil)))
+          } yield assert(members)(equalTo(Chunk("O", "N")))
+        },
+        testM("error when invalid weights provided ( less than sets number )") {
+          for {
+            first   <- uuid
+            second  <- uuid
+            _       <- zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
+            _       <- zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
+            members <- zInter[String, String](2, first, second)(weights = Some(::(2, Nil))).either
+          } yield assert(members)(isLeft(isSubtype[ProtocolError](anything)))
+        },
+        testM("error when invalid weights provided ( more than sets number )") {
+          for {
+            first  <- uuid
+            second <- uuid
+            _      <- zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
+            _      <- zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
+            members <-
+              zInter[String, String](2, first, second)(weights = Some(::(2.0, List(3.0, 5.0)))).either
+          } yield assert(members)(isLeft(isSubtype[ProtocolError](anything)))
+        },
+        testM("set aggregate parameter MAX") {
+          for {
+            first   <- uuid
+            second  <- uuid
+            _       <- zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
+            _       <- zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
+            members <- zInter[String, String](2, first, second)(Some(Aggregate.Max))
+          } yield assert(members)(equalTo(Chunk("N", "O")))
+        },
+        testM("set aggregate parameter MIN") {
+          for {
+            first   <- uuid
+            second  <- uuid
+            _       <- zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
+            _       <- zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
+            members <- zInter[String, String](2, first, second)(Some(Aggregate.Min))
+          } yield assert(members)(equalTo(Chunk("O", "N")))
+        }
+      ),
       suite("zInterStore")(
         testM("two non-empty sets") {
           for {

--- a/redis/src/test/scala/zio/redis/SortedSetsSpec.scala
+++ b/redis/src/test/scala/zio/redis/SortedSetsSpec.scala
@@ -349,6 +349,119 @@ trait SortedSetsSpec extends BaseSpec {
           } yield assert(members)(equalTo(Chunk("O", "N")))
         }
       ),
+      suite("zInterWithScores")(
+        testM("two non-empty sets") {
+          for {
+            first   <- uuid
+            second  <- uuid
+            _       <- zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
+            _       <- zAdd(second)(MemberScore(1d, "a"), MemberScore(3d, "c"), MemberScore(5d, "e"))
+            members <- zInterWithScores[String, String](2, first, second)()
+          } yield assert(members)(equalTo(Chunk(MemberScore(2d, "a"), MemberScore(6d, "c"))))
+        },
+        testM("empty when one of the sets is empty") {
+          for {
+            nonEmpty <- uuid
+            empty    <- uuid
+            _        <- zAdd(nonEmpty)(MemberScore(1d, "a"), MemberScore(2d, "b"))
+            members  <- zInterWithScores[String, String](2, nonEmpty, empty)()
+          } yield assert(members)(isEmpty)
+        },
+        testM("empty when both sets are empty") {
+          for {
+            first   <- uuid
+            second  <- uuid
+            members <- zInterWithScores[String, String](2, first, second)()
+          } yield assert(members)(isEmpty)
+        },
+        testM("non-empty set with multiple non-empty sets") {
+          for {
+            first   <- uuid
+            second  <- uuid
+            third   <- uuid
+            _       <- zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
+            _       <- zAdd(second)(MemberScore(2d, "b"), MemberScore(2d, "b"), MemberScore(4d, "d"))
+            _       <- zAdd(third)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"))
+            members <- zInterWithScores[String, String](3, first, second, third)()
+          } yield assert(members)(
+            equalTo(Chunk(MemberScore(6d, "b")))
+          )
+        },
+        testM("error when first parameter is not set") {
+          for {
+            first   <- uuid
+            second  <- uuid
+            value   <- uuid
+            _       <- set(first, value)
+            members <- zInterWithScores[String, String](2, first, second)().either
+          } yield assert(members)(isLeft(isSubtype[WrongType](anything)))
+        },
+        testM("error with empty first set and second parameter is not set") {
+          for {
+            first   <- uuid
+            second  <- uuid
+            value   <- uuid
+            _       <- set(second, value)
+            members <- zInterWithScores[String, String](2, first, second)().either
+          } yield assert(members)(isLeft(isSubtype[WrongType](anything)))
+        },
+        testM("error with non-empty first set and second parameter is not set") {
+          for {
+            first   <- uuid
+            second  <- uuid
+            value   <- uuid
+            _       <- zAdd(first)(MemberScore(1d, "a"))
+            _       <- set(second, value)
+            members <- zInterWithScores[String, String](2, first, second)().either
+          } yield assert(members)(isLeft(isSubtype[WrongType](anything)))
+        },
+        testM("parameter weights provided") {
+          for {
+            first   <- uuid
+            second  <- uuid
+            _       <- zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
+            _       <- zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
+            members <- zInterWithScores[String, String](2, first, second)(weights = Some(::(2.0, 3.0 :: Nil)))
+          } yield assert(members)(equalTo(Chunk(MemberScore(20d, "O"), MemberScore(21d, "N"))))
+        },
+        testM("error when invalid weights provided ( less than sets number )") {
+          for {
+            first   <- uuid
+            second  <- uuid
+            _       <- zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
+            _       <- zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
+            members <- zInterWithScores[String, String](2, first, second)(weights = Some(::(2, Nil))).either
+          } yield assert(members)(isLeft(isSubtype[ProtocolError](anything)))
+        },
+        testM("error when invalid weights provided ( more than sets number )") {
+          for {
+            first  <- uuid
+            second <- uuid
+            _      <- zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
+            _      <- zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
+            members <-
+              zInterWithScores[String, String](2, first, second)(weights = Some(::(2.0, List(3.0, 5.0)))).either
+          } yield assert(members)(isLeft(isSubtype[ProtocolError](anything)))
+        },
+        testM("set aggregate parameter MAX") {
+          for {
+            first   <- uuid
+            second  <- uuid
+            _       <- zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
+            _       <- zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
+            members <- zInterWithScores[String, String](2, first, second)(Some(Aggregate.Max))
+          } yield assert(members)(equalTo(Chunk(MemberScore(6d, "N"), MemberScore(7d, "O"))))
+        },
+        testM("set aggregate parameter MIN") {
+          for {
+            first   <- uuid
+            second  <- uuid
+            _       <- zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
+            _       <- zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
+            members <- zInterWithScores[String, String](2, first, second)(Some(Aggregate.Min))
+          } yield assert(members)(equalTo(Chunk(MemberScore(2d, "O"), MemberScore(3d, "N"))))
+        }
+      ),
       suite("zInterStore")(
         testM("two non-empty sets") {
           for {


### PR DESCRIPTION
Closes #350

This PR implements ZINTER under two functions: 

1. `def zInter: ZIO[..., Chunk[M]]`
2. `def zInterWithScores: ZIO[..., Chunk[MemberScore[M]]]`

Similar to how `zRange` and `zRangeWithScores` were split due to different return types.

Also note that the test suites for each command are the same to `zInterStore`, with the difference being the return values are checked individually.