### PR TITLE
Implement keys API in test executor (#194)

### DIFF
--- a/redis/src/main/scala/zio/redis/RedisExecutor.scala
+++ b/redis/src/main/scala/zio/redis/RedisExecutor.scala
@@ -1,6 +1,7 @@
 package zio.redis
 
 import zio._
+import zio.clock.Clock
 import zio.logging._
 import zio.schema.codec.Codec
 
@@ -17,7 +18,7 @@ object RedisExecutor {
   lazy val local: ZLayer[Logging with Has[Codec], RedisError.IOError, RedisExecutor] =
     ZLayer.identity[Logging] ++ ByteStream.default ++ ZLayer.identity[Has[Codec]] >>> StreamedExecutor
 
-  lazy val test: URLayer[zio.random.Random, RedisExecutor] = TestExecutor.live
+  lazy val test: URLayer[zio.random.Random with Clock, RedisExecutor] = TestExecutor.live
 
   private[this] final case class Request(command: Chunk[RespValue.BulkString], promise: Promise[RedisError, RespValue])
 

--- a/redis/src/test/scala/zio/redis/ApiSpec.scala
+++ b/redis/src/test/scala/zio/redis/ApiSpec.scala
@@ -4,6 +4,7 @@ import zio.ZLayer
 import zio.clock.Clock
 import zio.logging.Logging
 import zio.test._
+import zio.test.environment._
 
 object ApiSpec
     extends ConnectionSpec
@@ -32,7 +33,9 @@ object ApiSpec
         hyperLogLogSuite,
         hashSuite,
         streamsSuite
-      ).provideCustomLayerShared((Logging.ignore ++ ZLayer.succeed(codec) >>> RedisExecutor.local.orDie) ++ Clock.live),
+      ).provideCustomLayerShared(
+        (Logging.ignore ++ ZLayer.succeed(codec) >>> RedisExecutor.local.orDie) ++ Clock.live
+      ),
       suite("Test Executor")(
         connectionSuite,
         keysSuite,
@@ -42,6 +45,6 @@ object ApiSpec
         hashSuite
       ).filterAnnotations(TestAnnotation.tagged)(t => !t.contains(TestExecutorUnsupportedTag))
         .get
-        .provideCustomLayerShared(RedisExecutor.test ++ Clock.live)
+        .provideSomeLayer[TestEnvironment](RedisExecutor.test)
     )
 }

--- a/redis/src/test/scala/zio/redis/ApiSpec.scala
+++ b/redis/src/test/scala/zio/redis/ApiSpec.scala
@@ -35,6 +35,7 @@ object ApiSpec
       ).provideCustomLayerShared((Logging.ignore ++ ZLayer.succeed(codec) >>> RedisExecutor.local.orDie) ++ Clock.live),
       suite("Test Executor")(
         connectionSuite,
+        keysSuite,
         setsSuite,
         hyperLogLogSuite,
         listSuite,


### PR DESCRIPTION
This draft PR implements test executors for keys (#194) in two parts. Please comment on the approach if you have any concerns/improvements:

### Key Management
All keys are tracked in `keys: TSet[String]`. Support for key-related commands are performed against this set. To modify an underlying data structure, Redis commands must use functions that also manage adding keys and expirations (e.g., `def putList = list.put(...) <* keys.put(...) <* expirations.delete(...)`).

### Expiration Management
We introduce the concept of time whenever a Redis command is executed. First, keys are mapped to its expiration Instant (i.e., *when* it expires) in `expirations: TMap[String, Instant]`. Mappings are added using EXPIRE, EXPIREAT, etc. Mappings are removed using PERSIST or any command that modifies an existing key.

When a command is executed, the current time is captured from `zio.clock.Clock`. All keys in `expirations` with an instant before the current time are purged. Finally, execute the Redis command as usual using put and delete functions.

#### Action items
Implement the rest of commands in the keys test suite. Also implement commands in other test suites that use expirations (e.g., PSETEX). Finally, figure out how to use `zio.test.environment.TestClock` for reliable testing of expirations.