### PR TITLE
Fix wrong type failures with set operations

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,12 +3,12 @@ version: "3.2"
 services:
   redis1:
     container_name: test_redis_1
-    image: redis:6.2-alpine
+    image: redis:6.2.5-alpine
     ports:
       - "6379:6379"
 
   redis2:
     container_name: test_redis_2
-    image: redis:6.2-alpine
+    image: redis:6.2.5-alpine
     ports:
       - "6380:6379"

--- a/redis/src/main/scala/zio/redis/Output.scala
+++ b/redis/src/main/scala/zio/redis/Output.scala
@@ -55,18 +55,39 @@ object Output {
       }
   }
 
+  final case class ZRandMemberOutput[+A](output: Output[A]) extends Output[Chunk[A]] {
+    protected def tryDecode(respValue: RespValue)(implicit codec: Codec): Chunk[A] =
+      respValue match {
+        case RespValue.NullBulkString => Chunk.empty
+        case RespValue.NullArray      => Chunk.empty
+        case RespValue.Array(values)  => values.map(output.tryDecode)
+        case other                    => throw ProtocolError(s"$other isn't an array")
+      }
+  }
+
   final case class ChunkTuple2Output[+A, +B](_1: Output[A], _2: Output[B]) extends Output[Chunk[(A, B)]] {
     protected def tryDecode(respValue: RespValue)(implicit codec: Codec): Chunk[(A, B)] =
       respValue match {
         case RespValue.NullArray =>
           Chunk.empty
-
         case RespValue.Array(values) if values.length % 2 == 0 =>
           Chunk.fromIterator(values.grouped(2).map(g => _1.tryDecode(g(0)) -> _2.tryDecode(g(1))))
-
         case array @ RespValue.Array(_) =>
           throw ProtocolError(s"$array doesn't have an even number of elements")
+        case other =>
+          throw ProtocolError(s"$other isn't an array")
+      }
+  }
 
+  final case class ZRandMemberTuple2Output[+A, +B](_1: Output[A], _2: Output[B]) extends Output[Chunk[(A, B)]] {
+    protected def tryDecode(respValue: RespValue)(implicit codec: Codec): Chunk[(A, B)] =
+      respValue match {
+        case RespValue.NullBulkString => Chunk.empty
+        case RespValue.NullArray      => Chunk.empty
+        case RespValue.Array(values) if values.length % 2 == 0 =>
+          Chunk.fromIterator(values.grouped(2).map(g => _1.tryDecode(g(0)) -> _2.tryDecode(g(1))))
+        case array @ RespValue.Array(_) =>
+          throw ProtocolError(s"$array doesn't have an even number of elements")
         case other =>
           throw ProtocolError(s"$other isn't an array")
       }

--- a/redis/src/main/scala/zio/redis/api/SortedSets.scala
+++ b/redis/src/main/scala/zio/redis/api/SortedSets.scala
@@ -874,11 +874,11 @@ trait SortedSets {
    *              The array's length is either count or the sorted set's cardinality (ZCARD), whichever is lower
    * @return Return an array of elements from the sorted set value stored at key.
    */
-  final def zRandMember[K: Schema, M: Schema](key: K, count: Long): ZIO[RedisExecutor, RedisError, Option[Chunk[M]]] = {
+  final def zRandMember[K: Schema, M: Schema](key: K, count: Long): ZIO[RedisExecutor, RedisError, Chunk[M]] = {
     val command = RedisCommand(
       ZRandMember,
       Tuple2(ArbitraryInput[K](), LongInput),
-      OptionalOutput(ChunkOutput(ArbitraryOutput[M]()))
+      ZRandMemberOutput(ArbitraryOutput[M]())
     )
     command.run((key, count))
   }
@@ -895,14 +895,12 @@ trait SortedSets {
   final def zRandMemberWithScores[K: Schema, M: Schema](
     key: K,
     count: Long
-  ): ZIO[RedisExecutor, RedisError, Option[Chunk[MemberScore[M]]]] = {
+  ): ZIO[RedisExecutor, RedisError, Chunk[MemberScore[M]]] = {
     val command = RedisCommand(
       ZRandMember,
       Tuple3(ArbitraryInput[K](), LongInput, ArbitraryInput[String]()),
-      OptionalOutput(
-        ChunkTuple2Output(ArbitraryOutput[M](), DoubleOutput)
-          .map(_.map { case (m, s) => MemberScore(s, m) })
-      )
+      ZRandMemberTuple2Output(ArbitraryOutput[M](), DoubleOutput)
+        .map(_.map { case (m, s) => MemberScore(s, m) })
     )
     command.run((key, count, WithScores.stringify))
   }

--- a/redis/src/test/scala/zio/redis/SetsSpec.scala
+++ b/redis/src/test/scala/zio/redis/SetsSpec.scala
@@ -246,14 +246,14 @@ trait SetsSpec extends BaseSpec {
             inter  <- sInter[String, String](first, second).either
           } yield assert(inter)(isLeft(isSubtype[WrongType](anything)))
         },
-        testM("empty with empty first set and second parameter is not set") {
+        testM("error when empty first set and second parameter is not set") {
           for {
             first  <- uuid
             second <- uuid
             value  <- uuid
             _      <- set(second, value)
-            inter  <- sInter[String, String](first, second)
-          } yield assert(inter)(isEmpty)
+            inter  <- sInter[String, String](first, second).either
+          } yield assert(inter)(isLeft(isSubtype[WrongType](anything)))
         },
         testM("error with non-empty first set and second parameter is not set") {
           for {
@@ -316,15 +316,15 @@ trait SetsSpec extends BaseSpec {
             card   <- sInterStore(dest, first, second).either
           } yield assert(card)(isLeft(isSubtype[WrongType](anything)))
         },
-        testM("empty with empty first set and second parameter is not set") {
+        testM("error when empty first set and second parameter is not set") {
           for {
             dest   <- uuid
             first  <- uuid
             second <- uuid
             value  <- uuid
             _      <- set(second, value)
-            card   <- sInterStore(dest, first, second)
-          } yield assert(card)(equalTo(0L))
+            card   <- sInterStore(dest, first, second).either
+          } yield assert(card)(isLeft(isSubtype[WrongType](anything)))
         },
         testM("error with non-empty first set and second parameter is not set") {
           for {

--- a/redis/src/test/scala/zio/redis/SortedSetsSpec.scala
+++ b/redis/src/test/scala/zio/redis/SortedSetsSpec.scala
@@ -1748,7 +1748,7 @@ trait SortedSetsSpec extends BaseSpec {
             notExists <- uuid
             _         <- zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
             ret       <- zRandMember[String, String](notExists, 1)
-          } yield assert(ret)(isNone)
+          } yield assert(ret)(isEmpty)
         },
         testM("get an element") {
           for {
@@ -1762,7 +1762,7 @@ trait SortedSetsSpec extends BaseSpec {
             first <- uuid
             _     <- zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
             ret   <- zRandMember[String, String](first, 2)
-          } yield assert(ret)(isSome) && assert(ret.get.size)(equalTo(2))
+          } yield assert(ret)(hasSize(equalTo(2)))
         }
       ),
       suite("zRandMemberWithScores")(
@@ -1772,14 +1772,14 @@ trait SortedSetsSpec extends BaseSpec {
             notExists <- uuid
             _         <- zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
             ret       <- zRandMemberWithScores[String, String](notExists, 1)
-          } yield assert(ret)(isNone)
+          } yield assert(ret)(isEmpty)
         },
         testM("get elements with count") {
           for {
             first <- uuid
             _     <- zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
             ret   <- zRandMemberWithScores[String, String](first, 2)
-          } yield assert(ret)(isSome) && assert(ret.get.size)(equalTo(2))
+          } yield assert(ret)(hasSize(equalTo(2)))
         }
       )
     )


### PR DESCRIPTION
This PR resolves #418.

**Summary:**
- Change zRandMember command output from Option[Chunk[]] to the Chunk[] in some cases,
- Update tests.