### PR TITLE
Add lists API benchmarks

### DIFF
--- a/benchmarks/src/main/scala/zio/redis/lists/BlMoveBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/lists/BlMoveBenchmarks.scala
@@ -1,0 +1,40 @@
+package zio.redis.lists
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import zio.ZIO
+import zio.duration._
+import zio.redis._
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 15)
+@Warmup(iterations = 15)
+@Fork(2)
+class BlMoveBenchmarks extends BenchmarkRuntime {
+
+  @Param(Array("500"))
+  var count: Int = _
+
+  private var items: List[String] = _
+
+  private val key = "test-list"
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    items = (0 to count).toList.map(_.toString)
+    zioUnsafeRun(rPush(key, items.head, items.tail: _*).unit)
+  }
+
+  @TearDown(Level.Trial)
+  def tearDown(): Unit =
+    zioUnsafeRun(del(key).unit)
+
+  @Benchmark
+  def zio(): Unit = zioUnsafeRun(
+    ZIO.foreach_(items)(_ => blMove[String, String, String](key, key, Side.Left, Side.Right, 1.second))
+  )
+}

--- a/benchmarks/src/main/scala/zio/redis/lists/BlPopBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/lists/BlPopBenchmarks.scala
@@ -1,0 +1,65 @@
+package zio.redis.lists
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import zio.ZIO
+import zio.duration._
+import zio.redis.{ BenchmarkRuntime, blPop, rPush }
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 15)
+@Warmup(iterations = 15)
+@Fork(2)
+class BlPopBenchmarks extends BenchmarkRuntime {
+  @Param(Array("500"))
+  var count: Int = _
+
+  private var items: List[String] = _
+
+  private val key = "test-list"
+
+  @Setup(Level.Invocation)
+  def setup(): Unit = {
+    items = (0 to count).toList.map(_.toString)
+    zioUnsafeRun(rPush(key, items.head, items.tail: _*).unit)
+  }
+
+  @Benchmark
+  def laserdisc(): Unit = {
+    import _root_.laserdisc.fs2._
+    import _root_.laserdisc.{ all => cmd, _ }
+    import cats.instances.list._
+    import cats.syntax.foldable._
+
+    unsafeRun[LaserDiscClient](c =>
+      items.traverse_(_ => c.send(cmd.blocking.blpop[String](Key.unsafeFrom(key), PosInt.unsafeFrom(1))))
+    )
+  }
+
+  @Benchmark
+  def rediculous(): Unit = {
+    import cats.implicits._
+    import io.chrisdavenport.rediculous._
+
+    unsafeRun[RediculousClient](c => items.traverse_(_ => RedisCommands.blpop[RedisIO](List(key), 1).run(c)))
+  }
+
+  @Benchmark
+  def redis4cats(): Unit = {
+    import cats.data._
+    import cats.instances.list._
+    import cats.syntax.foldable._
+    import scala.concurrent.duration._
+
+    unsafeRun[Redis4CatsClient[String]](c =>
+      items.traverse_(_ => c.blPop(Duration(1, TimeUnit.SECONDS), NonEmptyList.one(key)))
+    )
+  }
+
+  @Benchmark
+  def zio(): Unit = zioUnsafeRun(ZIO.foreach_(items)(_ => blPop[String, String](key)(1.second)))
+}

--- a/benchmarks/src/main/scala/zio/redis/lists/BrPopBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/lists/BrPopBenchmarks.scala
@@ -1,0 +1,65 @@
+package zio.redis.lists
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import zio.ZIO
+import zio.duration._
+import zio.redis.{ BenchmarkRuntime, brPop, rPush }
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 15)
+@Warmup(iterations = 15)
+@Fork(2)
+class BrPopBenchmarks extends BenchmarkRuntime {
+  @Param(Array("500"))
+  var count: Int = _
+
+  private var items: List[String] = _
+
+  private val key = "test-list"
+
+  @Setup(Level.Invocation)
+  def setup(): Unit = {
+    items = (0 to count).toList.map(_.toString)
+    zioUnsafeRun(rPush(key, items.head, items.tail: _*).unit)
+  }
+
+  @Benchmark
+  def laserdisc(): Unit = {
+    import _root_.laserdisc.fs2._
+    import _root_.laserdisc.{ all => cmd, _ }
+    import cats.instances.list._
+    import cats.syntax.foldable._
+
+    unsafeRun[LaserDiscClient](c =>
+      items.traverse_(_ => c.send(cmd.blocking.brpop[String](Key.unsafeFrom(key), PosInt.unsafeFrom(1))))
+    )
+  }
+
+  @Benchmark
+  def rediculous(): Unit = {
+    import cats.implicits._
+    import io.chrisdavenport.rediculous._
+
+    unsafeRun[RediculousClient](c => items.traverse_(_ => RedisCommands.brpop[RedisIO](List(key), 1).run(c)))
+  }
+
+  @Benchmark
+  def redis4cats(): Unit = {
+    import cats.data._
+    import cats.instances.list._
+    import cats.syntax.foldable._
+    import scala.concurrent.duration._
+
+    unsafeRun[Redis4CatsClient[String]](c =>
+      items.traverse_(_ => c.brPop(Duration(1, TimeUnit.SECONDS), NonEmptyList.one(key)))
+    )
+  }
+
+  @Benchmark
+  def zio(): Unit = zioUnsafeRun(ZIO.foreach_(items)(_ => brPop[String, String](key)(1.second)))
+}

--- a/benchmarks/src/main/scala/zio/redis/lists/BrPopLPushBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/lists/BrPopLPushBenchmarks.scala
@@ -1,0 +1,74 @@
+package zio.redis.lists
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import zio.ZIO
+import zio.duration._
+import zio.redis.{ BenchmarkRuntime, brPopLPush, del, rPush }
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 15)
+@Warmup(iterations = 15)
+@Fork(2)
+class BrPopLPushBenchmarks extends BenchmarkRuntime {
+  @Param(Array("500"))
+  var count: Int = _
+
+  private var items: List[String] = _
+
+  private val key = "test-list"
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    items = (0 to count).toList.map(_.toString)
+    zioUnsafeRun(rPush(key, items.head, items.tail: _*).unit)
+  }
+
+  @TearDown(Level.Trial)
+  def tearDown(): Unit =
+    zioUnsafeRun(del(key).unit)
+
+  @Benchmark
+  def laserdisc(): Unit = {
+    import _root_.laserdisc.fs2._
+    import _root_.laserdisc.{ all => cmd, _ }
+    import cats.instances.list._
+    import cats.syntax.foldable._
+
+    unsafeRun[LaserDiscClient](c =>
+      items.traverse_(_ =>
+        c.send(
+          cmd.blocking.brpoplpush[String](Key.unsafeFrom(key), Key.unsafeFrom(key), PosInt.unsafeFrom(1))
+        )
+      )
+    )
+  }
+
+  @Benchmark
+  def rediculous(): Unit = {
+    import cats.implicits._
+    import io.chrisdavenport.rediculous._
+
+    unsafeRun[RediculousClient](c => items.traverse_(_ => RedisCommands.brpoplpush[RedisIO](key, key, 1).run(c)))
+  }
+
+  @Benchmark
+  def redis4cats(): Unit = {
+    import cats.instances.list._
+    import cats.syntax.foldable._
+    import scala.concurrent.duration._
+
+    unsafeRun[Redis4CatsClient[String]](c =>
+      items.traverse_(_ => c.brPopLPush(Duration(1, TimeUnit.SECONDS), key, key))
+    )
+  }
+
+  @Benchmark
+  def zio(): Unit = zioUnsafeRun(
+    ZIO.foreach_(items)(_ => brPopLPush[String, String, String](key, key, 1.second))
+  )
+}

--- a/benchmarks/src/main/scala/zio/redis/lists/LIndexBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/lists/LIndexBenchmarks.scala
@@ -1,0 +1,64 @@
+package zio.redis.lists
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import zio.ZIO
+import zio.redis.{ BenchmarkRuntime, del, lIndex, rPush }
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 15)
+@Warmup(iterations = 15)
+@Fork(2)
+class LIndexBenchmarks extends BenchmarkRuntime {
+  @Param(Array("500"))
+  var count: Int = _
+
+  private var items: List[Int] = _
+
+  private val key = "test-list"
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    items = (0 to count).toList
+    zioUnsafeRun(rPush(key, items.head, items.tail: _*).unit)
+  }
+
+  @TearDown(Level.Trial)
+  def tearDown(): Unit =
+    zioUnsafeRun(del(key).unit)
+
+  @Benchmark
+  def laserdisc(): Unit = {
+    import _root_.laserdisc.fs2._
+    import _root_.laserdisc.{ all => cmd, _ }
+    import cats.instances.list._
+    import cats.syntax.foldable._
+
+    unsafeRun[LaserDiscClient](c =>
+      items.traverse_(i => c.send(cmd.lindex[String](Key.unsafeFrom(key), Index.unsafeFrom(i.toLong))))
+    )
+  }
+
+  @Benchmark
+  def rediculous(): Unit = {
+    import cats.implicits._
+    import io.chrisdavenport.rediculous._
+
+    unsafeRun[RediculousClient](c => items.traverse_(i => RedisCommands.lindex[RedisIO](key, i).run(c)))
+  }
+
+  @Benchmark
+  def redis4cats(): Unit = {
+    import cats.instances.list._
+    import cats.syntax.foldable._
+
+    unsafeRun[Redis4CatsClient[String]](c => items.traverse_(i => c.lIndex(key, i.toLong)))
+  }
+
+  @Benchmark
+  def zio(): Unit = zioUnsafeRun(ZIO.foreach_(items)(i => lIndex[String, String](key, i.toLong)))
+}

--- a/benchmarks/src/main/scala/zio/redis/lists/LInsertBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/lists/LInsertBenchmarks.scala
@@ -1,0 +1,65 @@
+package zio.redis.lists
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import zio.ZIO
+import zio.redis._
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 15)
+@Warmup(iterations = 15)
+@Fork(2)
+class LInsertBenchmarks extends BenchmarkRuntime {
+  @Param(Array("500"))
+  var count: Int = _
+
+  private var items: List[String] = _
+
+  private val key = "test-list"
+
+  @Setup(Level.Invocation)
+  def setup(): Unit = {
+    items = (0 to count).toList.map(_.toString)
+    zioUnsafeRun(rPush(key, items.head, items.tail: _*).unit)
+  }
+
+  @TearDown(Level.Invocation)
+  def tearDown(): Unit =
+    zioUnsafeRun(del(key).unit)
+
+  @Benchmark
+  def laserdisc(): Unit = {
+    import _root_.laserdisc.fs2._
+    import _root_.laserdisc.{ all => cmd, _ }
+    import _root_.laserdisc.lists.listtypes._
+    import cats.instances.list._
+    import cats.syntax.foldable._
+
+    unsafeRun[LaserDiscClient](c =>
+      items.traverse_(i => c.send(cmd.linsert[String](Key.unsafeFrom(key), ListPosition.before, i, i)))
+    )
+  }
+
+  @Benchmark
+  def rediculous(): Unit = {
+    import cats.implicits._
+    import io.chrisdavenport.rediculous._
+
+    unsafeRun[RediculousClient](c => items.traverse_(i => RedisCommands.linsertbefore[RedisIO](key, i, i).run(c)))
+  }
+
+  @Benchmark
+  def redis4cats(): Unit = {
+    import cats.instances.list._
+    import cats.syntax.foldable._
+
+    unsafeRun[Redis4CatsClient[String]](c => items.traverse_(i => c.lInsertBefore(key, i, i)))
+  }
+
+  @Benchmark
+  def zio(): Unit = zioUnsafeRun(ZIO.foreach_(items)(i => lInsert[String, String](key, Position.Before, i, i)))
+}

--- a/benchmarks/src/main/scala/zio/redis/lists/LLenBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/lists/LLenBenchmarks.scala
@@ -1,0 +1,56 @@
+package zio.redis.lists
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import zio.ZIO
+import zio.redis.{ BenchmarkRuntime, lLen }
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 15)
+@Warmup(iterations = 15)
+@Fork(2)
+class LLenBenchmarks extends BenchmarkRuntime {
+  @Param(Array("500"))
+  var count: Int = _
+
+  private var items: List[String] = _
+
+  private val key = "test-list"
+
+  @Setup(Level.Trial)
+  def setup(): Unit =
+    items = (0 to count).toList.map(_.toString)
+
+  @Benchmark
+  def laserdisc(): Unit = {
+    import _root_.laserdisc.fs2._
+    import _root_.laserdisc.{ all => cmd, _ }
+    import cats.instances.list._
+    import cats.syntax.foldable._
+
+    unsafeRun[LaserDiscClient](c => items.traverse_(_ => c.send(cmd.llen(Key.unsafeFrom(key)))))
+  }
+
+  @Benchmark
+  def rediculous(): Unit = {
+    import cats.implicits._
+    import io.chrisdavenport.rediculous._
+
+    unsafeRun[RediculousClient](c => items.traverse_(_ => RedisCommands.llen[RedisIO](key).run(c)))
+  }
+
+  @Benchmark
+  def redis4cats(): Unit = {
+    import cats.instances.list._
+    import cats.syntax.foldable._
+
+    unsafeRun[Redis4CatsClient[String]](c => items.traverse_(_ => c.lLen(key)))
+  }
+
+  @Benchmark
+  def zio(): Unit = zioUnsafeRun(ZIO.foreach_(items)(_ => lLen[String](key)))
+}

--- a/benchmarks/src/main/scala/zio/redis/lists/LMoveBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/lists/LMoveBenchmarks.scala
@@ -1,0 +1,38 @@
+package zio.redis.lists
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import zio.ZIO
+import zio.redis._
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 15)
+@Warmup(iterations = 15)
+@Fork(2)
+class LMoveBenchmarks extends BenchmarkRuntime {
+  @Param(Array("500"))
+  var count: Int = _
+
+  private var items: List[String] = _
+
+  private val key = "test-list"
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    items = (0 to count).toList.map(_.toString)
+    zioUnsafeRun(rPush(key, items.head, items.tail: _*).unit)
+  }
+
+  @TearDown(Level.Trial)
+  def tearDown(): Unit =
+    zioUnsafeRun(del(key).unit)
+
+  @Benchmark
+  def zio(): Unit = zioUnsafeRun(
+    ZIO.foreach_(items)(_ => lMove[String, String, String](key, key, Side.Left, Side.Right))
+  )
+}

--- a/benchmarks/src/main/scala/zio/redis/lists/LPopBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/lists/LPopBenchmarks.scala
@@ -1,0 +1,58 @@
+package zio.redis.lists
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import zio.ZIO
+import zio.redis.{ BenchmarkRuntime, lPop, rPush }
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 15)
+@Warmup(iterations = 15)
+@Fork(2)
+class LPopBenchmarks extends BenchmarkRuntime {
+  @Param(Array("500"))
+  var count: Int = _
+
+  private var items: List[String] = _
+
+  private val key = "test-list"
+
+  @Setup(Level.Invocation)
+  def setup(): Unit = {
+    items = (0 to count).toList.map(_.toString)
+    zioUnsafeRun(rPush(key, items.head, items.tail: _*).unit)
+  }
+
+  @Benchmark
+  def laserdisc(): Unit = {
+    import _root_.laserdisc.fs2._
+    import _root_.laserdisc.{ all => cmd, _ }
+    import cats.instances.list._
+    import cats.syntax.foldable._
+
+    unsafeRun[LaserDiscClient](c => items.traverse_(_ => c.send(cmd.lpop[String](Key.unsafeFrom(key)))))
+  }
+
+  @Benchmark
+  def rediculous(): Unit = {
+    import cats.implicits._
+    import io.chrisdavenport.rediculous._
+
+    unsafeRun[RediculousClient](c => items.traverse_(_ => RedisCommands.lpop[RedisIO](key).run(c)))
+  }
+
+  @Benchmark
+  def redis4cats(): Unit = {
+    import cats.instances.list._
+    import cats.syntax.foldable._
+
+    unsafeRun[Redis4CatsClient[String]](c => items.traverse_(_ => c.lPop(key)))
+  }
+
+  @Benchmark
+  def zio(): Unit = zioUnsafeRun(ZIO.foreach_(items)(_ => lPop[String, String](key)))
+}

--- a/benchmarks/src/main/scala/zio/redis/lists/LPosBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/lists/LPosBenchmarks.scala
@@ -1,0 +1,36 @@
+package zio.redis.lists
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import zio.ZIO
+import zio.redis.{ BenchmarkRuntime, del, lPos, rPush }
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 15)
+@Warmup(iterations = 15)
+@Fork(2)
+class LPosBenchmarks extends BenchmarkRuntime {
+  @Param(Array("500"))
+  var count: Int = _
+
+  private var items: List[String] = _
+
+  private val key = "test-list"
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    items = (0 to count).toList.map(_.toString)
+    zioUnsafeRun(rPush(key, items.head, items.tail: _*).unit)
+  }
+
+  @TearDown(Level.Trial)
+  def tearDown(): Unit =
+    zioUnsafeRun(del(key).unit)
+
+  @Benchmark
+  def zio(): Unit = zioUnsafeRun(ZIO.foreach_(items)(i => lPos[String, String](key, i)))
+}

--- a/benchmarks/src/main/scala/zio/redis/lists/LPosCountBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/lists/LPosCountBenchmarks.scala
@@ -1,0 +1,36 @@
+package zio.redis.lists
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import zio.ZIO
+import zio.redis._
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 15)
+@Warmup(iterations = 15)
+@Fork(2)
+class LPosCountBenchmarks extends BenchmarkRuntime {
+  @Param(Array("500"))
+  var count: Int = _
+
+  private var items: List[String] = _
+
+  private val key = "test-list"
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    items = (0 to count).toList.map(_.toString)
+    zioUnsafeRun(rPush(key, items.head, items.tail: _*).unit)
+  }
+
+  @TearDown(Level.Trial)
+  def tearDown(): Unit =
+    zioUnsafeRun(del(key).unit)
+
+  @Benchmark
+  def zio(): Unit = zioUnsafeRun(ZIO.foreach_(items)(i => lPosCount[String, String](key, i, Count(0L))))
+}

--- a/benchmarks/src/main/scala/zio/redis/lists/LPushBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/lists/LPushBenchmarks.scala
@@ -1,0 +1,60 @@
+package zio.redis.lists
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import zio.ZIO
+import zio.redis.{ BenchmarkRuntime, del, lPush }
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 15)
+@Warmup(iterations = 15)
+@Fork(2)
+class LPushBenchmarks extends BenchmarkRuntime {
+  @Param(Array("500"))
+  var count: Int = _
+
+  private var items: List[String] = _
+
+  private val key = "test-list"
+
+  @Setup(Level.Trial)
+  def setup(): Unit =
+    items = (0 to count).toList.map(_.toString)
+
+  @TearDown(Level.Invocation)
+  def tearDown(): Unit =
+    zioUnsafeRun(del(key).unit)
+
+  @Benchmark
+  def laserdisc(): Unit = {
+    import _root_.laserdisc.fs2._
+    import _root_.laserdisc.{ all => cmd, _ }
+    import cats.instances.list._
+    import cats.syntax.foldable._
+
+    unsafeRun[LaserDiscClient](c => items.traverse_(i => c.send(cmd.lpush[String](Key.unsafeFrom(key), i))))
+  }
+
+  @Benchmark
+  def rediculous(): Unit = {
+    import cats.implicits._
+    import io.chrisdavenport.rediculous._
+
+    unsafeRun[RediculousClient](c => items.traverse_(i => RedisCommands.lpush[RedisIO](key, List(i)).run(c)))
+  }
+
+  @Benchmark
+  def redis4cats(): Unit = {
+    import cats.instances.list._
+    import cats.syntax.foldable._
+
+    unsafeRun[Redis4CatsClient[String]](c => items.traverse_(i => c.lPush(key, i)))
+  }
+
+  @Benchmark
+  def zio(): Unit = zioUnsafeRun(ZIO.foreach_(items)(i => lPush[String, String](key, i)))
+}

--- a/benchmarks/src/main/scala/zio/redis/lists/LPushXBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/lists/LPushXBenchmarks.scala
@@ -1,0 +1,62 @@
+package zio.redis.lists
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import zio.ZIO
+import zio.redis.{ BenchmarkRuntime, del, lPushX, rPush }
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 15)
+@Warmup(iterations = 15)
+@Fork(2)
+class LPushXBenchmarks extends BenchmarkRuntime {
+  @Param(Array("500"))
+  var count: Int = _
+
+  private var items: List[String] = _
+
+  private val key = "test-list"
+
+  @Setup(Level.Invocation)
+  def setup(): Unit = {
+    items = (0 to count).toList.map(_.toString)
+    zioUnsafeRun(rPush(key, items.head).unit)
+  }
+
+  @TearDown(Level.Invocation)
+  def tearDown(): Unit =
+    zioUnsafeRun(del(key).unit)
+
+  @Benchmark
+  def laserdisc(): Unit = {
+    import _root_.laserdisc.fs2._
+    import _root_.laserdisc.{ all => cmd, _ }
+    import cats.instances.list._
+    import cats.syntax.foldable._
+
+    unsafeRun[LaserDiscClient](c => items.traverse_(i => c.send(cmd.lpushx[String](Key.unsafeFrom(key), i))))
+  }
+
+  @Benchmark
+  def rediculous(): Unit = {
+    import cats.implicits._
+    import io.chrisdavenport.rediculous._
+
+    unsafeRun[RediculousClient](c => items.traverse_(i => RedisCommands.lpushx[RedisIO](key, i).run(c)))
+  }
+
+  @Benchmark
+  def redis4cats(): Unit = {
+    import cats.instances.list._
+    import cats.syntax.foldable._
+
+    unsafeRun[Redis4CatsClient[String]](c => items.traverse_(i => c.lPushX(key, i)))
+  }
+
+  @Benchmark
+  def zio(): Unit = zioUnsafeRun(ZIO.foreach_(items)(i => lPushX[String, String](key, i)))
+}

--- a/benchmarks/src/main/scala/zio/redis/lists/LRangeBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/lists/LRangeBenchmarks.scala
@@ -1,0 +1,64 @@
+package zio.redis.lists
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import zio.ZIO
+import zio.redis.{ BenchmarkRuntime, del, lRange, rPush }
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 15)
+@Warmup(iterations = 15)
+@Fork(2)
+class LRangeBenchmarks extends BenchmarkRuntime {
+  @Param(Array("400"))
+  var count: Int = _
+
+  private var items: List[Int] = _
+
+  private val key = "test-list"
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    items = (0 to count).toList
+    zioUnsafeRun(rPush(key, items.head, items.tail: _*).unit)
+  }
+
+  @TearDown(Level.Trial)
+  def tearDown(): Unit =
+    zioUnsafeRun(del(key).unit)
+
+  @Benchmark
+  def laserdisc(): Unit = {
+    import _root_.laserdisc.fs2._
+    import _root_.laserdisc.{ all => cmd, _ }
+    import cats.instances.list._
+    import cats.syntax.foldable._
+
+    unsafeRun[LaserDiscClient](c =>
+      items.traverse_(i => c.send(cmd.lrange[String](Key.unsafeFrom(key), Index(0L), Index.unsafeFrom(i.toLong))))
+    )
+  }
+
+  @Benchmark
+  def rediculous(): Unit = {
+    import cats.implicits._
+    import io.chrisdavenport.rediculous._
+
+    unsafeRun[RediculousClient](c => items.traverse_(i => RedisCommands.lrange[RedisIO](key, 0L, i.toLong).run(c)))
+  }
+
+  @Benchmark
+  def redis4cats(): Unit = {
+    import cats.instances.list._
+    import cats.syntax.foldable._
+
+    unsafeRun[Redis4CatsClient[String]](c => items.traverse_(i => c.lRange(key, 0L, i.toLong)))
+  }
+
+  @Benchmark
+  def zio(): Unit = zioUnsafeRun(ZIO.foreach_(items)(i => lRange[String, String](key, 0 to i)))
+}

--- a/benchmarks/src/main/scala/zio/redis/lists/LRemBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/lists/LRemBenchmarks.scala
@@ -1,0 +1,58 @@
+package zio.redis.lists
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import zio.ZIO
+import zio.redis.{ BenchmarkRuntime, lRem, rPush }
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 15)
+@Warmup(iterations = 15)
+@Fork(2)
+class LRemBenchmarks extends BenchmarkRuntime {
+  @Param(Array("500"))
+  var count: Int = _
+
+  private var items: List[String] = _
+
+  private val key = "test-list"
+
+  @Setup(Level.Invocation)
+  def setup(): Unit = {
+    items = (0 to count).toList.map(_.toString)
+    zioUnsafeRun(rPush(key, items.head, items.tail: _*).unit)
+  }
+
+  @Benchmark
+  def laserdisc(): Unit = {
+    import _root_.laserdisc.fs2._
+    import _root_.laserdisc.{ all => cmd, _ }
+    import cats.instances.list._
+    import cats.syntax.foldable._
+
+    unsafeRun[LaserDiscClient](c => items.traverse_(i => c.send(cmd.lrem[String](Key.unsafeFrom(key), Index(0), i))))
+  }
+
+  @Benchmark
+  def rediculous(): Unit = {
+    import cats.implicits._
+    import io.chrisdavenport.rediculous._
+
+    unsafeRun[RediculousClient](c => items.traverse_(i => RedisCommands.lrem[RedisIO](key, 0, i).run(c)))
+  }
+
+  @Benchmark
+  def redis4cats(): Unit = {
+    import cats.instances.list._
+    import cats.syntax.foldable._
+
+    unsafeRun[Redis4CatsClient[String]](c => items.traverse_(i => c.lRem(key, 0, i)))
+  }
+
+  @Benchmark
+  def zio(): Unit = zioUnsafeRun(ZIO.foreach_(items)(i => lRem[String](key, 0, i)))
+}

--- a/benchmarks/src/main/scala/zio/redis/lists/LSetBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/lists/LSetBenchmarks.scala
@@ -1,0 +1,64 @@
+package zio.redis.lists
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import zio.ZIO
+import zio.redis.{ BenchmarkRuntime, del, lSet, rPush }
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 15)
+@Warmup(iterations = 15)
+@Fork(2)
+class LSetBenchmarks extends BenchmarkRuntime {
+  @Param(Array("500"))
+  var count: Int = _
+
+  private var items: List[Long] = _
+
+  private val key = "test-list"
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    items = (0 to count).toList.map(_.toLong)
+    zioUnsafeRun(rPush(key, items.head, items.tail: _*).unit)
+  }
+
+  @TearDown(Level.Trial)
+  def tearDown(): Unit =
+    zioUnsafeRun(del(key).unit)
+
+  @Benchmark
+  def laserdisc(): Unit = {
+    import _root_.laserdisc.fs2._
+    import _root_.laserdisc.{ all => cmd, _ }
+    import cats.instances.list._
+    import cats.syntax.foldable._
+
+    unsafeRun[LaserDiscClient](c =>
+      items.traverse_(i => c.send(cmd.lset[String](Key.unsafeFrom(key), Index.unsafeFrom(i), i.toString)))
+    )
+  }
+
+  @Benchmark
+  def rediculous(): Unit = {
+    import cats.implicits._
+    import io.chrisdavenport.rediculous._
+
+    unsafeRun[RediculousClient](c => items.traverse_(i => RedisCommands.lset[RedisIO](key, i, i.toString).run(c)))
+  }
+
+  @Benchmark
+  def redis4cats(): Unit = {
+    import cats.instances.list._
+    import cats.syntax.foldable._
+
+    unsafeRun[Redis4CatsClient[String]](c => items.traverse_(i => c.lSet(key, i, i.toString)))
+  }
+
+  @Benchmark
+  def zio(): Unit = zioUnsafeRun(ZIO.foreach_(items)(i => lSet[String, String](key, i, i.toString)))
+}

--- a/benchmarks/src/main/scala/zio/redis/lists/LTrimBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/lists/LTrimBenchmarks.scala
@@ -1,0 +1,60 @@
+package zio.redis.lists
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import zio.ZIO
+import zio.redis.{ BenchmarkRuntime, lTrim, rPush }
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 15)
+@Warmup(iterations = 15)
+@Fork(2)
+class LTrimBenchmarks extends BenchmarkRuntime {
+  @Param(Array("500"))
+  var count: Int = _
+
+  private var items: List[Int] = _
+
+  private val key = "test-list"
+
+  @Setup(Level.Invocation)
+  def setup(): Unit = {
+    items = (count to 0 by -1).toList
+    zioUnsafeRun(rPush(key, items.head, items.tail: _*).unit)
+  }
+
+  @Benchmark
+  def laserdisc(): Unit = {
+    import _root_.laserdisc.fs2._
+    import _root_.laserdisc.{ all => cmd, _ }
+    import cats.instances.list._
+    import cats.syntax.foldable._
+
+    unsafeRun[LaserDiscClient](c =>
+      items.traverse_(i => c.send(cmd.ltrim(Key.unsafeFrom(key), Index(1L), Index.unsafeFrom(i.toLong))))
+    )
+  }
+
+  @Benchmark
+  def rediculous(): Unit = {
+    import cats.implicits._
+    import io.chrisdavenport.rediculous._
+
+    unsafeRun[RediculousClient](c => items.traverse_(i => RedisCommands.ltrim[RedisIO](key, 1L, i.toLong).run(c)))
+  }
+
+  @Benchmark
+  def redis4cats(): Unit = {
+    import cats.instances.list._
+    import cats.syntax.foldable._
+
+    unsafeRun[Redis4CatsClient[String]](c => items.traverse_(i => c.lTrim(key, 1L, i.toLong)))
+  }
+
+  @Benchmark
+  def zio(): Unit = zioUnsafeRun(ZIO.foreach_(items)(i => lTrim[String](key, 1 to i)))
+}

--- a/benchmarks/src/main/scala/zio/redis/lists/RPopBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/lists/RPopBenchmarks.scala
@@ -1,0 +1,58 @@
+package zio.redis.lists
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import zio.ZIO
+import zio.redis.{ BenchmarkRuntime, rPop, rPush }
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 15)
+@Warmup(iterations = 15)
+@Fork(2)
+class RPopBenchmarks extends BenchmarkRuntime {
+  @Param(Array("500"))
+  var count: Int = _
+
+  private var items: List[String] = _
+
+  private val key = "test-list"
+
+  @Setup(Level.Invocation)
+  def setup(): Unit = {
+    items = (0 to count).toList.map(_.toString)
+    zioUnsafeRun(rPush(key, items.head, items.tail: _*).unit)
+  }
+
+  @Benchmark
+  def laserdisc(): Unit = {
+    import _root_.laserdisc.fs2._
+    import _root_.laserdisc.{ all => cmd, _ }
+    import cats.instances.list._
+    import cats.syntax.foldable._
+
+    unsafeRun[LaserDiscClient](c => items.traverse_(_ => c.send(cmd.rpop[String](Key.unsafeFrom(key)))))
+  }
+
+  @Benchmark
+  def rediculous(): Unit = {
+    import cats.implicits._
+    import io.chrisdavenport.rediculous._
+
+    unsafeRun[RediculousClient](c => items.traverse_(_ => RedisCommands.rpop[RedisIO](key).run(c)))
+  }
+
+  @Benchmark
+  def redis4cats(): Unit = {
+    import cats.instances.list._
+    import cats.syntax.foldable._
+
+    unsafeRun[Redis4CatsClient[String]](c => items.traverse_(_ => c.rPop(key)))
+  }
+
+  @Benchmark
+  def zio(): Unit = zioUnsafeRun(ZIO.foreach_(items)(_ => rPop[String, String](key)))
+}

--- a/benchmarks/src/main/scala/zio/redis/lists/RPopLPushBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/lists/RPopLPushBenchmarks.scala
@@ -1,0 +1,66 @@
+package zio.redis.lists
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import zio.ZIO
+import zio.redis.{ BenchmarkRuntime, del, rPopLPush, rPush }
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 15)
+@Warmup(iterations = 15)
+@Fork(2)
+class RPopLPushBenchmarks extends BenchmarkRuntime {
+  @Param(Array("500"))
+  var count: Int = _
+
+  private var items: List[String] = _
+
+  private val key = "test-list"
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    items = (0 to count).toList.map(_.toString)
+    zioUnsafeRun(rPush(key, items.head, items.tail: _*).unit)
+  }
+
+  @TearDown(Level.Trial)
+  def tearDown(): Unit =
+    zioUnsafeRun(del(key).unit)
+
+  @Benchmark
+  def laserdisc(): Unit = {
+    import _root_.laserdisc.fs2._
+    import _root_.laserdisc.{ all => cmd, _ }
+    import cats.instances.list._
+    import cats.syntax.foldable._
+
+    unsafeRun[LaserDiscClient](c =>
+      items.traverse_(_ => c.send(cmd.rpoplpush[String](Key.unsafeFrom(key), Key.unsafeFrom(key))))
+    )
+  }
+
+  @Benchmark
+  def rediculous(): Unit = {
+    import cats.implicits._
+    import io.chrisdavenport.rediculous._
+
+    unsafeRun[RediculousClient](c => items.traverse_(_ => RedisCommands.rpoplpush[RedisIO](key, key).run(c)))
+  }
+
+  @Benchmark
+  def redis4cats(): Unit = {
+    import cats.instances.list._
+    import cats.syntax.foldable._
+
+    unsafeRun[Redis4CatsClient[String]](c => items.traverse_(_ => c.rPopLPush(key, key)))
+  }
+
+  @Benchmark
+  def zio(): Unit = zioUnsafeRun(
+    ZIO.foreach_(items)(_ => rPopLPush[String, String, String](key, key))
+  )
+}

--- a/benchmarks/src/main/scala/zio/redis/lists/RPushBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/lists/RPushBenchmarks.scala
@@ -1,0 +1,60 @@
+package zio.redis.lists
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import zio.ZIO
+import zio.redis.{ BenchmarkRuntime, del, rPush }
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 15)
+@Warmup(iterations = 15)
+@Fork(2)
+class RPushBenchmarks extends BenchmarkRuntime {
+  @Param(Array("500"))
+  var count: Int = _
+
+  private var items: List[String] = _
+
+  private val key = "test-list"
+
+  @Setup(Level.Trial)
+  def setup(): Unit =
+    items = (0 to count).toList.map(_.toString)
+
+  @TearDown(Level.Invocation)
+  def tearDown(): Unit =
+    zioUnsafeRun(del(key).unit)
+
+  @Benchmark
+  def laserdisc(): Unit = {
+    import _root_.laserdisc.fs2._
+    import _root_.laserdisc.{ all => cmd, _ }
+    import cats.instances.list._
+    import cats.syntax.foldable._
+
+    unsafeRun[LaserDiscClient](c => items.traverse_(i => c.send(cmd.rpush[String](Key.unsafeFrom(key), i))))
+  }
+
+  @Benchmark
+  def rediculous(): Unit = {
+    import cats.implicits._
+    import io.chrisdavenport.rediculous._
+
+    unsafeRun[RediculousClient](c => items.traverse_(i => RedisCommands.rpush[RedisIO](key, List(i)).run(c)))
+  }
+
+  @Benchmark
+  def redis4cats(): Unit = {
+    import cats.instances.list._
+    import cats.syntax.foldable._
+
+    unsafeRun[Redis4CatsClient[String]](c => items.traverse_(i => c.rPush(key, i)))
+  }
+
+  @Benchmark
+  def zio(): Unit = zioUnsafeRun(ZIO.foreach_(items)(i => rPush[String, String](key, i)))
+}

--- a/benchmarks/src/main/scala/zio/redis/lists/RPushXBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/lists/RPushXBenchmarks.scala
@@ -1,0 +1,62 @@
+package zio.redis.lists
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import zio.ZIO
+import zio.redis.{ BenchmarkRuntime, del, rPush, rPushX }
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 15)
+@Warmup(iterations = 15)
+@Fork(2)
+class RPushXBenchmarks extends BenchmarkRuntime {
+  @Param(Array("500"))
+  var count: Int = _
+
+  private var items: List[String] = _
+
+  private val key = "test-list"
+
+  @Setup(Level.Invocation)
+  def setup(): Unit = {
+    items = (0 to count).toList.map(_.toString)
+    zioUnsafeRun(rPush(key, items.head).unit)
+  }
+
+  @TearDown(Level.Invocation)
+  def tearDown(): Unit =
+    zioUnsafeRun(del(key).unit)
+
+  @Benchmark
+  def laserdisc(): Unit = {
+    import _root_.laserdisc.fs2._
+    import _root_.laserdisc.{ all => cmd, _ }
+    import cats.instances.list._
+    import cats.syntax.foldable._
+
+    unsafeRun[LaserDiscClient](c => items.traverse_(i => c.send(cmd.rpushx[String](Key.unsafeFrom(key), i))))
+  }
+
+  @Benchmark
+  def rediculous(): Unit = {
+    import cats.implicits._
+    import io.chrisdavenport.rediculous._
+
+    unsafeRun[RediculousClient](c => items.traverse_(i => RedisCommands.rpushx[RedisIO](key, i).run(c)))
+  }
+
+  @Benchmark
+  def redis4cats(): Unit = {
+    import cats.instances.list._
+    import cats.syntax.foldable._
+
+    unsafeRun[Redis4CatsClient[String]](c => items.traverse_(i => c.rPushX(key, i)))
+  }
+
+  @Benchmark
+  def zio(): Unit = zioUnsafeRun(ZIO.foreach_(items)(i => rPushX[String, String](key, i)))
+}


### PR DESCRIPTION
Closes #164

CPU
`Intel Celeron CPU N3350 1.10 GHz`

BlMove
```
Benchmark             (count)   Mode  Cnt  Score   Error  Units
BlMoveBenchmarks.zio      500  thrpt   30  1.865 ± 0.040  ops/s
```

BlPop
```
Benchmark                   (count)   Mode  Cnt  Score   Error  Units
BlPopBenchmarks.laserdisc       500  thrpt   30  1.060 ± 0.013  ops/s
BlPopBenchmarks.rediculous      500  thrpt   30  0.896 ± 0.009  ops/s
BlPopBenchmarks.redis4cats      500  thrpt   30  2.054 ± 0.062  ops/s
BlPopBenchmarks.zio             500  thrpt   30  1.825 ± 0.038  ops/s
```

BrPop
```
Benchmark                   (count)   Mode  Cnt  Score   Error  Units
BrPopBenchmarks.laserdisc       500  thrpt   30  1.065 ± 0.014  ops/s
BrPopBenchmarks.rediculous      500  thrpt   30  0.893 ± 0.024  ops/s
BrPopBenchmarks.redis4cats      500  thrpt   30  1.991 ± 0.048  ops/s
BrPopBenchmarks.zio             500  thrpt   30  1.834 ± 0.063  ops/s
```

BrPopLPush
```
Benchmark                        (count)   Mode  Cnt  Score   Error  Units
BrPopLPushBenchmarks.laserdisc       500  thrpt   30  1.083 ± 0.018  ops/s
BrPopLPushBenchmarks.rediculous      500  thrpt   30  0.903 ± 0.024  ops/s
BrPopLPushBenchmarks.redis4cats      500  thrpt   30  2.079 ± 0.079  ops/s
BrPopLPushBenchmarks.zio             500  thrpt   30  1.926 ± 0.052  ops/s
```

LIndex
```
Benchmark                    (count)   Mode  Cnt  Score   Error  Units
LIndexBenchmarks.laserdisc       500  thrpt   30  1.078 ± 0.020  ops/s
LIndexBenchmarks.rediculous      500  thrpt   30  0.891 ± 0.016  ops/s
LIndexBenchmarks.redis4cats      500  thrpt   30  2.014 ± 0.040  ops/s
LIndexBenchmarks.zio             500  thrpt   30  1.864 ± 0.044  ops/s
```

LInsert
```
Benchmark                     (count)   Mode  Cnt  Score   Error  Units
LInsertBenchmarks.laserdisc       500  thrpt   30  1.053 ± 0.017  ops/s
LInsertBenchmarks.rediculous      500  thrpt   30  0.892 ± 0.006  ops/s
LInsertBenchmarks.redis4cats      500  thrpt   30  2.003 ± 0.045  ops/s
LInsertBenchmarks.zio             500  thrpt   30  1.813 ± 0.028  ops/s
```

LLen
```
Benchmark                  (count)   Mode  Cnt  Score   Error  Units
LLenBenchmarks.laserdisc       500  thrpt   30  1.135 ± 0.012  ops/s
LLenBenchmarks.rediculous      500  thrpt   30  0.931 ± 0.017  ops/s
LLenBenchmarks.redis4cats      500  thrpt   30  2.153 ± 0.071  ops/s
LLenBenchmarks.zio             500  thrpt   30  2.002 ± 0.084  ops/s
```

LMove
```
Benchmark            (count)   Mode  Cnt  Score   Error  Units
LMoveBenchmarks.zio      500  thrpt   30  1.877 ± 0.053  ops/s
```

LPop
```
Benchmark                  (count)   Mode  Cnt  Score   Error  Units
LPopBenchmarks.laserdisc       500  thrpt   30  1.129 ± 0.019  ops/s
LPopBenchmarks.rediculous      500  thrpt   30  0.911 ± 0.017  ops/s
LPopBenchmarks.redis4cats      500  thrpt   30  2.078 ± 0.051  ops/s
LPopBenchmarks.zio             500  thrpt   30  1.908 ± 0.069  ops/s
```

LPos
```
Benchmark           (count)   Mode  Cnt  Score   Error  Units
LPosBenchmarks.zio      500  thrpt   30  1.863 ± 0.059  ops/s
```

LPosCount
```
Benchmark                (count)   Mode  Cnt  Score   Error  Units
LPosCountBenchmarks.zio      500  thrpt   30  1.786 ± 0.030  ops/s
```

LPush
```
Benchmark                   (count)   Mode  Cnt  Score   Error  Units
LPushBenchmarks.laserdisc       500  thrpt   30  1.090 ± 0.026  ops/s
LPushBenchmarks.rediculous      500  thrpt   30  0.906 ± 0.015  ops/s
LPushBenchmarks.redis4cats      500  thrpt   30  2.071 ± 0.053  ops/s
LPushBenchmarks.zio             500  thrpt   30  1.921 ± 0.042  ops/s
```

LPushX
```
Benchmark                    (count)   Mode  Cnt  Score   Error  Units
LPushXBenchmarks.laserdisc       500  thrpt   30  1.109 ± 0.012  ops/s
LPushXBenchmarks.rediculous      500  thrpt   30  0.916 ± 0.016  ops/s
LPushXBenchmarks.redis4cats      500  thrpt   30  2.093 ± 0.046  ops/s
LPushXBenchmarks.zio             500  thrpt   30  1.930 ± 0.038  ops/s
```

LRange
```
Benchmark                    (count)   Mode  Cnt  Score   Error  Units
LRangeBenchmarks.laserdisc       400  thrpt   30  0.893 ± 0.015  ops/s
LRangeBenchmarks.rediculous      400  thrpt   30  0.833 ± 0.011  ops/s
LRangeBenchmarks.redis4cats      400  thrpt   30  2.060 ± 0.049  ops/s
LRangeBenchmarks.zio             400  thrpt   30  1.646 ± 0.027  ops/s
```

LRem
```
Benchmark                  (count)   Mode  Cnt  Score   Error  Units
LRemBenchmarks.laserdisc       500  thrpt   30  1.091 ± 0.014  ops/s
LRemBenchmarks.rediculous      500  thrpt   30  0.887 ± 0.011  ops/s
LRemBenchmarks.redis4cats      500  thrpt   30  2.046 ± 0.041  ops/s
LRemBenchmarks.zio             500  thrpt   30  1.892 ± 0.026  ops/s
```

LSet
```
Benchmark                  (count)   Mode  Cnt  Score   Error  Units
LSetBenchmarks.laserdisc       500  thrpt   30  1.106 ± 0.019  ops/s
LSetBenchmarks.rediculous      500  thrpt   30  0.875 ± 0.014  ops/s
LSetBenchmarks.redis4cats      500  thrpt   30  2.000 ± 0.055  ops/s
LSetBenchmarks.zio             500  thrpt   30  1.899 ± 0.062  ops/s
```

LTrim
```
Benchmark                   (count)   Mode  Cnt  Score   Error  Units
LTrimBenchmarks.laserdisc       500  thrpt   30  1.054 ± 0.028  ops/s
LTrimBenchmarks.rediculous      500  thrpt   30  0.851 ± 0.013  ops/s
LTrimBenchmarks.redis4cats      500  thrpt   30  2.038 ± 0.062  ops/s
LTrimBenchmarks.zio             500  thrpt   30  1.859 ± 0.039  ops/s
```

RPop
```
Benchmark                  (count)   Mode  Cnt  Score   Error  Units
RPopBenchmarks.laserdisc       500  thrpt   30  1.110 ± 0.015  ops/s
RPopBenchmarks.rediculous      500  thrpt   30  0.876 ± 0.011  ops/s
RPopBenchmarks.redis4cats      500  thrpt   30  2.069 ± 0.042  ops/s
RPopBenchmarks.zio             500  thrpt   30  1.923 ± 0.049  ops/s
```

RPopLPush
```
Benchmark                       (count)   Mode  Cnt  Score   Error  Units
RPopLPushBenchmarks.laserdisc       500  thrpt   30  1.107 ± 0.012  ops/s
RPopLPushBenchmarks.rediculous      500  thrpt   30  0.905 ± 0.009  ops/s
RPopLPushBenchmarks.redis4cats      500  thrpt   30  2.066 ± 0.066  ops/s
RPopLPushBenchmarks.zio             500  thrpt   30  1.918 ± 0.035  ops/s
```

RPush
```
Benchmark                   (count)   Mode  Cnt  Score   Error  Units
RPushBenchmarks.laserdisc       500  thrpt   30  1.121 ± 0.025  ops/s
RPushBenchmarks.rediculous      500  thrpt   30  0.889 ± 0.015  ops/s
RPushBenchmarks.redis4cats      500  thrpt   30  2.121 ± 0.064  ops/s
RPushBenchmarks.zio             500  thrpt   30  1.956 ± 0.059  ops/s
```

RPushX
```
Benchmark                    (count)   Mode  Cnt  Score   Error  Units
RPushXBenchmarks.laserdisc       500  thrpt   30  1.130 ± 0.012  ops/s
RPushXBenchmarks.rediculous      500  thrpt   30  0.915 ± 0.018  ops/s
RPushXBenchmarks.redis4cats      500  thrpt   30  2.081 ± 0.038  ops/s
RPushXBenchmarks.zio             500  thrpt   30  1.944 ± 0.057  ops/s
```