### PR TITLE
Upgrade zio-prelude to 1.0.0-RC8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -70,7 +70,7 @@ lazy val example =
         "dev.zio"                       %% "zio-streams"                   % Zio,
         "dev.zio"                       %% "zio-config-magnolia"           % "1.0.10",
         "dev.zio"                       %% "zio-config-typesafe"           % "1.0.10",
-        "dev.zio"                       %% "zio-prelude"                   % "1.0.0-RC10",
+        "dev.zio"                       %% "zio-prelude"                   % "1.0.0-RC8",
         "dev.zio"                       %% "zio-json"                      % "0.1.5",
         "io.d11"                        %% "zhttp"                         % "1.0.0.0-RC23",
         "io.github.kitlangton"          %% "zio-magic"                     % "0.3.11"

--- a/build.sbt
+++ b/build.sbt
@@ -70,7 +70,7 @@ lazy val example =
         "dev.zio"                       %% "zio-streams"                   % Zio,
         "dev.zio"                       %% "zio-config-magnolia"           % "1.0.10",
         "dev.zio"                       %% "zio-config-typesafe"           % "1.0.10",
-        "dev.zio"                       %% "zio-prelude"                   % "1.0.0-RC7",
+        "dev.zio"                       %% "zio-prelude"                   % "1.0.0-RC10",
         "dev.zio"                       %% "zio-json"                      % "0.1.5",
         "io.d11"                        %% "zhttp"                         % "1.0.0.0-RC23",
         "io.github.kitlangton"          %% "zio-magic"                     % "0.3.11"


### PR DESCRIPTION
**Note:** `1.0.0-RC8` is the latest prelude release compatible with ZIO 1.x