### PR TITLE
#460: Implement CLIENT INFO and CLIENT LIST commands

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,6 +43,7 @@ lazy val redis =
         "dev.zio"                %% "zio-streams"             % "2.0.1",
         "dev.zio"                %% "zio-logging"             % "2.1.0",
         "dev.zio"                %% "zio-schema"              % "0.2.1",
+        "dev.zio"                %% "zio-schema-derivation"   % "0.2.1",
         "dev.zio"                %% "zio-schema-protobuf"     % "0.2.1" % Test,
         "dev.zio"                %% "zio-test"                % "2.0.1" % Test,
         "dev.zio"                %% "zio-test-sbt"            % "2.0.1" % Test,

--- a/redis/src/main/scala/zio/redis/Input.scala
+++ b/redis/src/main/scala/zio/redis/Input.scala
@@ -125,6 +125,16 @@ object Input {
       Chunk.single(encodeString(data.stringify))
   }
 
+  case object ClientListInput extends Input[ClientListFilter] {
+    def encode(data: ClientListFilter)(implicit codec: Codec): Chunk[RespValue.BulkString] = data match {
+      case ClientListFilter.All => Chunk.empty
+      case ClientListFilter.Id(ids) =>
+        Chunk.single(encodeString(data.stringify)) ++ ids.map(id => encodeString(id.toString))
+      case ClientListFilter.Type(t) =>
+        Chunk(encodeString(data.stringify), encodeString(t.stringify))
+    }
+  }
+
   case object ClientKillInput extends Input[ClientKillFilter] {
     def encode(data: ClientKillFilter)(implicit codec: Codec): Chunk[RespValue.BulkString] = data match {
       case addr: ClientKillFilter.Address       => Chunk(encodeString("ADDR"), encodeString(addr.stringify))

--- a/redis/src/main/scala/zio/redis/Input.scala
+++ b/redis/src/main/scala/zio/redis/Input.scala
@@ -128,8 +128,8 @@ object Input {
   case object ClientListInput extends Input[ClientListFilter] {
     def encode(data: ClientListFilter)(implicit codec: Codec): Chunk[RespValue.BulkString] = data match {
       case ClientListFilter.All => Chunk.empty
-      case ClientListFilter.Id(ids) =>
-        Chunk.single(encodeString(data.stringify)) ++ ids.map(id => encodeString(id.toString))
+      case ClientListFilter.Id(id, ids @ _*) =>
+        Chunk.single(encodeString(data.stringify)) ++ (id :: ids.toList).map(i => encodeString(i.toString))
       case ClientListFilter.Type(t) =>
         Chunk(encodeString(data.stringify), encodeString(t.stringify))
     }

--- a/redis/src/main/scala/zio/redis/api/Connection.scala
+++ b/redis/src/main/scala/zio/redis/api/Connection.scala
@@ -74,6 +74,32 @@ trait Connection {
   }
 
   /**
+   * Returns information about the current connection.
+   *
+   * @return
+   *   the current connection information in property=value fields separated by a space character.
+   */
+  final def clientInfo: ZIO[Redis, RedisError, ClientInfo] = {
+    val command = RedisCommand(ClientInfo, NoInput, ClientInfoOutput)
+
+    command.run(())
+  }
+
+  /**
+   * Returns information about the client connections.
+   *
+   * @param filter
+   *   subcomand to filter the clientList by client type or client ids.
+   * @return
+   *   the list of clients information in property=value fields separated by a space character.
+   */
+  final def clientList(filter: ClientListFilter = ClientListFilter.All): ZIO[Redis, RedisError, Chunk[ClientInfo]] = {
+    val command = RedisCommand(ClientList, ClientListInput, ClientListOutput)
+
+    command.run(filter)
+  }
+
+  /**
    * Closes a given client connection with the specified address
    *
    * @param address
@@ -331,6 +357,8 @@ private[redis] object Connection {
   final val Auth               = "AUTH"
   final val ClientCaching      = "CLIENT CACHING"
   final val ClientId           = "CLIENT ID"
+  final val ClientInfo         = "CLIENT INFO"
+  final val ClientList         = "CLIENT LIST"
   final val ClientKill         = "CLIENT KILL"
   final val ClientGetName      = "CLIENT GETNAME"
   final val ClientGetRedir     = "CLIENT GETREDIR"

--- a/redis/src/main/scala/zio/redis/options/Connection.scala
+++ b/redis/src/main/scala/zio/redis/options/Connection.scala
@@ -16,7 +16,6 @@
 
 package zio.redis.options
 
-import zio.prelude.NonEmptyList
 import zio.schema.ast.SchemaAst
 import zio.schema.{DeriveSchema, DynamicValue, Schema, StandardType, TypeId}
 import zio.stream.ZPipeline
@@ -328,15 +327,14 @@ trait Connection {
       },
       extractField = address => address.map(c => c.ip.getHostAddress + ":" + c.port).getOrElse("")
     )
-    implicit val clientEventsSchema: Schema[ClientEvents] = Schema
-      .CaseClass2(
-        TypeId.fromTypeName("ClientEvents"),
-        field1 = Schema.Field[String]("readable", Schema.primitive[String]),
-        field2 = Schema.Field[String]("writable", Schema.primitive[String]),
-        construct = (readable: String, writable: String) => ClientEvents(readable == "r", writable == "w"),
-        extractField1 = c => if (c.readable) "r" else "",
-        extractField2 = c => if (c.writable) "w" else ""
-      )
+    implicit val clientEventsSchema: Schema[ClientEvents] = Schema.CaseClass2(
+      TypeId.fromTypeName("ClientEvents"),
+      field1 = Schema.Field[String]("readable", Schema.primitive[String]),
+      field2 = Schema.Field[String]("writable", Schema.primitive[String]),
+      construct = (readable: String, writable: String) => ClientEvents(readable == "r", writable == "w"),
+      extractField1 = c => if (c.readable) "r" else "",
+      extractField2 = c => if (c.writable) "w" else ""
+    )
     implicit val clientFlagSchema: Schema[ClientFlag] = Schema
       .Primitive(StandardType.StringType)
       .transform[ClientFlag](
@@ -354,9 +352,8 @@ trait Connection {
     private val decoder = ClientInfoCodec.decode(schema)
     private val encoder = ClientInfoCodec.encode(schema)
 
-    def decode(in: String): Either[String, ClientInfo] =
-      decoder(Chunk.fromArray(in.getBytes))
-    def encode(info: ClientInfo): String = new String(encoder(info).toArray)
+    def decode(in: String): Either[String, ClientInfo] = decoder(Chunk.fromArray(in.getBytes))
+    def encode(info: ClientInfo): String               = new String(encoder(info).toArray)
   }
 
   sealed trait ClientListType { self =>
@@ -389,7 +386,7 @@ trait Connection {
       private[redis] final def stringify: String = s"TYPE"
     }
 
-    sealed case class Id(ids: NonEmptyList[Long]) extends ClientListFilter {
+    sealed case class Id(id: Long, ids: Long*) extends ClientListFilter {
       private[redis] final def stringify: String = "ID"
     }
   }

--- a/redis/src/test/scala/zio/redis/BaseSpec.scala
+++ b/redis/src/test/scala/zio/redis/BaseSpec.scala
@@ -25,6 +25,13 @@ trait BaseSpec extends ZIOSpecDefault {
   final val genPatternOption: Gen[Any, Option[String]] =
     Gen.option(Gen.constSample(Sample.noShrink("*")))
 
+  final val genClientListType = Gen.elements(
+    ClientListType.Master,
+    ClientListType.PubSub,
+    ClientListType.Replica,
+    ClientListType.Normal
+  )
+
   final val uuid: UIO[String] =
     ZIO.succeed(UUID.randomUUID().toString)
 

--- a/redis/src/test/scala/zio/redis/ConnectionSpec.scala
+++ b/redis/src/test/scala/zio/redis/ConnectionSpec.scala
@@ -94,7 +94,7 @@ trait ConnectionSpec extends BaseSpec {
         },
         test("zero results when id does not exists") {
           for {
-            res <- clientList(ClientListFilter.Id(zio.prelude.NonEmptyList(1)))
+            res <- clientList(ClientListFilter.Id(1))
           } yield assert(res)(isEmpty)
         }
       ),

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -16,7 +16,7 @@ object InputSpec extends BaseSpec {
   import RadiusUnit._
   import StrAlgoLcsQueryType._
 
-  def spec: Spec[Any, Throwable] =
+  def spec: Spec[TestConfig, Throwable] =
     suite("Input encoders")(
       suite("AbsTtl")(
         test("valid value") {
@@ -257,6 +257,26 @@ object InputSpec extends BaseSpec {
             result <- ZIO.attempt(ClientKillInput.encode(ClientKillFilter.SkipMe(true)))
           } yield assert(result)(equalTo(respArgs("SKIPME", "YES")))
         }
+      ),
+      suite("ClientList")(
+        test("filter by id") {
+          for {
+            filter <- ZIO.succeed(ClientListFilter.Id(zio.prelude.NonEmptyList(12)))
+            result <- ZIO.attempt(ClientListInput.encode(filter))
+          } yield assert(result)(equalTo(respArgs("ID", "12")))
+        },
+        test("filter by more than one id") {
+          for {
+            filter <- ZIO.succeed(ClientListFilter.Id(zio.prelude.NonEmptyList(12, 13, 14)))
+            result <- ZIO.attempt(ClientListInput.encode(filter))
+          } yield assert(result)(equalTo(respArgs("ID", "12", "13", "14")))
+        },
+        test("filter by type")(check(genClientListType) { clientType =>
+          for {
+            filter <- ZIO.succeed(ClientListFilter.Type(clientType))
+            result <- ZIO.attempt(ClientListInput.encode(filter))
+          } yield assert(result)(equalTo(respArgs("TYPE", clientType.toString.toUpperCase)))
+        })
       ),
       suite("ClientPauseMode")(
         test("all") {

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -261,13 +261,13 @@ object InputSpec extends BaseSpec {
       suite("ClientList")(
         test("filter by id") {
           for {
-            filter <- ZIO.succeed(ClientListFilter.Id(zio.prelude.NonEmptyList(12)))
+            filter <- ZIO.succeed(ClientListFilter.Id(12))
             result <- ZIO.attempt(ClientListInput.encode(filter))
           } yield assert(result)(equalTo(respArgs("ID", "12")))
         },
         test("filter by more than one id") {
           for {
-            filter <- ZIO.succeed(ClientListFilter.Id(zio.prelude.NonEmptyList(12, 13, 14)))
+            filter <- ZIO.succeed(ClientListFilter.Id(12, 13, 14))
             result <- ZIO.attempt(ClientListInput.encode(filter))
           } yield assert(result)(equalTo(respArgs("ID", "12", "13", "14")))
         },


### PR DESCRIPTION
This PR tries to implement #460.

* Added zio-schema-derivation to redis library-dependencies (needed to create a codec/schema for encode/decode ClientInfo as described here https://redis.io/commands/client-list/)
* Added clientInfo and clientList commands to api/Connection.scala
* Addded ClientListFilter input to allow filter clients in clientList

Maybe is unrelated but I'm facing some blocking issues during test executing (LiveExecutor):

to be able to execute the tests I have to change RedisExecutor run and receive methods:
1) Run
```
(send.forever race receive)
```

to
```
(send *> receive).forever
```

2) Receive (I really don't understand this one)
```
byteStream.read
```
to
```
byteStream.read.tap(r => logger.debug(s"Received: $r")))
```

So, Is it possible that I am introducing some error in the Input/Output encoding without realizing it?

My environment:
* Redis 7.0.2
* openjdk 17


* UPDATE ABOUT LOCKING PROBLEM
I Think I found the cause of the blocking problem at #613.
Seems to be caused by ClientInfo being a bulkString with a newline character (\n) at the end of the string data.
