### PR TITLE
Fix bulkstring decoder when it ends with a '\n' character

### DIFF
--- a/redis/src/test/scala/zio/redis/ConnectionSpec.scala
+++ b/redis/src/test/scala/zio/redis/ConnectionSpec.scala
@@ -157,6 +157,13 @@ trait ConnectionSpec extends BaseSpec {
         },
         test("PING with input") {
           ping(Some("Hello")).map(assert(_)(equalTo("Hello")))
+        },
+        test("PING with a string argument will not lock executor") {
+          ping(Some("Hello with a newline\n")).map(assert(_)(equalTo("Hello with a newline\n")))
+        },
+        test("PING with a multiline string argument will not lock executor") {
+          ping(Some("Hello with a newline\r\nAnd another line\n"))
+            .map(assert(_)(equalTo("Hello with a newline\r\nAnd another line\n")))
         }
       ),
       test("reset") {


### PR DESCRIPTION
Fixes #613.

As described in #613, If a bulkString has a '\n' at the end of the actual string data, RespValue Decoder produces a lock in the current RedisExecutor.

This simple PR adds a transition from Start to Start, when the line is blank, in RespValue.feed.

