### PR TITLE
Implement remaining script API commands

### DIFF
--- a/redis/src/main/scala/zio/redis/Input.scala
+++ b/redis/src/main/scala/zio/redis/Input.scala
@@ -596,6 +596,11 @@ object Input {
       Chunk.single(encodeString(data.stringify))
   }
 
+  case object ScriptFlushInput extends Input[FlushMode] {
+    def encode(data: FlushMode)(implicit codec: Codec): Chunk[RespValue.BulkString] =
+      Chunk.single(encodeString(data.stringify))
+  }
+
   case object WithScoresInput extends Input[WithScores] {
     def encode(data: WithScores)(implicit codec: Codec): Chunk[RespValue.BulkString] =
       Chunk.single(encodeString(data.stringify))

--- a/redis/src/main/scala/zio/redis/api/Scripting.scala
+++ b/redis/src/main/scala/zio/redis/api/Scripting.scala
@@ -104,6 +104,18 @@ trait Scripting {
   }
 
   /**
+   * Kills the currently executing [[zio.redis.api.Scripting.eval]] script, assuming no write operation was yet
+   * performed by the script.
+   *
+   * @return
+   *   unit if successful, error otherwise.
+   */
+  def scriptKill: ZIO[Redis, RedisError, Unit] = {
+    val command = RedisCommand(ScriptKill, NoInput, UnitOutput)
+    command.run(())
+  }
+
+  /**
    * Loads a script into the scripts cache. After the script is loaded into the script cache it could be evaluated using
    * the [[zio.redis.api.Scripting.evalSha]] method.
    *
@@ -123,5 +135,6 @@ private[redis] object Scripting {
   final val EvalSha      = "EVALSHA"
   final val ScriptExists = "SCRIPT EXISTS"
   final val ScriptFlush  = "SCRIPT FLUSH"
+  final val ScriptKill   = "SCRIPT KILL"
   final val ScriptLoad   = "SCRIPT LOAD"
 }

--- a/redis/src/main/scala/zio/redis/api/Scripting.scala
+++ b/redis/src/main/scala/zio/redis/api/Scripting.scala
@@ -91,6 +91,19 @@ trait Scripting {
   }
 
   /**
+   * Flush the Lua script cache. By default, this command will flush the cache synchronously.
+   *
+   * @param flushMode
+   *   synchronously or asynchronously flush the cache
+   * @return
+   *   unit if successful, error otherwise.
+   */
+  def scriptFlush(flushMode: Option[FlushMode] = None): ZIO[Redis, RedisError, Unit] = {
+    val command = RedisCommand(ScriptFlush, OptionalInput(ScriptFlushInput), UnitOutput)
+    command.run(flushMode)
+  }
+
+  /**
    * Loads a script into the scripts cache. After the script is loaded into the script cache it could be evaluated using
    * the [[zio.redis.api.Scripting.evalSha]] method.
    *
@@ -109,5 +122,6 @@ private[redis] object Scripting {
   final val Eval         = "EVAL"
   final val EvalSha      = "EVALSHA"
   final val ScriptExists = "SCRIPT EXISTS"
+  final val ScriptFlush  = "SCRIPT FLUSH"
   final val ScriptLoad   = "SCRIPT LOAD"
 }

--- a/redis/src/main/scala/zio/redis/api/Scripting.scala
+++ b/redis/src/main/scala/zio/redis/api/Scripting.scala
@@ -78,11 +78,11 @@ trait Scripting {
    * Set the debug mode for subsequent scripts executed with [[zio.redis.api.Scripting.eval]].
    *
    * @param debugMode
-   *   - [[zio.redis.options.DebugMode.Yes]]: Enable non-blocking asynchronous debugging of Lua scripts (changes are
+   *   - [[zio.redis.DebugMode.Yes]]: Enable non-blocking asynchronous debugging of Lua scripts (changes are
    *     discarded).
-   *   - [[zio.redis.options.DebugMode.Sync]]: Enable blocking synchronous debugging of Lua scripts (saves changes to
+   *   - [[zio.redis.DebugMode.Sync]]: Enable blocking synchronous debugging of Lua scripts (saves changes to
    *     data).
-   *   - [[zio.redis.options.DebugMode.No]]: Disables scripts debug mode.
+   *   - [[zio.redis.DebugMode.No]]: Disables scripts debug mode.
    * @return
    *   unit if successful, error otherwise.
    */

--- a/redis/src/main/scala/zio/redis/api/Scripting.scala
+++ b/redis/src/main/scala/zio/redis/api/Scripting.scala
@@ -75,6 +75,23 @@ trait Scripting {
   }
 
   /**
+   * Set the debug mode for subsequent scripts executed with [[zio.redis.api.Scripting.eval]].
+   *
+   * @param debugMode
+   *   - [[zio.redis.options.DebugMode.Yes]]: Enable non-blocking asynchronous debugging of Lua scripts (changes are
+   *     discarded).
+   *   - [[zio.redis.options.DebugMode.Sync]]: Enable blocking synchronous debugging of Lua scripts (saves changes to
+   *     data).
+   *   - [[zio.redis.options.DebugMode.No]]: Disables scripts debug mode.
+   * @return
+   *   unit if successful, error otherwise.
+   */
+  def scriptDebug(debugMode: DebugMode): ZIO[Redis, RedisError, Unit] = {
+    val command = RedisCommand(ScriptDebug, ScriptDebugInput, UnitOutput)
+    command.run(debugMode)
+  }
+
+  /**
    * Checks existence of the scripts in the script cache.
    *
    * @param sha1
@@ -133,6 +150,7 @@ trait Scripting {
 private[redis] object Scripting {
   final val Eval         = "EVAL"
   final val EvalSha      = "EVALSHA"
+  final val ScriptDebug  = "SCRIPT DEBUG"
   final val ScriptExists = "SCRIPT EXISTS"
   final val ScriptFlush  = "SCRIPT FLUSH"
   final val ScriptKill   = "SCRIPT KILL"

--- a/redis/src/main/scala/zio/redis/options/Scripting.scala
+++ b/redis/src/main/scala/zio/redis/options/Scripting.scala
@@ -31,4 +31,17 @@ trait Scripting {
     case object Sync extends DebugMode
     case object No   extends DebugMode
   }
+
+  sealed trait FlushMode { self =>
+    private[redis] final def stringify: String =
+      self match {
+        case FlushMode.Async => "ASYNC"
+        case FlushMode.Sync  => "SYNC"
+      }
+  }
+
+  object FlushMode {
+    case object Sync  extends FlushMode
+    case object Async extends FlushMode
+  }
 }

--- a/redis/src/test/scala/zio/redis/ScriptingSpec.scala
+++ b/redis/src/test/scala/zio/redis/ScriptingSpec.scala
@@ -147,6 +147,15 @@ trait ScriptingSpec extends BaseSpec {
           } yield assert(res)(isLeft(isSubtype[NoScript](hasField("message", _.message, equalTo(error)))))
         }
       ),
+      suite("scriptDebug")(
+        test("return true if all debug command options are executed successfully") {
+          for {
+            res1 <- scriptDebug(DebugMode.Yes)
+            res2 <- scriptDebug(DebugMode.Sync)
+            res3 <- scriptDebug(DebugMode.No)
+          } yield assert(res1)(isUnit) && assert(res2)(isUnit) && assert(res3)(isUnit)
+        }
+      ),
       suite("scriptExists")(
         test("return true if scripts are found in the cache") {
           val lua1 = """return "1""""

--- a/redis/src/test/scala/zio/redis/ScriptingSpec.scala
+++ b/redis/src/test/scala/zio/redis/ScriptingSpec.scala
@@ -179,6 +179,18 @@ trait ScriptingSpec extends BaseSpec {
             sha <- scriptLoad(lua).either
           } yield assert(sha)(isLeft(isSubtype[ProtocolError](hasField("message", _.message, equalTo(error)))))
         }
+      ),
+      suite("scriptFlush")(
+        test("return true if loaded scripts are flushed from the cache") {
+          val lua1 = """return "1""""
+          val lua2 = """return "2""""
+          for {
+            sha1 <- scriptLoad(lua1)
+            sha2 <- scriptLoad(lua2)
+            _    <- scriptFlush()
+            res  <- scriptExists(sha1, sha2)
+          } yield assertTrue(res == Chunk(false, false))
+        }
       )
     )
 }

--- a/redis/src/test/scala/zio/redis/ScriptingSpec.scala
+++ b/redis/src/test/scala/zio/redis/ScriptingSpec.scala
@@ -191,6 +191,16 @@ trait ScriptingSpec extends BaseSpec {
             res  <- scriptExists(sha1, sha2)
           } yield assertTrue(res == Chunk(false, false))
         }
+      ),
+      suite("scriptKill")(
+        test("throw an error when attempting to kill when no script is running") {
+          val lua        = """return true"""
+          val emptyInput = Chunk.empty[String]
+          for {
+            _   <- eval(lua, emptyInput, emptyInput).returning[Boolean]
+            res <- scriptKill.exit
+          } yield assert(res)(failsWithA[RedisError])
+        }
       )
     )
 }


### PR DESCRIPTION
Addresses remaining items in #158.

Please check if tests for these commands are satisfactory, I could only come up with a basic test for `scriptDebug`, and for `scriptKill` I couldn't figure out how to fork a long-running script (e.g., infinite loop) and attempt to kill it.