### PR TITLE
Ignore Snapshot Versions on The README Page

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,6 +8,6 @@ addSbtPlugin("de.heikoseeberger"                 % "sbt-header"       % "5.9.0")
 addSbtPlugin("org.scalameta"                     % "sbt-mdoc"         % "2.3.6")
 addSbtPlugin("org.scalameta"                     % "sbt-scalafmt"     % "2.5.0")
 addSbtPlugin("pl.project13.scala"                % "sbt-jmh"          % "0.4.3")
-addSbtPlugin("dev.zio"                           % "zio-sbt-website"  % "0.2.3")
+addSbtPlugin("dev.zio"                           % "zio-sbt-website"  % "0.2.4")
 
 libraryDependencies += "org.snakeyaml" % "snakeyaml-engine" % "2.5"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,8 +8,6 @@ addSbtPlugin("de.heikoseeberger"                 % "sbt-header"       % "5.9.0")
 addSbtPlugin("org.scalameta"                     % "sbt-mdoc"         % "2.3.6")
 addSbtPlugin("org.scalameta"                     % "sbt-scalafmt"     % "2.5.0")
 addSbtPlugin("pl.project13.scala"                % "sbt-jmh"          % "0.4.3")
-addSbtPlugin("dev.zio"                           % "zio-sbt-website"  % "0.1.5+27-a79a4f13-SNAPSHOT")
+addSbtPlugin("dev.zio"                           % "zio-sbt-website"  % "0.2.3")
 
 libraryDependencies += "org.snakeyaml" % "snakeyaml-engine" % "2.5"
-
-resolvers ++= Resolver.sonatypeOssRepos("public")


### PR DESCRIPTION
There was a bug in previous versions of the zio-sbt-website plugin which makes an endless loop when the library hasn't been released yet.