### PR TITLE
[548] Expose Redis operations via Redis trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,13 @@ import zio.schema.codec._
 
 object ZIORedisExample extends ZIOAppDefault {
   val myApp: ZIO[Redis, RedisError, Unit] = for {
-    _ <- set("myKey", 8L, Some(1.minutes))
-    v <- get("myKey").returning[Long]
-    _ <- Console.printLine(s"Value of myKey: $v").orDie
-    _ <- hSet("myHash", ("k1", 6), ("k2", 2))
-    _ <- rPush("myList", 1, 2, 3, 4)
-    _ <- sAdd("mySet", "a", "b", "a", "c")
+    redis <- ZIO.service[Redis]
+    _     <- redis.set("myKey", 8L, Some(1.minutes))
+    v     <- redis.get("myKey").returning[Long]
+    _     <- Console.printLine(s"Value of myKey: $v").orDie
+    _     <- redis.hSet("myHash", ("k1", 6), ("k2", 2))
+    _     <- redis.rPush("myList", 1, 2, 3, 4)
+    _     <- redis.sAdd("mySet", "a", "b", "a", "c")
   } yield ()
 
   override def run = myApp.provide(

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/hash/HDelBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/hash/HDelBenchmarks.scala
@@ -40,7 +40,7 @@ class HDelBenchmarks extends BenchmarkRuntime {
   @Setup(Level.Trial)
   def setup(): Unit = {
     items = (0 to size).map(e => e.toString -> e.toString).toList
-    execute(hSet(key, items.head, items.tail: _*).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.hSet(key, items.head, items.tail: _*).unit))
   }
 
   @Benchmark
@@ -67,5 +67,5 @@ class HDelBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(it => hDel(key, it._1)))
+  def zio(): Unit = execute(ZIO.foreachDiscard(items)(it => ZIO.serviceWithZIO[Redis](_.hDel(key, it._1))))
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/hash/HExistsBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/hash/HExistsBenchmarks.scala
@@ -40,7 +40,7 @@ class HExistsBenchmarks extends BenchmarkRuntime {
   @Setup(Level.Trial)
   def setup(): Unit = {
     items = (0 to size).map(e => e.toString -> e.toString).toList
-    execute(hSet(key, items.head, items.tail: _*).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.hSet(key, items.head, items.tail: _*).unit))
   }
 
   @Benchmark
@@ -69,5 +69,5 @@ class HExistsBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(it => hExists(key, it._1)))
+  def zio(): Unit = execute(ZIO.foreachDiscard(items)(it => ZIO.serviceWithZIO[Redis](_.hExists(key, it._1))))
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/hash/HGetAllBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/hash/HGetAllBenchmarks.scala
@@ -67,5 +67,7 @@ class HGetAllBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(_ => ZIO.serviceWithZIO[Redis](_.hGetAll(key).returning[String, String])))
+  def zio(): Unit = execute(
+    ZIO.foreachDiscard(items)(_ => ZIO.serviceWithZIO[Redis](_.hGetAll(key).returning[String, String]))
+  )
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/hash/HGetAllBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/hash/HGetAllBenchmarks.scala
@@ -40,7 +40,7 @@ class HGetAllBenchmarks extends BenchmarkRuntime {
   @Setup(Level.Trial)
   def setup(): Unit = {
     items = (0 to size).map(e => e.toString -> e.toString).toList
-    execute(hSet(key, items.head, items.tail: _*).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.hSet(key, items.head, items.tail: _*).unit))
   }
 
   @Benchmark
@@ -67,5 +67,5 @@ class HGetAllBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(_ => hGetAll(key).returning[String, String]))
+  def zio(): Unit = execute(ZIO.foreachDiscard(items)(_ => ZIO.serviceWithZIO[Redis](_.hGetAll(key).returning[String, String])))
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/hash/HGetBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/hash/HGetBenchmarks.scala
@@ -40,7 +40,7 @@ class HGetBenchmarks extends BenchmarkRuntime {
   @Setup(Level.Trial)
   def setup(): Unit = {
     items = (0 to size).map(e => e.toString -> e.toString).toList
-    execute(hSet(key, items.head, items.tail: _*).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.hSet(key, items.head, items.tail: _*).unit))
   }
 
   @Benchmark
@@ -68,5 +68,5 @@ class HGetBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(it => hGet(key, it._1).returning[String]))
+  def zio(): Unit = execute(ZIO.foreachDiscard(items)(it => ZIO.serviceWithZIO[Redis](_.hGet(key, it._1).returning[String])))
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/hash/HGetBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/hash/HGetBenchmarks.scala
@@ -68,5 +68,7 @@ class HGetBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(it => ZIO.serviceWithZIO[Redis](_.hGet(key, it._1).returning[String])))
+  def zio(): Unit = execute(
+    ZIO.foreachDiscard(items)(it => ZIO.serviceWithZIO[Redis](_.hGet(key, it._1).returning[String]))
+  )
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/hash/HIncrbyBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/hash/HIncrbyBenchmarks.scala
@@ -73,5 +73,7 @@ class HIncrbyBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(it => ZIO.serviceWithZIO[Redis](_.hIncrBy(key, it._1, increment))))
+  def zio(): Unit = execute(
+    ZIO.foreachDiscard(items)(it => ZIO.serviceWithZIO[Redis](_.hIncrBy(key, it._1, increment)))
+  )
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/hash/HIncrbyBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/hash/HIncrbyBenchmarks.scala
@@ -43,7 +43,7 @@ class HIncrbyBenchmarks extends BenchmarkRuntime {
   @Setup(Level.Trial)
   def setup(): Unit = {
     items = (0 to size).map(e => e.toString -> e.toString).toList
-    execute(hSet(key, items.head, items.tail: _*).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.hSet(key, items.head, items.tail: _*).unit))
   }
 
   @Benchmark
@@ -73,5 +73,5 @@ class HIncrbyBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(it => hIncrBy(key, it._1, increment)))
+  def zio(): Unit = execute(ZIO.foreachDiscard(items)(it => ZIO.serviceWithZIO[Redis](_.hIncrBy(key, it._1, increment))))
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/hash/HIncrbyFloatBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/hash/HIncrbyFloatBenchmarks.scala
@@ -75,5 +75,7 @@ class HIncrbyFloatBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(it => ZIO.serviceWithZIO[Redis](_.hIncrByFloat(key, it._1, increment))))
+  def zio(): Unit = execute(
+    ZIO.foreachDiscard(items)(it => ZIO.serviceWithZIO[Redis](_.hIncrByFloat(key, it._1, increment)))
+  )
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/hash/HIncrbyFloatBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/hash/HIncrbyFloatBenchmarks.scala
@@ -43,7 +43,7 @@ class HIncrbyFloatBenchmarks extends BenchmarkRuntime {
   @Setup(Level.Trial)
   def setup(): Unit = {
     items = (0 to size).map(e => e.toString -> e.toString).toList
-    execute(hSet(key, items.head, items.tail: _*).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.hSet(key, items.head, items.tail: _*).unit))
   }
 
   @Benchmark
@@ -75,5 +75,5 @@ class HIncrbyFloatBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(it => hIncrByFloat(key, it._1, increment)))
+  def zio(): Unit = execute(ZIO.foreachDiscard(items)(it => ZIO.serviceWithZIO[Redis](_.hIncrByFloat(key, it._1, increment))))
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/hash/HKeysBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/hash/HKeysBenchmarks.scala
@@ -40,7 +40,7 @@ class HKeysBenchmarks extends BenchmarkRuntime {
   @Setup(Level.Trial)
   def setup(): Unit = {
     items = (0 to size).map(e => e.toString -> e.toString).toList
-    execute(hSet(key, items.head, items.tail: _*).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.hSet(key, items.head, items.tail: _*).unit))
   }
 
   @Benchmark
@@ -67,5 +67,5 @@ class HKeysBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(_ => hKeys(key).returning[String]))
+  def zio(): Unit = execute(ZIO.foreachDiscard(items)(_ => ZIO.serviceWithZIO[Redis](_.hKeys(key).returning[String])))
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/hash/HLenBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/hash/HLenBenchmarks.scala
@@ -40,7 +40,7 @@ class HLenBenchmarks extends BenchmarkRuntime {
   @Setup(Level.Trial)
   def setup(): Unit = {
     items = (0 to size).map(e => e.toString -> e.toString).toList
-    execute(hSet(key, items.head, items.tail: _*).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.hSet(key, items.head, items.tail: _*).unit))
   }
 
   @Benchmark
@@ -67,5 +67,5 @@ class HLenBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(_ => hLen(key)))
+  def zio(): Unit = execute(ZIO.foreachDiscard(items)(_ => ZIO.serviceWithZIO[Redis](_.hLen(key))))
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/hash/HMGetBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/hash/HMGetBenchmarks.scala
@@ -40,7 +40,7 @@ class HMGetBenchmarks extends BenchmarkRuntime {
   @Setup(Level.Trial)
   def setup(): Unit = {
     items = (0 to size).map(e => e.toString -> e.toString).toList
-    execute(hSet(key, items.head, items.tail: _*).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.hSet(key, items.head, items.tail: _*).unit))
   }
 
   @Benchmark
@@ -68,5 +68,5 @@ class HMGetBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(it => hmGet(key, it._1).returning[String]))
+  def zio(): Unit = execute(ZIO.foreachDiscard(items)(it => ZIO.serviceWithZIO[Redis](_.hmGet(key, it._1).returning[String])))
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/hash/HMGetBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/hash/HMGetBenchmarks.scala
@@ -68,5 +68,7 @@ class HMGetBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(it => ZIO.serviceWithZIO[Redis](_.hmGet(key, it._1).returning[String])))
+  def zio(): Unit = execute(
+    ZIO.foreachDiscard(items)(it => ZIO.serviceWithZIO[Redis](_.hmGet(key, it._1).returning[String]))
+  )
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/hash/HMSetBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/hash/HMSetBenchmarks.scala
@@ -66,5 +66,5 @@ class HMSetBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(it => hmSet(key, it)))
+  def zio(): Unit = execute(ZIO.foreachDiscard(items)(it => ZIO.serviceWithZIO[Redis](_.hmSet(key, it))))
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/hash/HSetBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/hash/HSetBenchmarks.scala
@@ -66,5 +66,5 @@ class HSetBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(it => hSet(key, it)))
+  def zio(): Unit = execute(ZIO.foreachDiscard(items)(it => ZIO.serviceWithZIO[Redis](_.hSet(key, it))))
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/hash/HSetNxBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/hash/HSetNxBenchmarks.scala
@@ -67,5 +67,5 @@ class HSetNxBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(it => hSetNx(key, it._1, it._2)))
+  def zio(): Unit = execute(ZIO.foreachDiscard(items)(it => ZIO.serviceWithZIO[Redis](_.hSetNx(key, it._1, it._2))))
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/hash/HStrLenBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/hash/HStrLenBenchmarks.scala
@@ -39,7 +39,7 @@ class HStrLenBenchmarks extends BenchmarkRuntime {
 
   def setup(): Unit = {
     items = (0 to size).map(e => e.toString -> e.toString).toList
-    execute(hSet(key, items.head, items.tail: _*).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.hSet(key, items.head, items.tail: _*).unit))
   }
   @Benchmark
   def laserdisc(): Unit = {
@@ -66,5 +66,5 @@ class HStrLenBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(it => hStrLen(key, it._1)))
+  def zio(): Unit = execute(ZIO.foreachDiscard(items)(it => ZIO.serviceWithZIO[Redis](_.hStrLen(key, it._1))))
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/hash/HValsBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/hash/HValsBenchmarks.scala
@@ -40,7 +40,7 @@ class HValsBenchmarks extends BenchmarkRuntime {
   @Setup(Level.Trial)
   def setup(): Unit = {
     items = (0 to size).map(e => e.toString -> e.toString).toList
-    execute(hSet(key, items.head, items.tail: _*).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.hSet(key, items.head, items.tail: _*).unit))
   }
 
   @Benchmark
@@ -67,5 +67,5 @@ class HValsBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(_ => hVals(key).returning[String]))
+  def zio(): Unit = execute(ZIO.foreachDiscard(items)(_ => ZIO.serviceWithZIO[Redis](_.hVals(key).returning[String])))
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/lists/BlMoveBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/lists/BlMoveBenchmarks.scala
@@ -41,15 +41,15 @@ class BlMoveBenchmarks extends BenchmarkRuntime {
   @Setup(Level.Trial)
   def setup(): Unit = {
     items = (0 to count).toList.map(_.toString)
-    execute(rPush(key, items.head, items.tail: _*).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.rPush(key, items.head, items.tail: _*).unit))
   }
 
   @TearDown(Level.Trial)
   def tearDown(): Unit =
-    execute(del(key).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.del(key).unit))
 
   @Benchmark
   def zio(): Unit = execute(
-    ZIO.foreachDiscard(items)(_ => blMove(key, key, Side.Left, Side.Right, 1.second).returning[String])
+    ZIO.foreachDiscard(items)(_ => ZIO.serviceWithZIO[Redis](_.blMove(key, key, Side.Left, Side.Right, 1.second).returning[String]))
   )
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/lists/BlMoveBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/lists/BlMoveBenchmarks.scala
@@ -50,6 +50,8 @@ class BlMoveBenchmarks extends BenchmarkRuntime {
 
   @Benchmark
   def zio(): Unit = execute(
-    ZIO.foreachDiscard(items)(_ => ZIO.serviceWithZIO[Redis](_.blMove(key, key, Side.Left, Side.Right, 1.second).returning[String]))
+    ZIO.foreachDiscard(items)(_ =>
+      ZIO.serviceWithZIO[Redis](_.blMove(key, key, Side.Left, Side.Right, 1.second).returning[String])
+    )
   )
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/lists/BlPopBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/lists/BlPopBenchmarks.scala
@@ -40,7 +40,7 @@ class BlPopBenchmarks extends BenchmarkRuntime {
   @Setup(Level.Invocation)
   def setup(): Unit = {
     items = (0 to count).toList.map(_.toString)
-    execute(rPush(key, items.head, items.tail: _*).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.rPush(key, items.head, items.tail: _*).unit))
   }
 
   @Benchmark
@@ -76,5 +76,7 @@ class BlPopBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(_ => blPop(key)(1.second).returning[String]))
+  def zio(): Unit = execute(
+    ZIO.foreachDiscard(items)(_ => ZIO.serviceWithZIO[Redis](_.blPop(key)(1.second).returning[String]))
+  )
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/lists/BrPopBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/lists/BrPopBenchmarks.scala
@@ -40,7 +40,7 @@ class BrPopBenchmarks extends BenchmarkRuntime {
   @Setup(Level.Invocation)
   def setup(): Unit = {
     items = (0 to count).toList.map(_.toString)
-    execute(rPush(key, items.head, items.tail: _*).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.rPush(key, items.head, items.tail: _*).unit))
   }
 
   @Benchmark
@@ -76,5 +76,7 @@ class BrPopBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(_ => brPop(key)(1.second).returning[String]))
+  def zio(): Unit = execute(
+    ZIO.foreachDiscard(items)(_ => ZIO.serviceWithZIO[Redis](_.brPop(key)(1.second).returning[String]))
+  )
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/lists/BrPopLPushBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/lists/BrPopLPushBenchmarks.scala
@@ -40,12 +40,12 @@ class BrPopLPushBenchmarks extends BenchmarkRuntime {
   @Setup(Level.Trial)
   def setup(): Unit = {
     items = (0 to count).toList.map(_.toString)
-    execute(rPush(key, items.head, items.tail: _*).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.rPush(key, items.head, items.tail: _*).unit))
   }
 
   @TearDown(Level.Trial)
   def tearDown(): Unit =
-    execute(del(key).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.del(key).unit))
 
   @Benchmark
   def laserdisc(): Unit = {
@@ -82,6 +82,6 @@ class BrPopLPushBenchmarks extends BenchmarkRuntime {
 
   @Benchmark
   def zio(): Unit = execute(
-    ZIO.foreachDiscard(items)(_ => brPopLPush(key, key, 1.second).returning[String])
+    ZIO.foreachDiscard(items)(_ => ZIO.serviceWithZIO[Redis](_.brPopLPush(key, key, 1.second).returning[String]))
   )
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/lists/LIndexBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/lists/LIndexBenchmarks.scala
@@ -76,5 +76,7 @@ class LIndexBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(i => ZIO.serviceWithZIO[Redis](_.lIndex(key, i.toLong).returning[String])))
+  def zio(): Unit = execute(
+    ZIO.foreachDiscard(items)(i => ZIO.serviceWithZIO[Redis](_.lIndex(key, i.toLong).returning[String]))
+  )
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/lists/LIndexBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/lists/LIndexBenchmarks.scala
@@ -40,12 +40,12 @@ class LIndexBenchmarks extends BenchmarkRuntime {
   @Setup(Level.Trial)
   def setup(): Unit = {
     items = (0 to count).toList
-    execute(rPush(key, items.head, items.tail: _*).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.rPush(key, items.head, items.tail: _*).unit))
   }
 
   @TearDown(Level.Trial)
   def tearDown(): Unit =
-    execute(del(key).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.del(key).unit))
 
   @Benchmark
   def laserdisc(): Unit = {
@@ -76,5 +76,5 @@ class LIndexBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(i => lIndex(key, i.toLong).returning[String]))
+  def zio(): Unit = execute(ZIO.foreachDiscard(items)(i => ZIO.serviceWithZIO[Redis](_.lIndex(key, i.toLong).returning[String])))
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/lists/LInsertBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/lists/LInsertBenchmarks.scala
@@ -77,5 +77,7 @@ class LInsertBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(i => ZIO.serviceWithZIO[Redis](_.lInsert[String, String](key, Position.Before, i, i))))
+  def zio(): Unit = execute(
+    ZIO.foreachDiscard(items)(i => ZIO.serviceWithZIO[Redis](_.lInsert[String, String](key, Position.Before, i, i)))
+  )
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/lists/LInsertBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/lists/LInsertBenchmarks.scala
@@ -40,12 +40,12 @@ class LInsertBenchmarks extends BenchmarkRuntime {
   @Setup(Level.Invocation)
   def setup(): Unit = {
     items = (0 to count).toList.map(_.toString)
-    execute(rPush(key, items.head, items.tail: _*).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.rPush(key, items.head, items.tail: _*).unit))
   }
 
   @TearDown(Level.Invocation)
   def tearDown(): Unit =
-    execute(del(key).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.del(key).unit))
 
   @Benchmark
   def laserdisc(): Unit = {
@@ -77,5 +77,5 @@ class LInsertBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(i => lInsert[String, String](key, Position.Before, i, i)))
+  def zio(): Unit = execute(ZIO.foreachDiscard(items)(i => ZIO.serviceWithZIO[Redis](_.lInsert[String, String](key, Position.Before, i, i))))
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/lists/LLenBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/lists/LLenBenchmarks.scala
@@ -68,5 +68,5 @@ class LLenBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(_ => lLen[String](key)))
+  def zio(): Unit = execute(ZIO.foreachDiscard(items)(_ => ZIO.serviceWithZIO[Redis](_.lLen[String](key))))
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/lists/LMoveBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/lists/LMoveBenchmarks.scala
@@ -49,6 +49,8 @@ class LMoveBenchmarks extends BenchmarkRuntime {
 
   @Benchmark
   def zio(): Unit = execute(
-    ZIO.foreachDiscard(items)(_ => ZIO.serviceWithZIO[Redis](_.lMove(key, key, Side.Left, Side.Right).returning[String]))
+    ZIO.foreachDiscard(items)(_ =>
+      ZIO.serviceWithZIO[Redis](_.lMove(key, key, Side.Left, Side.Right).returning[String])
+    )
   )
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/lists/LMoveBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/lists/LMoveBenchmarks.scala
@@ -40,15 +40,15 @@ class LMoveBenchmarks extends BenchmarkRuntime {
   @Setup(Level.Trial)
   def setup(): Unit = {
     items = (0 to count).toList.map(_.toString)
-    execute(rPush(key, items.head, items.tail: _*).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.rPush(key, items.head, items.tail: _*).unit))
   }
 
   @TearDown(Level.Trial)
   def tearDown(): Unit =
-    execute(del(key).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.del(key).unit))
 
   @Benchmark
   def zio(): Unit = execute(
-    ZIO.foreachDiscard(items)(_ => lMove(key, key, Side.Left, Side.Right).returning[String])
+    ZIO.foreachDiscard(items)(_ => ZIO.serviceWithZIO[Redis](_.lMove(key, key, Side.Left, Side.Right).returning[String]))
   )
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/lists/LPopBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/lists/LPopBenchmarks.scala
@@ -40,7 +40,7 @@ class LPopBenchmarks extends BenchmarkRuntime {
   @Setup(Level.Invocation)
   def setup(): Unit = {
     items = (0 to count).toList.map(_.toString)
-    execute(rPush(key, items.head, items.tail: _*).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.rPush(key, items.head, items.tail: _*).unit))
   }
 
   @Benchmark
@@ -70,5 +70,5 @@ class LPopBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(_ => lPop(key).returning[String]))
+  def zio(): Unit = execute(ZIO.foreachDiscard(items)(_ => ZIO.serviceWithZIO[Redis](_.lPop(key).returning[String])))
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/lists/LPosBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/lists/LPosBenchmarks.scala
@@ -40,13 +40,13 @@ class LPosBenchmarks extends BenchmarkRuntime {
   @Setup(Level.Trial)
   def setup(): Unit = {
     items = (0 to count).toList.map(_.toString)
-    execute(rPush(key, items.head, items.tail: _*).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.rPush(key, items.head, items.tail: _*).unit))
   }
 
   @TearDown(Level.Trial)
   def tearDown(): Unit =
-    execute(del(key).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.del(key).unit))
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(i => lPos[String, String](key, i)))
+  def zio(): Unit = execute(ZIO.foreachDiscard(items)(i => ZIO.serviceWithZIO[Redis](_.lPos[String, String](key, i))))
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/lists/LPosCountBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/lists/LPosCountBenchmarks.scala
@@ -40,13 +40,13 @@ class LPosCountBenchmarks extends BenchmarkRuntime {
   @Setup(Level.Trial)
   def setup(): Unit = {
     items = (0 to count).toList.map(_.toString)
-    execute(rPush(key, items.head, items.tail: _*).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.rPush(key, items.head, items.tail: _*).unit))
   }
 
   @TearDown(Level.Trial)
   def tearDown(): Unit =
-    execute(del(key).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.del(key).unit))
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(i => lPosCount[String, String](key, i, Count(0L))))
+  def zio(): Unit = execute(ZIO.foreachDiscard(items)(i => ZIO.serviceWithZIO[Redis](_.lPosCount[String, String](key, i, Count(0L)))))
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/lists/LPosCountBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/lists/LPosCountBenchmarks.scala
@@ -48,5 +48,7 @@ class LPosCountBenchmarks extends BenchmarkRuntime {
     execute(ZIO.serviceWithZIO[Redis](_.del(key).unit))
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(i => ZIO.serviceWithZIO[Redis](_.lPosCount[String, String](key, i, Count(0L)))))
+  def zio(): Unit = execute(
+    ZIO.foreachDiscard(items)(i => ZIO.serviceWithZIO[Redis](_.lPosCount[String, String](key, i, Count(0L))))
+  )
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/lists/LPushBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/lists/LPushBenchmarks.scala
@@ -43,7 +43,7 @@ class LPushBenchmarks extends BenchmarkRuntime {
 
   @TearDown(Level.Invocation)
   def tearDown(): Unit =
-    execute(del(key).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.del(key).unit))
 
   @Benchmark
   def laserdisc(): Unit = {
@@ -72,5 +72,5 @@ class LPushBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(i => lPush[String, String](key, i)))
+  def zio(): Unit = execute(ZIO.foreachDiscard(items)(i => ZIO.serviceWithZIO[Redis](_.lPush[String, String](key, i))))
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/lists/LPushXBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/lists/LPushXBenchmarks.scala
@@ -40,12 +40,12 @@ class LPushXBenchmarks extends BenchmarkRuntime {
   @Setup(Level.Invocation)
   def setup(): Unit = {
     items = (0 to count).toList.map(_.toString)
-    execute(rPush(key, items.head).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.rPush(key, items.head).unit))
   }
 
   @TearDown(Level.Invocation)
   def tearDown(): Unit =
-    execute(del(key).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.del(key).unit))
 
   @Benchmark
   def laserdisc(): Unit = {
@@ -74,5 +74,5 @@ class LPushXBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(i => lPushX[String, String](key, i)))
+  def zio(): Unit = execute(ZIO.foreachDiscard(items)(i => ZIO.serviceWithZIO[Redis](_.lPushX[String, String](key, i))))
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/lists/LRangeBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/lists/LRangeBenchmarks.scala
@@ -40,12 +40,12 @@ class LRangeBenchmarks extends BenchmarkRuntime {
   @Setup(Level.Trial)
   def setup(): Unit = {
     items = (0 to count).toList
-    execute(rPush(key, items.head, items.tail: _*).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.rPush(key, items.head, items.tail: _*).unit))
   }
 
   @TearDown(Level.Trial)
   def tearDown(): Unit =
-    execute(del(key).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.del(key).unit))
 
   @Benchmark
   def laserdisc(): Unit = {
@@ -76,5 +76,7 @@ class LRangeBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(i => lRange(key, 0 to i).returning[String]))
+  def zio(): Unit = execute(
+    ZIO.foreachDiscard(items)(i => ZIO.serviceWithZIO[Redis](_.lRange(key, 0 to i).returning[String]))
+  )
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/lists/LRemBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/lists/LRemBenchmarks.scala
@@ -40,7 +40,7 @@ class LRemBenchmarks extends BenchmarkRuntime {
   @Setup(Level.Invocation)
   def setup(): Unit = {
     items = (0 to count).toList.map(_.toString)
-    execute(rPush(key, items.head, items.tail: _*).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.rPush(key, items.head, items.tail: _*).unit))
   }
 
   @Benchmark
@@ -70,5 +70,5 @@ class LRemBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(i => lRem[String](key, 0, i)))
+  def zio(): Unit = execute(ZIO.foreachDiscard(items)(i => ZIO.serviceWithZIO[Redis](_.lRem[String](key, 0, i))))
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/lists/LSetBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/lists/LSetBenchmarks.scala
@@ -40,12 +40,12 @@ class LSetBenchmarks extends BenchmarkRuntime {
   @Setup(Level.Trial)
   def setup(): Unit = {
     items = (0 to count).toList.map(_.toLong)
-    execute(rPush(key, items.head, items.tail: _*).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.rPush(key, items.head, items.tail: _*).unit))
   }
 
   @TearDown(Level.Trial)
   def tearDown(): Unit =
-    execute(del(key).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.del(key).unit))
 
   @Benchmark
   def laserdisc(): Unit = {
@@ -76,5 +76,7 @@ class LSetBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(i => lSet[String, String](key, i, i.toString)))
+  def zio(): Unit = execute(
+    ZIO.foreachDiscard(items)(i => ZIO.serviceWithZIO[Redis](_.lSet[String, String](key, i, i.toString)))
+  )
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/lists/LTrimBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/lists/LTrimBenchmarks.scala
@@ -40,7 +40,7 @@ class LTrimBenchmarks extends BenchmarkRuntime {
   @Setup(Level.Invocation)
   def setup(): Unit = {
     items = (count to 0 by -1).toList
-    execute(rPush(key, items.head, items.tail: _*).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.rPush(key, items.head, items.tail: _*).unit))
   }
 
   @Benchmark
@@ -72,5 +72,5 @@ class LTrimBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(i => lTrim[String](key, 1 to i)))
+  def zio(): Unit = execute(ZIO.foreachDiscard(items)(i => ZIO.serviceWithZIO[Redis](_.lTrim[String](key, 1 to i))))
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/lists/RPopBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/lists/RPopBenchmarks.scala
@@ -40,7 +40,7 @@ class RPopBenchmarks extends BenchmarkRuntime {
   @Setup(Level.Invocation)
   def setup(): Unit = {
     items = (0 to count).toList.map(_.toString)
-    execute(rPush(key, items.head, items.tail: _*).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.rPush(key, items.head, items.tail: _*).unit))
   }
 
   @Benchmark
@@ -70,5 +70,5 @@ class RPopBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(_ => rPop(key).returning[String]))
+  def zio(): Unit = execute(ZIO.foreachDiscard(items)(_ => ZIO.serviceWithZIO[Redis](_.rPop(key).returning[String])))
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/lists/RPopLPushBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/lists/RPopLPushBenchmarks.scala
@@ -40,12 +40,12 @@ class RPopLPushBenchmarks extends BenchmarkRuntime {
   @Setup(Level.Trial)
   def setup(): Unit = {
     items = (0 to count).toList.map(_.toString)
-    execute(rPush(key, items.head, items.tail: _*).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.rPush(key, items.head, items.tail: _*).unit))
   }
 
   @TearDown(Level.Trial)
   def tearDown(): Unit =
-    execute(del(key).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.del(key).unit))
 
   @Benchmark
   def laserdisc(): Unit = {
@@ -77,6 +77,6 @@ class RPopLPushBenchmarks extends BenchmarkRuntime {
 
   @Benchmark
   def zio(): Unit = execute(
-    ZIO.foreachDiscard(items)(_ => rPopLPush(key, key).returning[String])
+    ZIO.foreachDiscard(items)(_ => ZIO.serviceWithZIO[Redis](_.rPopLPush(key, key).returning[String]))
   )
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/lists/RPushBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/lists/RPushBenchmarks.scala
@@ -43,7 +43,7 @@ class RPushBenchmarks extends BenchmarkRuntime {
 
   @TearDown(Level.Invocation)
   def tearDown(): Unit =
-    execute(del(key).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.del(key).unit))
 
   @Benchmark
   def laserdisc(): Unit = {
@@ -72,5 +72,5 @@ class RPushBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(i => rPush[String, String](key, i)))
+  def zio(): Unit = execute(ZIO.foreachDiscard(items)(i => ZIO.serviceWithZIO[Redis](_.rPush[String, String](key, i))))
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/lists/RPushXBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/lists/RPushXBenchmarks.scala
@@ -40,12 +40,12 @@ class RPushXBenchmarks extends BenchmarkRuntime {
   @Setup(Level.Invocation)
   def setup(): Unit = {
     items = (0 to count).toList.map(_.toString)
-    execute(rPush(key, items.head).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.rPush(key, items.head).unit))
   }
 
   @TearDown(Level.Invocation)
   def tearDown(): Unit =
-    execute(del(key).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.del(key).unit))
 
   @Benchmark
   def laserdisc(): Unit = {
@@ -74,5 +74,5 @@ class RPushXBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(i => rPushX[String, String](key, i)))
+  def zio(): Unit = execute(ZIO.foreachDiscard(items)(i => ZIO.serviceWithZIO[Redis](_.rPushX[String, String](key, i))))
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/sets/SAddBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/sets/SAddBenchmarks.scala
@@ -67,5 +67,5 @@ class SAddBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(i => sAdd(key, i)))
+  def zio(): Unit = execute(ZIO.foreachDiscard(items)(i => ZIO.serviceWithZIO[Redis](_.sAdd(key, i))))
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/sets/SCardBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/sets/SCardBenchmarks.scala
@@ -41,7 +41,7 @@ class SCardBenchmarks extends BenchmarkRuntime {
   @Setup(Level.Trial)
   def setup(): Unit = {
     items = (0 to count).toList.map(_.toString)
-    execute(sAdd(key, items.head, items.tail: _*).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.sAdd(key, items.head, items.tail: _*).unit))
   }
 
   @Benchmark
@@ -69,5 +69,5 @@ class SCardBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(_ => sCard(key)))
+  def zio(): Unit = execute(ZIO.foreachDiscard(items)(_ => ZIO.serviceWithZIO[Redis](_.sCard(key))))
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/sets/SDiffBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/sets/SDiffBenchmarks.scala
@@ -44,8 +44,8 @@ class SDiffBenchmarks extends BenchmarkRuntime {
   def setup(): Unit = {
     items = (0 to count).toList.map(_.toString)
     otherItems = (0 to count).toList.map(_.toString)
-    execute(sAdd(key, items.head, items.tail: _*).unit)
-    execute(sAdd(otherKey, otherItems.head, otherItems.tail: _*).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.sAdd(key, items.head, items.tail: _*).unit))
+    execute(ZIO.serviceWithZIO[Redis](_.sAdd(otherKey, otherItems.head, otherItems.tail: _*).unit))
 
   }
 
@@ -76,5 +76,5 @@ class SDiffBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(_ => sDiff(key, otherKey).returning[String]))
+  def zio(): Unit = execute(ZIO.foreachDiscard(items)(_ => ZIO.serviceWithZIO[Redis](_.sDiff(key, otherKey).returning[String])))
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/sets/SDiffBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/sets/SDiffBenchmarks.scala
@@ -76,5 +76,7 @@ class SDiffBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(_ => ZIO.serviceWithZIO[Redis](_.sDiff(key, otherKey).returning[String])))
+  def zio(): Unit = execute(
+    ZIO.foreachDiscard(items)(_ => ZIO.serviceWithZIO[Redis](_.sDiff(key, otherKey).returning[String]))
+  )
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/sets/SDiffStoreBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/sets/SDiffStoreBenchmarks.scala
@@ -45,8 +45,8 @@ class SDiffStoreBenchmarks extends BenchmarkRuntime {
   def setup(): Unit = {
     items = (0 to count).toList.map(_.toString)
     otherItems = (0 to count).toList.map(_.toString)
-    execute(sAdd(key, items.head, items.tail: _*).unit)
-    execute(sAdd(otherKey, otherItems.head, otherItems.tail: _*).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.sAdd(key, items.head, items.tail: _*).unit))
+    execute(ZIO.serviceWithZIO[Redis](_.sAdd(otherKey, otherItems.head, otherItems.tail: _*).unit))
 
   }
 
@@ -81,5 +81,7 @@ class SDiffStoreBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(_ => sDiffStore(destinationKey, key, otherKey)))
+  def zio(): Unit = execute(
+    ZIO.foreachDiscard(items)(_ => ZIO.serviceWithZIO[Redis](_.sDiffStore(destinationKey, key, otherKey)))
+  )
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/sets/SInterBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/sets/SInterBenchmarks.scala
@@ -76,5 +76,7 @@ class SInterBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(_ => ZIO.serviceWithZIO[Redis](_.sInter(key, otherKey).returning[String])))
+  def zio(): Unit = execute(
+    ZIO.foreachDiscard(items)(_ => ZIO.serviceWithZIO[Redis](_.sInter(key, otherKey).returning[String]))
+  )
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/sets/SInterBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/sets/SInterBenchmarks.scala
@@ -44,8 +44,8 @@ class SInterBenchmarks extends BenchmarkRuntime {
   def setup(): Unit = {
     items = (0 to count).toList.map(_.toString)
     otherItems = (0 to count).toList.map(_.toString)
-    execute(sAdd(key, items.head, items.tail: _*).unit)
-    execute(sAdd(otherKey, otherItems.head, otherItems.tail: _*).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.sAdd(key, items.head, items.tail: _*).unit))
+    execute(ZIO.serviceWithZIO[Redis](_.sAdd(otherKey, otherItems.head, otherItems.tail: _*).unit))
 
   }
 
@@ -76,5 +76,5 @@ class SInterBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(_ => sInter(key, otherKey).returning[String]))
+  def zio(): Unit = execute(ZIO.foreachDiscard(items)(_ => ZIO.serviceWithZIO[Redis](_.sInter(key, otherKey).returning[String])))
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/sets/SInterStoreBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/sets/SInterStoreBenchmarks.scala
@@ -45,8 +45,8 @@ class SInterStoreBenchmarks extends BenchmarkRuntime {
   def setup(): Unit = {
     items = (0 to count).toList.map(_.toString)
     otherItems = (0 to count).toList.map(_.toString)
-    execute(sAdd(key, items.head, items.tail: _*).unit)
-    execute(sAdd(otherKey, otherItems.head, otherItems.tail: _*).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.sAdd(key, items.head, items.tail: _*).unit))
+    execute(ZIO.serviceWithZIO[Redis](_.sAdd(otherKey, otherItems.head, otherItems.tail: _*).unit))
 
   }
 
@@ -81,5 +81,7 @@ class SInterStoreBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(_ => sInterStore(destinationKey, key, otherKey)))
+  def zio(): Unit = execute(
+    ZIO.foreachDiscard(items)(_ => ZIO.serviceWithZIO[Redis](_.sInterStore(destinationKey, key, otherKey)))
+  )
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/sets/SIsMemberBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/sets/SIsMemberBenchmarks.scala
@@ -41,7 +41,7 @@ class SIsMemberBenchmarks extends BenchmarkRuntime {
   @Setup(Level.Trial)
   def setup(): Unit = {
     items = (0 to count).toList.map(_.toString)
-    execute(sAdd(key, items.head, items.tail: _*).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.sAdd(key, items.head, items.tail: _*).unit))
   }
 
   @Benchmark
@@ -69,5 +69,5 @@ class SIsMemberBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(i => sIsMember(key, i)))
+  def zio(): Unit = execute(ZIO.foreachDiscard(items)(i => ZIO.serviceWithZIO[Redis](_.sIsMember(key, i))))
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/sets/SMembersBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/sets/SMembersBenchmarks.scala
@@ -40,7 +40,7 @@ class SMembersBenchmarks extends BenchmarkRuntime {
   @Setup(Level.Trial)
   def setup(): Unit = {
     items = (0 to count).toList.map(_.toString)
-    execute(sAdd(key, items.head, items.tail: _*).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.sAdd(key, items.head, items.tail: _*).unit))
   }
 
   @Benchmark
@@ -68,5 +68,5 @@ class SMembersBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(_ => sMembers(key).returning[String]))
+  def zio(): Unit = execute(ZIO.foreachDiscard(items)(_ => ZIO.serviceWithZIO[Redis](_.sMembers(key).returning[String])))
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/sets/SMembersBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/sets/SMembersBenchmarks.scala
@@ -68,5 +68,7 @@ class SMembersBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(_ => ZIO.serviceWithZIO[Redis](_.sMembers(key).returning[String])))
+  def zio(): Unit = execute(
+    ZIO.foreachDiscard(items)(_ => ZIO.serviceWithZIO[Redis](_.sMembers(key).returning[String]))
+  )
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/sets/SMoveBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/sets/SMoveBenchmarks.scala
@@ -42,7 +42,7 @@ class SMoveBenchmarks extends BenchmarkRuntime {
   @Setup(Level.Trial)
   def setup(): Unit = {
     items = (0 to count).toList.map(_.toString)
-    execute(sAdd(key, items.head, items.tail: _*).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.sAdd(key, items.head, items.tail: _*).unit))
   }
 
   @Benchmark
@@ -72,5 +72,5 @@ class SMoveBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(i => sMove(key, destinationKey, i)))
+  def zio(): Unit = execute(ZIO.foreachDiscard(items)(i => ZIO.serviceWithZIO[Redis](_.sMove(key, destinationKey, i))))
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/sets/SPopBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/sets/SPopBenchmarks.scala
@@ -41,7 +41,7 @@ class SPopBenchmarks extends BenchmarkRuntime {
   @Setup(Level.Trial)
   def setup(): Unit = {
     items = (0 to count).toList.map(_.toString)
-    execute(sAdd(key, items.head, items.tail: _*).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.sAdd(key, items.head, items.tail: _*).unit))
   }
 
   @Benchmark
@@ -69,5 +69,5 @@ class SPopBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(_ => sPop(key).returning[String]))
+  def zio(): Unit = execute(ZIO.foreachDiscard(items)(_ => ZIO.serviceWithZIO[Redis](_.sPop(key).returning[String])))
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/sets/SRandMemberBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/sets/SRandMemberBenchmarks.scala
@@ -41,7 +41,7 @@ class SRandMemberBenchmarks extends BenchmarkRuntime {
   @Setup(Level.Trial)
   def setup(): Unit = {
     items = (0 to count).toList.map(_.toString)
-    execute(sAdd(key, items.head, items.tail: _*).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.sAdd(key, items.head, items.tail: _*).unit))
   }
 
   @Benchmark
@@ -69,5 +69,7 @@ class SRandMemberBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(_ => sRandMember(key).returning[String]))
+  def zio(): Unit = execute(
+    ZIO.foreachDiscard(items)(_ => ZIO.serviceWithZIO[Redis](_.sRandMember(key).returning[String]))
+  )
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/sets/SRemBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/sets/SRemBenchmarks.scala
@@ -41,7 +41,7 @@ class SRemBenchmarks extends BenchmarkRuntime {
   @Setup(Level.Trial)
   def setup(): Unit = {
     items = (0 to count).toList.map(_.toString)
-    execute(sAdd(key, items.head, items.tail: _*).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.sAdd(key, items.head, items.tail: _*).unit))
   }
 
   @Benchmark
@@ -69,5 +69,5 @@ class SRemBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(i => sRem(key, i)))
+  def zio(): Unit = execute(ZIO.foreachDiscard(items)(i => ZIO.serviceWithZIO[Redis](_.sRem(key, i))))
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/sets/SUnionBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/sets/SUnionBenchmarks.scala
@@ -44,8 +44,8 @@ class SUnionBenchmarks extends BenchmarkRuntime {
   def setup(): Unit = {
     items = (0 to count).toList.map(_.toString)
     otherItems = (0 to count).toList.map(_.toString)
-    execute(sAdd(key, items.head, items.tail: _*).unit)
-    execute(sAdd(otherKey, otherItems.head, otherItems.tail: _*).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.sAdd(key, items.head, items.tail: _*).unit))
+    execute(ZIO.serviceWithZIO[Redis](_.sAdd(otherKey, otherItems.head, otherItems.tail: _*).unit))
   }
 
   @Benchmark
@@ -75,5 +75,7 @@ class SUnionBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(_ => sUnion(key, otherKey).returning[String]))
+  def zio(): Unit = execute(
+    ZIO.foreachDiscard(items)(_ => ZIO.serviceWithZIO[Redis](_.sUnion(key, otherKey).returning[String]))
+  )
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/sets/SUnionStoreBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/sets/SUnionStoreBenchmarks.scala
@@ -45,8 +45,8 @@ class SUnionStoreBenchmarks extends BenchmarkRuntime {
   def setup(): Unit = {
     items = (0 to count).toList.map(_.toString)
     otherItems = (0 to count).toList.map(_.toString)
-    execute(sAdd(key, items.head, items.tail: _*).unit)
-    execute(sAdd(otherKey, otherItems.head, otherItems.tail: _*).unit)
+    execute(ZIO.serviceWithZIO[Redis](_.sAdd(key, items.head, items.tail: _*).unit))
+    execute(ZIO.serviceWithZIO[Redis](_.sAdd(otherKey, otherItems.head, otherItems.tail: _*).unit))
 
   }
 
@@ -81,5 +81,7 @@ class SUnionStoreBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(_ => sUnionStore(destinationKey, key, otherKey)))
+  def zio(): Unit = execute(
+    ZIO.foreachDiscard(items)(_ => ZIO.serviceWithZIO[Redis](_.sUnionStore(destinationKey, key, otherKey)))
+  )
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/strings/AppendBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/strings/AppendBenchmarks.scala
@@ -42,7 +42,7 @@ class AppendBenchmarks extends BenchmarkRuntime {
   @Setup(Level.Trial)
   def setup(): Unit = {
     items = (0 to count).toList.map(_.toString)
-    execute(ZIO.foreachDiscard(items)(i => set(i, i)))
+    execute(ZIO.foreachDiscard(items)(i => ZIO.serviceWithZIO[Redis](_.set(i, i))))
   }
 
   @Benchmark
@@ -61,5 +61,5 @@ class AppendBenchmarks extends BenchmarkRuntime {
     execute[Redis4CatsClient[String]](c => items.traverse_(i => c.append(i, i)))
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(i => append(i, i)))
+  def zio(): Unit = execute(ZIO.foreachDiscard(items)(i => ZIO.serviceWithZIO[Redis](_.append(i, i))))
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/strings/DecrBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/strings/DecrBenchmarks.scala
@@ -42,7 +42,7 @@ class DecrBenchmarks extends BenchmarkRuntime {
   @Setup(Level.Trial)
   def setup(): Unit = {
     items = (0 to count).toList.map(_.toString)
-    execute(ZIO.foreachDiscard(items)(i => set(i, i)))
+    execute(ZIO.foreachDiscard(items)(i => ZIO.serviceWithZIO[Redis](_.set(i, i))))
   }
 
   @Benchmark
@@ -61,5 +61,5 @@ class DecrBenchmarks extends BenchmarkRuntime {
     execute[Redis4CatsClient[Long]](c => items.traverse_(i => c.decr(i)))
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(i => decr(i)))
+  def zio(): Unit = execute(ZIO.foreachDiscard(items)(i => ZIO.serviceWithZIO[Redis](_.decr(i))))
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/strings/GetBitBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/strings/GetBitBenchmarks.scala
@@ -42,7 +42,7 @@ class GetBitBenchmarks extends BenchmarkRuntime {
   @Setup(Level.Trial)
   def setup(): Unit = {
     items = (0 to count).toList.map(_.toString)
-    execute(ZIO.foreachDiscard(items)(i => set(i, i)))
+    execute(ZIO.foreachDiscard(items)(i => ZIO.serviceWithZIO[Redis](_.set(i, i))))
   }
 
   @Benchmark
@@ -61,5 +61,5 @@ class GetBitBenchmarks extends BenchmarkRuntime {
     execute[Redis4CatsClient[String]](c => items.traverse_(i => c.getBit(i, 0L)))
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(i => getBit(i, 0L)))
+  def zio(): Unit = execute(ZIO.foreachDiscard(items)(i => ZIO.serviceWithZIO[Redis](_.getBit(i, 0L))))
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/strings/IncrBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/strings/IncrBenchmarks.scala
@@ -42,7 +42,7 @@ class IncrBenchmarks extends BenchmarkRuntime {
   @Setup(Level.Trial)
   def setup(): Unit = {
     items = (0 to count).toList.map(_.toString)
-    execute(ZIO.foreachDiscard(items)(i => set(i, i)))
+    execute(ZIO.foreachDiscard(items)(i => ZIO.serviceWithZIO[Redis](_.set(i, i))))
   }
 
   @Benchmark
@@ -62,5 +62,5 @@ class IncrBenchmarks extends BenchmarkRuntime {
     execute[Redis4CatsClient[Long]](c => items.traverse_(i => c.incr(i)))
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(i => incr(i)))
+  def zio(): Unit = execute(ZIO.foreachDiscard(items)(i => ZIO.serviceWithZIO[Redis](_.incr(i))))
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/strings/SetBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/strings/SetBenchmarks.scala
@@ -65,5 +65,5 @@ class SetBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(i => set(i, i)))
+  def zio(): Unit = execute(ZIO.foreachDiscard(items)(i => ZIO.serviceWithZIO[Redis](_.set(i, i))))
 }

--- a/benchmarks/src/main/scala/zio/redis/benchmarks/strings/StrLenBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/redis/benchmarks/strings/StrLenBenchmarks.scala
@@ -39,7 +39,7 @@ class StrLenBenchmarks extends BenchmarkRuntime {
   @Setup(Level.Trial)
   def setup(): Unit = {
     items = (0 to count).toList.map(_.toString)
-    execute(ZIO.foreachDiscard(items)(i => set(i, i)))
+    execute(ZIO.foreachDiscard(items)(i => ZIO.serviceWithZIO[Redis](_.set(i, i))))
   }
 
   @Benchmark
@@ -66,5 +66,5 @@ class StrLenBenchmarks extends BenchmarkRuntime {
   }
 
   @Benchmark
-  def zio(): Unit = execute(ZIO.foreachDiscard(items)(strLen[String]))
+  def zio(): Unit = execute(ZIO.serviceWithZIO[Redis](redis => ZIO.foreachDiscard(items)(redis.strLen[String])))
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,12 +51,13 @@ import zio.schema.codec._
 
 object ZIORedisExample extends ZIOAppDefault {
   val myApp: ZIO[Redis, RedisError, Unit] = for {
-    _ <- set("myKey", 8L, Some(1.minutes))
-    v <- get("myKey").returning[Long]
-    _ <- Console.printLine(s"Value of myKey: $v").orDie
-    _ <- hSet("myHash", ("k1", 6), ("k2", 2))
-    _ <- rPush("myList", 1, 2, 3, 4)
-    _ <- sAdd("mySet", "a", "b", "a", "c")
+    redis <- ZIO.service[Redis]
+    _     <- redis.set("myKey", 8L, Some(1.minutes))
+    v     <- redis.get("myKey").returning[Long]
+    _     <- Console.printLine(s"Value of myKey: $v").orDie
+    _     <- redis.hSet("myHash", ("k1", 6), ("k2", 2))
+    _     <- redis.rPush("myList", 1, 2, 3, 4)
+    _     <- redis.sAdd("mySet", "a", "b", "a", "c")
   } yield ()
 
   override def run = myApp.provide(

--- a/docs/index.md.bak
+++ b/docs/index.md.bak
@@ -51,12 +51,13 @@ import zio.schema.codec._
 
 object ZIORedisExample extends ZIOAppDefault {
   val myApp: ZIO[Redis, RedisError, Unit] = for {
-    _ <- set("myKey", 8L, Some(1.minutes))
-    v <- get("myKey").returning[Long]
-    _ <- Console.printLine(s"Value of myKey: $v").orDie
-    _ <- hSet("myHash", ("k1", 6), ("k2", 2))
-    _ <- rPush("myList", 1, 2, 3, 4)
-    _ <- sAdd("mySet", "a", "b", "a", "c")
+    redis <- ZIO.service[Redis]
+    _     <- redis.set("myKey", 8L, Some(1.minutes))
+    v     <- redis.get("myKey").returning[Long]
+    _     <- Console.printLine(s"Value of myKey: $v").orDie
+    _     <- redis.hSet("myHash", ("k1", 6), ("k2", 2))
+    _     <- redis.rPush("myList", 1, 2, 3, 4)
+    _     <- redis.sAdd("mySet", "a", "b", "a", "c")
   } yield ()
 
   override def run = myApp.provide(

--- a/example/src/main/scala/example/contributorsCache.scala
+++ b/example/src/main/scala/example/contributorsCache.scala
@@ -41,10 +41,7 @@ final case class ContributorsCacheLive(r: Redis, s: Sttp) extends ContributorsCa
 
   private def read(repository: Repository): ZIO[Redis, ApiError, Contributors] =
     ZIO
-      .serviceWithZIO[Redis](
-        _.get(repository.key)
-          .returning[String]
-      )
+      .serviceWithZIO[Redis](_.get(repository.key).returning[String])
       .someOrFail(ApiError.CacheMiss(repository.key))
       .map(_.fromJson[Contributors])
       .foldZIO(_ => ZIO.fail(ApiError.CorruptedData), s => ZIO.succeed(s.getOrElse(Contributors(Chunk.empty))))

--- a/redis/src/main/scala/zio/redis/ClusterExecutor.scala
+++ b/redis/src/main/scala/zio/redis/ClusterExecutor.scala
@@ -42,7 +42,7 @@ final case class ClusterExecutor(
     def executeAsk(address: RedisUri) =
       for {
         executor <- executor(address)
-        _        <- executor.execute(AskingCommand(this, StringUtf8Codec).resp(()))
+        _        <- executor.execute(AskingCommand(StringUtf8Codec, this).resp(()))
         res      <- executor.execute(command)
       } yield res
 

--- a/redis/src/main/scala/zio/redis/ClusterExecutor.scala
+++ b/redis/src/main/scala/zio/redis/ClusterExecutor.scala
@@ -19,7 +19,7 @@ package zio.redis
 import zio._
 import zio.redis.ClusterExecutor._
 import zio.redis.api.Cluster.AskingCommand
-import zio.redis.codec.StringUtf8Codec
+import zio.redis.codecs.StringUtf8Codec
 import zio.redis.options.Cluster._
 import zio.schema.codec.BinaryCodec
 
@@ -132,7 +132,7 @@ object ClusterExecutor {
     for {
       temporaryRedis    <- redis(address)
       (trLayer, trScope) = temporaryRedis
-      partitions        <- slots.provideLayer(trLayer)
+      partitions        <- ZIO.serviceWithZIO[Redis](_.slots).provideLayer(trLayer)
       _                 <- ZIO.logTrace(s"Cluster configs:\n${partitions.mkString("\n")}")
       uniqueAddresses    = partitions.map(_.master.address).distinct
       uriExecScope      <- ZIO.foreachPar(uniqueAddresses)(address => connectToNode(address).map(es => address -> es))

--- a/redis/src/main/scala/zio/redis/ClusterExecutor.scala
+++ b/redis/src/main/scala/zio/redis/ClusterExecutor.scala
@@ -42,7 +42,7 @@ final case class ClusterExecutor(
     def executeAsk(address: RedisUri) =
       for {
         executor <- executor(address)
-        _        <- executor.execute(AskingCommand.resp((), StringUtf8Codec))
+        _        <- executor.execute(AskingCommand(this, StringUtf8Codec).resp(()))
         res      <- executor.execute(command)
       } yield res
 

--- a/redis/src/main/scala/zio/redis/CommandExecutor.scala
+++ b/redis/src/main/scala/zio/redis/CommandExecutor.scala
@@ -1,9 +1,0 @@
-package zio.redis
-
-import zio.schema.codec.BinaryCodec
-
-trait CommandExecutor {
-  implicit def codec: BinaryCodec
-
-  implicit def executor: RedisExecutor
-}

--- a/redis/src/main/scala/zio/redis/CommandExecutor.scala
+++ b/redis/src/main/scala/zio/redis/CommandExecutor.scala
@@ -1,0 +1,9 @@
+package zio.redis
+
+import zio.schema.codec.BinaryCodec
+
+trait CommandExecutor {
+  implicit def codec: BinaryCodec
+
+  implicit def executor: RedisExecutor
+}

--- a/redis/src/main/scala/zio/redis/Redis.scala
+++ b/redis/src/main/scala/zio/redis/Redis.scala
@@ -19,7 +19,19 @@ package zio.redis
 import zio._
 import zio.schema.codec.BinaryCodec
 
-trait Redis {
+trait Redis
+    extends api.Connection
+    with api.Geo
+    with api.Hashes
+    with api.HyperLogLog
+    with api.Keys
+    with api.Lists
+    with api.Sets
+    with api.Strings
+    with api.SortedSets
+    with api.Streams
+    with api.Scripting
+    with api.Cluster {
   def codec: BinaryCodec
   def executor: RedisExecutor
 }

--- a/redis/src/main/scala/zio/redis/RedisCommand.scala
+++ b/redis/src/main/scala/zio/redis/RedisCommand.scala
@@ -30,6 +30,12 @@ final class RedisCommand[-In, +Out] private (val name: String, val input: Input[
       }
       .refineToOrDie[RedisError]
 
+  private[redis] def run(in: In)(implicit executor: RedisExecutor, codec: BinaryCodec): ZIO[Any, RedisError, Out] =
+    executor
+      .execute(resp(in, codec))
+      .flatMap[Any, Throwable, Out](out => ZIO.attempt(output.unsafeDecode(out)(codec)))
+      .refineToOrDie[RedisError]
+
   private[redis] def resp(in: In, codec: BinaryCodec): Chunk[RespValue.BulkString] =
     Varargs(StringInput).encode(name.split(" "))(codec) ++ input.encode(in)(codec)
 }

--- a/redis/src/main/scala/zio/redis/RedisCommand.scala
+++ b/redis/src/main/scala/zio/redis/RedisCommand.scala
@@ -20,9 +20,12 @@ import zio._
 import zio.redis.Input.{StringInput, Varargs}
 import zio.schema.codec.BinaryCodec
 
-final class RedisCommand[-In, +Out] private (val name: String, val input: Input[In], val output: Output[Out])(
-  val executor: RedisExecutor,
-  val codec: BinaryCodec
+final class RedisCommand[-In, +Out] private (
+  val name: String,
+  val input: Input[In],
+  val output: Output[Out],
+  val codec: BinaryCodec,
+  val executor: RedisExecutor
 ) {
 
   private[redis] def run(in: In): IO[RedisError, Out] =
@@ -36,9 +39,12 @@ final class RedisCommand[-In, +Out] private (val name: String, val input: Input[
 }
 
 object RedisCommand {
-  private[redis] def apply[In, Out](name: String, input: Input[In], output: Output[Out])(
-    executor: RedisExecutor,
-    codec: BinaryCodec
+  private[redis] def apply[In, Out](
+    name: String,
+    input: Input[In],
+    output: Output[Out],
+    codec: BinaryCodec,
+    executor: RedisExecutor
   ): RedisCommand[In, Out] =
-    new RedisCommand(name, input, output)(executor, codec)
+    new RedisCommand(name, input, output, codec, executor)
 }

--- a/redis/src/main/scala/zio/redis/RedisEnvironment.scala
+++ b/redis/src/main/scala/zio/redis/RedisEnvironment.scala
@@ -2,7 +2,7 @@ package zio.redis
 
 import zio.schema.codec.BinaryCodec
 
-trait RedisEnvironment {
+private[redis] trait RedisEnvironment {
   def codec: BinaryCodec
   def executor: RedisExecutor
 }

--- a/redis/src/main/scala/zio/redis/RedisEnvironment.scala
+++ b/redis/src/main/scala/zio/redis/RedisEnvironment.scala
@@ -1,0 +1,8 @@
+package zio.redis
+
+import zio.schema.codec.BinaryCodec
+
+trait RedisEnvironment {
+  def codec: BinaryCodec
+  def executor: RedisExecutor
+}

--- a/redis/src/main/scala/zio/redis/RespValue.scala
+++ b/redis/src/main/scala/zio/redis/RespValue.scala
@@ -17,7 +17,7 @@
 package zio.redis
 
 import zio._
-import zio.redis.codec.CRC16
+import zio.redis.codecs.CRC16
 import zio.redis.options.Cluster.Slot
 import zio.stream._
 

--- a/redis/src/main/scala/zio/redis/api/Cluster.scala
+++ b/redis/src/main/scala/zio/redis/api/Cluster.scala
@@ -26,7 +26,6 @@ import zio.{Chunk, ZIO}
 
 trait Cluster extends CommandExecutor {
 
-
   /**
    * When a cluster client receives an -ASK redirect, the ASKING command is sent to the target node followed by the
    * command which was redirected.

--- a/redis/src/main/scala/zio/redis/api/Cluster.scala
+++ b/redis/src/main/scala/zio/redis/api/Cluster.scala
@@ -24,7 +24,8 @@ import zio.redis.options.Cluster.SetSlotSubCommand._
 import zio.redis.options.Cluster.{Partition, Slot}
 import zio.{Chunk, ZIO}
 
-trait Cluster {
+trait Cluster extends CommandExecutor {
+
 
   /**
    * When a cluster client receives an -ASK redirect, the ASKING command is sent to the target node followed by the
@@ -33,7 +34,7 @@ trait Cluster {
    * @return
    *   the Unit value.
    */
-  def asking: ZIO[Redis, RedisError, Unit] =
+  def asking: ZIO[Any, RedisError, Unit] =
     AskingCommand.run(())
 
   /**
@@ -42,7 +43,7 @@ trait Cluster {
    * @return
    *   details about which cluster
    */
-  def slots: ZIO[Redis, RedisError, Chunk[Partition]] = {
+  def slots: ZIO[Any, RedisError, Chunk[Partition]] = {
     val command = RedisCommand(ClusterSlots, NoInput, ChunkOutput(ClusterPartitionOutput))
     command.run(())
   }
@@ -55,7 +56,7 @@ trait Cluster {
    * @return
    *   the Unit value.
    */
-  def setSlotStable(slot: Slot): ZIO[Redis, RedisError, Unit] = {
+  def setSlotStable(slot: Slot): ZIO[Any, RedisError, Unit] = {
     val command = RedisCommand(ClusterSetSlots, Tuple2(LongInput, ArbitraryInput[String]()), UnitOutput)
     command.run((slot.number, Stable.stringify))
   }
@@ -71,7 +72,7 @@ trait Cluster {
    * @return
    *   the Unit value.
    */
-  def setSlotMigrating(slot: Slot, nodeId: String): ZIO[Redis, RedisError, Unit] = {
+  def setSlotMigrating(slot: Slot, nodeId: String): ZIO[Any, RedisError, Unit] = {
     val command = RedisCommand(
       ClusterSetSlots,
       Tuple3(LongInput, ArbitraryInput[String](), ArbitraryInput[String]()),
@@ -91,7 +92,7 @@ trait Cluster {
    * @return
    *   the Unit value.
    */
-  def setSlotImporting(slot: Slot, nodeId: String): ZIO[Redis, RedisError, Unit] = {
+  def setSlotImporting(slot: Slot, nodeId: String): ZIO[Any, RedisError, Unit] = {
     val command = RedisCommand(
       ClusterSetSlots,
       Tuple3(LongInput, ArbitraryInput[String](), ArbitraryInput[String]()),
@@ -111,7 +112,7 @@ trait Cluster {
    * @return
    *   the Unit value.
    */
-  def setSlotNode(slot: Slot, nodeId: String): ZIO[Redis, RedisError, Unit] = {
+  def setSlotNode(slot: Slot, nodeId: String): ZIO[Any, RedisError, Unit] = {
     val command = RedisCommand(
       ClusterSetSlots,
       Tuple3(LongInput, ArbitraryInput[String](), ArbitraryInput[String]()),

--- a/redis/src/main/scala/zio/redis/api/Connection.scala
+++ b/redis/src/main/scala/zio/redis/api/Connection.scala
@@ -37,7 +37,7 @@ trait Connection extends RedisEnvironment {
    *   the server starts accepting commands. Otherwise, an error is returned and the client needs to try a new password.
    */
   final def auth(password: String): IO[RedisError, Unit] = {
-    val command = RedisCommand(Auth, StringInput, UnitOutput)(executor, codec)
+    val command = RedisCommand(Auth, StringInput, UnitOutput, codec, executor)
 
     command.run(password)
   }
@@ -52,7 +52,7 @@ trait Connection extends RedisEnvironment {
    *   the Unit value.
    */
   final def clientCaching(track: Boolean): IO[RedisError, Unit] = {
-    val command = RedisCommand(ClientCaching, YesNoInput, UnitOutput)(executor, codec)
+    val command = RedisCommand(ClientCaching, YesNoInput, UnitOutput, codec, executor)
 
     command.run(track)
   }
@@ -68,7 +68,7 @@ trait Connection extends RedisEnvironment {
    *   the ID of the current connection.
    */
   final def clientId: IO[RedisError, Long] = {
-    val command = RedisCommand(ClientId, NoInput, LongOutput)(executor, codec)
+    val command = RedisCommand(ClientId, NoInput, LongOutput, codec, executor)
 
     command.run(())
   }
@@ -82,7 +82,7 @@ trait Connection extends RedisEnvironment {
    *   the Unit value.
    */
   final def clientKill(address: Address): IO[RedisError, Unit] = {
-    val command = RedisCommand(ClientKill, AddressInput, UnitOutput)(executor, codec)
+    val command = RedisCommand(ClientKill, AddressInput, UnitOutput, codec, executor)
 
     command.run(address)
   }
@@ -108,7 +108,7 @@ trait Connection extends RedisEnvironment {
    *   the number of clients killed.
    */
   final def clientKill(filters: ClientKillFilter*): IO[RedisError, Long] = {
-    val command = RedisCommand(ClientKill, Varargs(ClientKillInput), LongOutput)(executor, codec)
+    val command = RedisCommand(ClientKill, Varargs(ClientKillInput), LongOutput, codec, executor)
 
     command.run(filters)
   }
@@ -120,7 +120,7 @@ trait Connection extends RedisEnvironment {
    *   the connection name, or None if a name wasn't set.
    */
   final def clientGetName: IO[RedisError, Option[String]] = {
-    val command = RedisCommand(ClientGetName, NoInput, OptionalOutput(MultiStringOutput))(executor, codec)
+    val command = RedisCommand(ClientGetName, NoInput, OptionalOutput(MultiStringOutput), codec, executor)
 
     command.run(())
   }
@@ -132,7 +132,7 @@ trait Connection extends RedisEnvironment {
    *   the client ID if the tracking is enabled and the notifications are being redirected
    */
   final def clientGetRedir: IO[RedisError, ClientTrackingRedirect] = {
-    val command = RedisCommand(ClientGetRedir, NoInput, ClientTrackingRedirectOutput)(executor, codec)
+    val command = RedisCommand(ClientGetRedir, NoInput, ClientTrackingRedirectOutput, codec, executor)
 
     command.run(())
   }
@@ -143,7 +143,7 @@ trait Connection extends RedisEnvironment {
    *   the Unit value.
    */
   final def clientUnpause: IO[RedisError, Unit] = {
-    val command = RedisCommand(ClientUnpause, NoInput, UnitOutput)(executor, codec)
+    val command = RedisCommand(ClientUnpause, NoInput, UnitOutput, codec, executor)
 
     command.run(())
   }
@@ -168,8 +168,10 @@ trait Connection extends RedisEnvironment {
     val command = RedisCommand(
       ClientPause,
       Tuple2(DurationMillisecondsInput, OptionalInput(ClientPauseModeInput)),
-      UnitOutput
-    )(executor, codec)
+      UnitOutput,
+      codec,
+      executor
+    )
 
     command.run((timeout, mode))
   }
@@ -183,7 +185,7 @@ trait Connection extends RedisEnvironment {
    *   the Unit value.
    */
   final def clientSetName(name: String): IO[RedisError, Unit] = {
-    val command = RedisCommand(ClientSetName, StringInput, UnitOutput)(executor, codec)
+    val command = RedisCommand(ClientSetName, StringInput, UnitOutput, codec, executor)
 
     command.run(name)
   }
@@ -209,7 +211,7 @@ trait Connection extends RedisEnvironment {
     noLoop: Boolean = false,
     prefixes: Set[String] = Set.empty
   ): IO[RedisError, Unit] = {
-    val command = RedisCommand(ClientTracking, ClientTrackingInput, UnitOutput)(executor, codec)
+    val command = RedisCommand(ClientTracking, ClientTrackingInput, UnitOutput, codec, executor)
     command.run(Some((redirect, trackingMode, noLoop, Chunk.fromIterable(prefixes))))
   }
 
@@ -220,7 +222,7 @@ trait Connection extends RedisEnvironment {
    *   the Unit value.
    */
   final def clientTrackingOff: IO[RedisError, Unit] = {
-    val command = RedisCommand(ClientTracking, ClientTrackingInput, UnitOutput)(executor, codec)
+    val command = RedisCommand(ClientTracking, ClientTrackingInput, UnitOutput, codec, executor)
     command.run(None)
   }
 
@@ -231,7 +233,7 @@ trait Connection extends RedisEnvironment {
    *   tracking information.
    */
   final def clientTrackingInfo: IO[RedisError, ClientTrackingInfo] = {
-    val command = RedisCommand(ClientTrackingInfo, NoInput, ClientTrackingInfoOutput)(executor, codec)
+    val command = RedisCommand(ClientTrackingInfo, NoInput, ClientTrackingInfoOutput, codec, executor)
 
     command.run(())
   }
@@ -251,7 +253,7 @@ trait Connection extends RedisEnvironment {
     error: Option[UnblockBehavior] = None
   ): IO[RedisError, Boolean] = {
     val command =
-      RedisCommand(ClientUnblock, Tuple2(LongInput, OptionalInput(UnblockBehaviorInput)), BoolOutput)(executor, codec)
+      RedisCommand(ClientUnblock, Tuple2(LongInput, OptionalInput(UnblockBehaviorInput)), BoolOutput, codec, executor)
 
     command.run((clientId, error))
   }
@@ -265,7 +267,7 @@ trait Connection extends RedisEnvironment {
    *   the message.
    */
   final def echo(message: String): IO[RedisError, String] = {
-    val command = RedisCommand(Echo, StringInput, MultiStringOutput)(executor, codec)
+    val command = RedisCommand(Echo, StringInput, MultiStringOutput, codec, executor)
 
     command.run(message)
   }
@@ -280,7 +282,7 @@ trait Connection extends RedisEnvironment {
    *   test if a connection is still alive, or to measure latency.
    */
   final def ping(message: Option[String] = None): IO[RedisError, String] = {
-    val command = RedisCommand(Ping, OptionalInput(StringInput), SingleOrMultiStringOutput)(executor, codec)
+    val command = RedisCommand(Ping, OptionalInput(StringInput), SingleOrMultiStringOutput, codec, executor)
 
     command.run(message)
   }
@@ -293,7 +295,7 @@ trait Connection extends RedisEnvironment {
    *   the Unit value.
    */
   final def quit: IO[RedisError, Unit] = {
-    val command = RedisCommand(Quit, NoInput, UnitOutput)(executor, codec)
+    val command = RedisCommand(Quit, NoInput, UnitOutput, codec, executor)
 
     command.run(())
   }
@@ -306,7 +308,7 @@ trait Connection extends RedisEnvironment {
    *   the Unit value.
    */
   final def reset: IO[RedisError, Unit] = {
-    val command = RedisCommand(Reset, NoInput, ResetOutput)(executor, codec)
+    val command = RedisCommand(Reset, NoInput, ResetOutput, codec, executor)
 
     command.run(())
   }
@@ -322,7 +324,7 @@ trait Connection extends RedisEnvironment {
    *   the Unit value.
    */
   final def select(index: Long): IO[RedisError, Unit] = {
-    val command = RedisCommand(Select, LongInput, UnitOutput)(executor, codec)
+    val command = RedisCommand(Select, LongInput, UnitOutput, codec, executor)
 
     command.run(index)
   }

--- a/redis/src/main/scala/zio/redis/api/Connection.scala
+++ b/redis/src/main/scala/zio/redis/api/Connection.scala
@@ -21,7 +21,7 @@ import zio.redis.Input._
 import zio.redis.Output._
 import zio.redis._
 
-trait Connection {
+trait Connection extends CommandExecutor {
   import Connection._
 
   /**
@@ -36,7 +36,7 @@ trait Connection {
    *   if the password provided via AUTH matches the password in the configuration file, the Unit value is returned and
    *   the server starts accepting commands. Otherwise, an error is returned and the client needs to try a new password.
    */
-  final def auth(password: String): ZIO[Redis, RedisError, Unit] = {
+  final def auth(password: String): ZIO[Any, RedisError, Unit] = {
     val command = RedisCommand(Auth, StringInput, UnitOutput)
 
     command.run(password)
@@ -51,7 +51,7 @@ trait Connection {
    * @return
    *   the Unit value.
    */
-  final def clientCaching(track: Boolean): ZIO[Redis, RedisError, Unit] = {
+  final def clientCaching(track: Boolean): ZIO[Any, RedisError, Unit] = {
     val command = RedisCommand(ClientCaching, YesNoInput, UnitOutput)
 
     command.run(track)
@@ -67,7 +67,7 @@ trait Connection {
    * @return
    *   the ID of the current connection.
    */
-  final def clientId: ZIO[Redis, RedisError, Long] = {
+  final def clientId: ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(ClientId, NoInput, LongOutput)
 
     command.run(())
@@ -81,7 +81,7 @@ trait Connection {
    * @return
    *   the Unit value.
    */
-  final def clientKill(address: Address): ZIO[Redis, RedisError, Unit] = {
+  final def clientKill(address: Address): ZIO[Any, RedisError, Unit] = {
     val command = RedisCommand(ClientKill, AddressInput, UnitOutput)
 
     command.run(address)
@@ -107,7 +107,7 @@ trait Connection {
    * @return
    *   the number of clients killed.
    */
-  final def clientKill(filters: ClientKillFilter*): ZIO[Redis, RedisError, Long] = {
+  final def clientKill(filters: ClientKillFilter*): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(ClientKill, Varargs(ClientKillInput), LongOutput)
 
     command.run(filters)
@@ -119,7 +119,7 @@ trait Connection {
    * @return
    *   the connection name, or None if a name wasn't set.
    */
-  final def clientGetName: ZIO[Redis, RedisError, Option[String]] = {
+  final def clientGetName: ZIO[Any, RedisError, Option[String]] = {
     val command = RedisCommand(ClientGetName, NoInput, OptionalOutput(MultiStringOutput))
 
     command.run(())
@@ -131,7 +131,7 @@ trait Connection {
    * @return
    *   the client ID if the tracking is enabled and the notifications are being redirected
    */
-  final def clientGetRedir: ZIO[Redis, RedisError, ClientTrackingRedirect] = {
+  final def clientGetRedir: ZIO[Any, RedisError, ClientTrackingRedirect] = {
     val command = RedisCommand(ClientGetRedir, NoInput, ClientTrackingRedirectOutput)
 
     command.run(())
@@ -142,7 +142,7 @@ trait Connection {
    * @return
    *   the Unit value.
    */
-  final def clientUnpause: ZIO[Redis, RedisError, Unit] = {
+  final def clientUnpause: ZIO[Any, RedisError, Unit] = {
     val command = RedisCommand(ClientUnpause, NoInput, UnitOutput)
 
     command.run(())
@@ -164,7 +164,7 @@ trait Connection {
   final def clientPause(
     timeout: Duration,
     mode: Option[ClientPauseMode] = None
-  ): ZIO[Redis, RedisError, Unit] = {
+  ): ZIO[Any, RedisError, Unit] = {
     val command = RedisCommand(
       ClientPause,
       Tuple2(DurationMillisecondsInput, OptionalInput(ClientPauseModeInput)),
@@ -182,7 +182,7 @@ trait Connection {
    * @return
    *   the Unit value.
    */
-  final def clientSetName(name: String): ZIO[Redis, RedisError, Unit] = {
+  final def clientSetName(name: String): ZIO[Any, RedisError, Unit] = {
     val command = RedisCommand(ClientSetName, StringInput, UnitOutput)
 
     command.run(name)
@@ -208,7 +208,7 @@ trait Connection {
     trackingMode: Option[ClientTrackingMode] = None,
     noLoop: Boolean = false,
     prefixes: Set[String] = Set.empty
-  ): ZIO[Redis, RedisError, Unit] = {
+  ): ZIO[Any, RedisError, Unit] = {
     val command = RedisCommand(ClientTracking, ClientTrackingInput, UnitOutput)
     command.run(Some((redirect, trackingMode, noLoop, Chunk.fromIterable(prefixes))))
   }
@@ -219,7 +219,7 @@ trait Connection {
    * @return
    *   the Unit value.
    */
-  final def clientTrackingOff: ZIO[Redis, RedisError, Unit] = {
+  final def clientTrackingOff: ZIO[Any, RedisError, Unit] = {
     val command = RedisCommand(ClientTracking, ClientTrackingInput, UnitOutput)
     command.run(None)
   }
@@ -230,7 +230,7 @@ trait Connection {
    * @return
    *   tracking information.
    */
-  final def clientTrackingInfo: ZIO[Redis, RedisError, ClientTrackingInfo] = {
+  final def clientTrackingInfo: ZIO[Any, RedisError, ClientTrackingInfo] = {
     val command = RedisCommand(ClientTrackingInfo, NoInput, ClientTrackingInfoOutput)
 
     command.run(())
@@ -249,7 +249,7 @@ trait Connection {
   final def clientUnblock(
     clientId: Long,
     error: Option[UnblockBehavior] = None
-  ): ZIO[Redis, RedisError, Boolean] = {
+  ): ZIO[Any, RedisError, Boolean] = {
     val command = RedisCommand(ClientUnblock, Tuple2(LongInput, OptionalInput(UnblockBehaviorInput)), BoolOutput)
 
     command.run((clientId, error))
@@ -263,7 +263,7 @@ trait Connection {
    * @return
    *   the message.
    */
-  final def echo(message: String): ZIO[Redis, RedisError, String] = {
+  final def echo(message: String): ZIO[Any, RedisError, String] = {
     val command = RedisCommand(Echo, StringInput, MultiStringOutput)
 
     command.run(message)
@@ -278,7 +278,7 @@ trait Connection {
    *   PONG if no argument is provided, otherwise return a copy of the argument as a bulk. This command is often used to
    *   test if a connection is still alive, or to measure latency.
    */
-  final def ping(message: Option[String] = None): ZIO[Redis, RedisError, String] = {
+  final def ping(message: Option[String] = None): ZIO[Any, RedisError, String] = {
     val command = RedisCommand(Ping, OptionalInput(StringInput), SingleOrMultiStringOutput)
 
     command.run(message)
@@ -291,7 +291,7 @@ trait Connection {
    * @return
    *   the Unit value.
    */
-  final def quit: ZIO[Redis, RedisError, Unit] = {
+  final def quit: ZIO[Any, RedisError, Unit] = {
     val command = RedisCommand(Quit, NoInput, UnitOutput)
 
     command.run(())
@@ -304,7 +304,7 @@ trait Connection {
    * @return
    *   the Unit value.
    */
-  final def reset: ZIO[Redis, RedisError, Unit] = {
+  final def reset: ZIO[Any, RedisError, Unit] = {
     val command = RedisCommand(Reset, NoInput, ResetOutput)
 
     command.run(())
@@ -320,7 +320,7 @@ trait Connection {
    * @return
    *   the Unit value.
    */
-  final def select(index: Long): ZIO[Redis, RedisError, Unit] = {
+  final def select(index: Long): ZIO[Any, RedisError, Unit] = {
     val command = RedisCommand(Select, LongInput, UnitOutput)
 
     command.run(index)

--- a/redis/src/main/scala/zio/redis/api/Connection.scala
+++ b/redis/src/main/scala/zio/redis/api/Connection.scala
@@ -21,7 +21,7 @@ import zio.redis.Input._
 import zio.redis.Output._
 import zio.redis._
 
-trait Connection extends CommandExecutor {
+trait Connection extends RedisEnvironment {
   import Connection._
 
   /**
@@ -36,8 +36,8 @@ trait Connection extends CommandExecutor {
    *   if the password provided via AUTH matches the password in the configuration file, the Unit value is returned and
    *   the server starts accepting commands. Otherwise, an error is returned and the client needs to try a new password.
    */
-  final def auth(password: String): ZIO[Any, RedisError, Unit] = {
-    val command = RedisCommand(Auth, StringInput, UnitOutput)
+  final def auth(password: String): IO[RedisError, Unit] = {
+    val command = RedisCommand(Auth, StringInput, UnitOutput)(executor, codec)
 
     command.run(password)
   }
@@ -51,8 +51,8 @@ trait Connection extends CommandExecutor {
    * @return
    *   the Unit value.
    */
-  final def clientCaching(track: Boolean): ZIO[Any, RedisError, Unit] = {
-    val command = RedisCommand(ClientCaching, YesNoInput, UnitOutput)
+  final def clientCaching(track: Boolean): IO[RedisError, Unit] = {
+    val command = RedisCommand(ClientCaching, YesNoInput, UnitOutput)(executor, codec)
 
     command.run(track)
   }
@@ -67,8 +67,8 @@ trait Connection extends CommandExecutor {
    * @return
    *   the ID of the current connection.
    */
-  final def clientId: ZIO[Any, RedisError, Long] = {
-    val command = RedisCommand(ClientId, NoInput, LongOutput)
+  final def clientId: IO[RedisError, Long] = {
+    val command = RedisCommand(ClientId, NoInput, LongOutput)(executor, codec)
 
     command.run(())
   }
@@ -81,8 +81,8 @@ trait Connection extends CommandExecutor {
    * @return
    *   the Unit value.
    */
-  final def clientKill(address: Address): ZIO[Any, RedisError, Unit] = {
-    val command = RedisCommand(ClientKill, AddressInput, UnitOutput)
+  final def clientKill(address: Address): IO[RedisError, Unit] = {
+    val command = RedisCommand(ClientKill, AddressInput, UnitOutput)(executor, codec)
 
     command.run(address)
   }
@@ -107,8 +107,8 @@ trait Connection extends CommandExecutor {
    * @return
    *   the number of clients killed.
    */
-  final def clientKill(filters: ClientKillFilter*): ZIO[Any, RedisError, Long] = {
-    val command = RedisCommand(ClientKill, Varargs(ClientKillInput), LongOutput)
+  final def clientKill(filters: ClientKillFilter*): IO[RedisError, Long] = {
+    val command = RedisCommand(ClientKill, Varargs(ClientKillInput), LongOutput)(executor, codec)
 
     command.run(filters)
   }
@@ -119,8 +119,8 @@ trait Connection extends CommandExecutor {
    * @return
    *   the connection name, or None if a name wasn't set.
    */
-  final def clientGetName: ZIO[Any, RedisError, Option[String]] = {
-    val command = RedisCommand(ClientGetName, NoInput, OptionalOutput(MultiStringOutput))
+  final def clientGetName: IO[RedisError, Option[String]] = {
+    val command = RedisCommand(ClientGetName, NoInput, OptionalOutput(MultiStringOutput))(executor, codec)
 
     command.run(())
   }
@@ -131,8 +131,8 @@ trait Connection extends CommandExecutor {
    * @return
    *   the client ID if the tracking is enabled and the notifications are being redirected
    */
-  final def clientGetRedir: ZIO[Any, RedisError, ClientTrackingRedirect] = {
-    val command = RedisCommand(ClientGetRedir, NoInput, ClientTrackingRedirectOutput)
+  final def clientGetRedir: IO[RedisError, ClientTrackingRedirect] = {
+    val command = RedisCommand(ClientGetRedir, NoInput, ClientTrackingRedirectOutput)(executor, codec)
 
     command.run(())
   }
@@ -142,8 +142,8 @@ trait Connection extends CommandExecutor {
    * @return
    *   the Unit value.
    */
-  final def clientUnpause: ZIO[Any, RedisError, Unit] = {
-    val command = RedisCommand(ClientUnpause, NoInput, UnitOutput)
+  final def clientUnpause: IO[RedisError, Unit] = {
+    val command = RedisCommand(ClientUnpause, NoInput, UnitOutput)(executor, codec)
 
     command.run(())
   }
@@ -164,12 +164,12 @@ trait Connection extends CommandExecutor {
   final def clientPause(
     timeout: Duration,
     mode: Option[ClientPauseMode] = None
-  ): ZIO[Any, RedisError, Unit] = {
+  ): IO[RedisError, Unit] = {
     val command = RedisCommand(
       ClientPause,
       Tuple2(DurationMillisecondsInput, OptionalInput(ClientPauseModeInput)),
       UnitOutput
-    )
+    )(executor, codec)
 
     command.run((timeout, mode))
   }
@@ -182,8 +182,8 @@ trait Connection extends CommandExecutor {
    * @return
    *   the Unit value.
    */
-  final def clientSetName(name: String): ZIO[Any, RedisError, Unit] = {
-    val command = RedisCommand(ClientSetName, StringInput, UnitOutput)
+  final def clientSetName(name: String): IO[RedisError, Unit] = {
+    val command = RedisCommand(ClientSetName, StringInput, UnitOutput)(executor, codec)
 
     command.run(name)
   }
@@ -208,8 +208,8 @@ trait Connection extends CommandExecutor {
     trackingMode: Option[ClientTrackingMode] = None,
     noLoop: Boolean = false,
     prefixes: Set[String] = Set.empty
-  ): ZIO[Any, RedisError, Unit] = {
-    val command = RedisCommand(ClientTracking, ClientTrackingInput, UnitOutput)
+  ): IO[RedisError, Unit] = {
+    val command = RedisCommand(ClientTracking, ClientTrackingInput, UnitOutput)(executor, codec)
     command.run(Some((redirect, trackingMode, noLoop, Chunk.fromIterable(prefixes))))
   }
 
@@ -219,8 +219,8 @@ trait Connection extends CommandExecutor {
    * @return
    *   the Unit value.
    */
-  final def clientTrackingOff: ZIO[Any, RedisError, Unit] = {
-    val command = RedisCommand(ClientTracking, ClientTrackingInput, UnitOutput)
+  final def clientTrackingOff: IO[RedisError, Unit] = {
+    val command = RedisCommand(ClientTracking, ClientTrackingInput, UnitOutput)(executor, codec)
     command.run(None)
   }
 
@@ -230,8 +230,8 @@ trait Connection extends CommandExecutor {
    * @return
    *   tracking information.
    */
-  final def clientTrackingInfo: ZIO[Any, RedisError, ClientTrackingInfo] = {
-    val command = RedisCommand(ClientTrackingInfo, NoInput, ClientTrackingInfoOutput)
+  final def clientTrackingInfo: IO[RedisError, ClientTrackingInfo] = {
+    val command = RedisCommand(ClientTrackingInfo, NoInput, ClientTrackingInfoOutput)(executor, codec)
 
     command.run(())
   }
@@ -249,8 +249,9 @@ trait Connection extends CommandExecutor {
   final def clientUnblock(
     clientId: Long,
     error: Option[UnblockBehavior] = None
-  ): ZIO[Any, RedisError, Boolean] = {
-    val command = RedisCommand(ClientUnblock, Tuple2(LongInput, OptionalInput(UnblockBehaviorInput)), BoolOutput)
+  ): IO[RedisError, Boolean] = {
+    val command =
+      RedisCommand(ClientUnblock, Tuple2(LongInput, OptionalInput(UnblockBehaviorInput)), BoolOutput)(executor, codec)
 
     command.run((clientId, error))
   }
@@ -263,8 +264,8 @@ trait Connection extends CommandExecutor {
    * @return
    *   the message.
    */
-  final def echo(message: String): ZIO[Any, RedisError, String] = {
-    val command = RedisCommand(Echo, StringInput, MultiStringOutput)
+  final def echo(message: String): IO[RedisError, String] = {
+    val command = RedisCommand(Echo, StringInput, MultiStringOutput)(executor, codec)
 
     command.run(message)
   }
@@ -278,8 +279,8 @@ trait Connection extends CommandExecutor {
    *   PONG if no argument is provided, otherwise return a copy of the argument as a bulk. This command is often used to
    *   test if a connection is still alive, or to measure latency.
    */
-  final def ping(message: Option[String] = None): ZIO[Any, RedisError, String] = {
-    val command = RedisCommand(Ping, OptionalInput(StringInput), SingleOrMultiStringOutput)
+  final def ping(message: Option[String] = None): IO[RedisError, String] = {
+    val command = RedisCommand(Ping, OptionalInput(StringInput), SingleOrMultiStringOutput)(executor, codec)
 
     command.run(message)
   }
@@ -291,8 +292,8 @@ trait Connection extends CommandExecutor {
    * @return
    *   the Unit value.
    */
-  final def quit: ZIO[Any, RedisError, Unit] = {
-    val command = RedisCommand(Quit, NoInput, UnitOutput)
+  final def quit: IO[RedisError, Unit] = {
+    val command = RedisCommand(Quit, NoInput, UnitOutput)(executor, codec)
 
     command.run(())
   }
@@ -304,8 +305,8 @@ trait Connection extends CommandExecutor {
    * @return
    *   the Unit value.
    */
-  final def reset: ZIO[Any, RedisError, Unit] = {
-    val command = RedisCommand(Reset, NoInput, ResetOutput)
+  final def reset: IO[RedisError, Unit] = {
+    val command = RedisCommand(Reset, NoInput, ResetOutput)(executor, codec)
 
     command.run(())
   }
@@ -320,8 +321,8 @@ trait Connection extends CommandExecutor {
    * @return
    *   the Unit value.
    */
-  final def select(index: Long): ZIO[Any, RedisError, Unit] = {
-    val command = RedisCommand(Select, LongInput, UnitOutput)
+  final def select(index: Long): IO[RedisError, Unit] = {
+    val command = RedisCommand(Select, LongInput, UnitOutput)(executor, codec)
 
     command.run(index)
   }

--- a/redis/src/main/scala/zio/redis/api/Geo.scala
+++ b/redis/src/main/scala/zio/redis/api/Geo.scala
@@ -45,8 +45,10 @@ trait Geo extends RedisEnvironment {
     val command = RedisCommand(
       GeoAdd,
       Tuple2(ArbitraryInput[K](), NonEmptyList(Tuple2(LongLatInput, ArbitraryInput[M]()))),
-      LongOutput
-    )(executor, codec)
+      LongOutput,
+      codec,
+      executor
+    )
     command.run((key, (item, items.toList)))
   }
 
@@ -73,8 +75,10 @@ trait Geo extends RedisEnvironment {
     val command = RedisCommand(
       GeoDist,
       Tuple4(ArbitraryInput[K](), ArbitraryInput[M](), ArbitraryInput[M](), OptionalInput(RadiusUnitInput)),
-      OptionalOutput(DoubleOutput)
-    )(executor, codec)
+      OptionalOutput(DoubleOutput),
+      codec,
+      executor
+    )
     command.run((key, member1, member2, radiusUnit))
   }
 
@@ -99,8 +103,10 @@ trait Geo extends RedisEnvironment {
     val command = RedisCommand(
       GeoHash,
       Tuple2(ArbitraryInput[K](), NonEmptyList(ArbitraryInput[M]())),
-      ChunkOutput(OptionalOutput(MultiStringOutput))
-    )(executor, codec)
+      ChunkOutput(OptionalOutput(MultiStringOutput)),
+      codec,
+      executor
+    )
     command.run((key, (member, members.toList)))
   }
 
@@ -123,7 +129,7 @@ trait Geo extends RedisEnvironment {
     members: M*
   ): IO[RedisError, Chunk[Option[LongLat]]] = {
     val command =
-      RedisCommand(GeoPos, Tuple2(ArbitraryInput[K](), NonEmptyList(ArbitraryInput[M]())), GeoOutput)(executor, codec)
+      RedisCommand(GeoPos, Tuple2(ArbitraryInput[K](), NonEmptyList(ArbitraryInput[M]())), GeoOutput, codec, executor)
     command.run((key, (member, members.toList)))
   }
 
@@ -176,8 +182,10 @@ trait Geo extends RedisEnvironment {
         OptionalInput(CountInput),
         OptionalInput(OrderInput)
       ),
-      GeoRadiusOutput
-    )(executor, codec)
+      GeoRadiusOutput,
+      codec,
+      executor
+    )
     command.run((key, center, radius, radiusUnit, withCoord, withDist, withHash, count, order))
   }
 
@@ -239,8 +247,10 @@ trait Geo extends RedisEnvironment {
         OptionalInput(StoreInput),
         OptionalInput(StoreDistInput)
       ),
-      LongOutput
-    )(executor, codec)
+      LongOutput,
+      codec,
+      executor
+    )
     command.run(
       (key, center, radius, radiusUnit, withCoord, withDist, withHash, count, order, store.store, store.storeDist)
     )
@@ -295,8 +305,10 @@ trait Geo extends RedisEnvironment {
         OptionalInput(CountInput),
         OptionalInput(OrderInput)
       ),
-      GeoRadiusOutput
-    )(executor, codec)
+      GeoRadiusOutput,
+      codec,
+      executor
+    )
     command.run((key, member, radius, radiusUnit, withCoord, withDist, withHash, count, order))
   }
 
@@ -358,8 +370,10 @@ trait Geo extends RedisEnvironment {
         OptionalInput(StoreInput),
         OptionalInput(StoreDistInput)
       ),
-      LongOutput
-    )(executor, codec)
+      LongOutput,
+      codec,
+      executor
+    )
     command.run(
       (key, member, radius, radiusUnit, withCoord, withDist, withHash, count, order, store.store, store.storeDist)
     )

--- a/redis/src/main/scala/zio/redis/api/Geo.scala
+++ b/redis/src/main/scala/zio/redis/api/Geo.scala
@@ -22,7 +22,7 @@ import zio.redis.Output._
 import zio.redis._
 import zio.schema.Schema
 
-trait Geo {
+trait Geo extends CommandExecutor {
   import Geo._
 
   /**
@@ -41,7 +41,7 @@ trait Geo {
     key: K,
     item: (LongLat, M),
     items: (LongLat, M)*
-  ): ZIO[Redis, RedisError, Long] = {
+  ): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(
       GeoAdd,
       Tuple2(ArbitraryInput[K](), NonEmptyList(Tuple2(LongLatInput, ArbitraryInput[M]()))),
@@ -69,7 +69,7 @@ trait Geo {
     member1: M,
     member2: M,
     radiusUnit: Option[RadiusUnit] = None
-  ): ZIO[Redis, RedisError, Option[Double]] = {
+  ): ZIO[Any, RedisError, Option[Double]] = {
     val command = RedisCommand(
       GeoDist,
       Tuple4(ArbitraryInput[K](), ArbitraryInput[M](), ArbitraryInput[M](), OptionalInput(RadiusUnitInput)),
@@ -95,7 +95,7 @@ trait Geo {
     key: K,
     member: M,
     members: M*
-  ): ZIO[Redis, RedisError, Chunk[Option[String]]] = {
+  ): ZIO[Any, RedisError, Chunk[Option[String]]] = {
     val command = RedisCommand(
       GeoHash,
       Tuple2(ArbitraryInput[K](), NonEmptyList(ArbitraryInput[M]())),
@@ -121,7 +121,7 @@ trait Geo {
     key: K,
     member: M,
     members: M*
-  ): ZIO[Redis, RedisError, Chunk[Option[LongLat]]] = {
+  ): ZIO[Any, RedisError, Chunk[Option[LongLat]]] = {
     val command = RedisCommand(GeoPos, Tuple2(ArbitraryInput[K](), NonEmptyList(ArbitraryInput[M]())), GeoOutput)
     command.run((key, (member, members.toList)))
   }
@@ -161,7 +161,7 @@ trait Geo {
     withHash: Option[WithHash] = None,
     count: Option[Count] = None,
     order: Option[Order] = None
-  ): ZIO[Redis, RedisError, Chunk[GeoView]] = {
+  ): ZIO[Any, RedisError, Chunk[GeoView]] = {
     val command = RedisCommand(
       GeoRadius,
       Tuple9(
@@ -222,7 +222,7 @@ trait Geo {
     withHash: Option[WithHash] = None,
     count: Option[Count] = None,
     order: Option[Order] = None
-  ): ZIO[Redis, RedisError, Long] = {
+  ): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(
       GeoRadius,
       Tuple11(
@@ -280,7 +280,7 @@ trait Geo {
     withHash: Option[WithHash] = None,
     count: Option[Count] = None,
     order: Option[Order] = None
-  ): ZIO[Redis, RedisError, Chunk[GeoView]] = {
+  ): ZIO[Any, RedisError, Chunk[GeoView]] = {
     val command = RedisCommand(
       GeoRadiusByMember,
       Tuple9(
@@ -341,7 +341,7 @@ trait Geo {
     withHash: Option[WithHash] = None,
     count: Option[Count] = None,
     order: Option[Order] = None
-  ): ZIO[Redis, RedisError, Long] = {
+  ): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(
       GeoRadiusByMember,
       Tuple11(

--- a/redis/src/main/scala/zio/redis/api/Geo.scala
+++ b/redis/src/main/scala/zio/redis/api/Geo.scala
@@ -22,7 +22,7 @@ import zio.redis.Output._
 import zio.redis._
 import zio.schema.Schema
 
-trait Geo extends CommandExecutor {
+trait Geo extends RedisEnvironment {
   import Geo._
 
   /**
@@ -41,12 +41,12 @@ trait Geo extends CommandExecutor {
     key: K,
     item: (LongLat, M),
     items: (LongLat, M)*
-  ): ZIO[Any, RedisError, Long] = {
+  ): IO[RedisError, Long] = {
     val command = RedisCommand(
       GeoAdd,
       Tuple2(ArbitraryInput[K](), NonEmptyList(Tuple2(LongLatInput, ArbitraryInput[M]()))),
       LongOutput
-    )
+    )(executor, codec)
     command.run((key, (item, items.toList)))
   }
 
@@ -69,12 +69,12 @@ trait Geo extends CommandExecutor {
     member1: M,
     member2: M,
     radiusUnit: Option[RadiusUnit] = None
-  ): ZIO[Any, RedisError, Option[Double]] = {
+  ): IO[RedisError, Option[Double]] = {
     val command = RedisCommand(
       GeoDist,
       Tuple4(ArbitraryInput[K](), ArbitraryInput[M](), ArbitraryInput[M](), OptionalInput(RadiusUnitInput)),
       OptionalOutput(DoubleOutput)
-    )
+    )(executor, codec)
     command.run((key, member1, member2, radiusUnit))
   }
 
@@ -95,12 +95,12 @@ trait Geo extends CommandExecutor {
     key: K,
     member: M,
     members: M*
-  ): ZIO[Any, RedisError, Chunk[Option[String]]] = {
+  ): IO[RedisError, Chunk[Option[String]]] = {
     val command = RedisCommand(
       GeoHash,
       Tuple2(ArbitraryInput[K](), NonEmptyList(ArbitraryInput[M]())),
       ChunkOutput(OptionalOutput(MultiStringOutput))
-    )
+    )(executor, codec)
     command.run((key, (member, members.toList)))
   }
 
@@ -121,8 +121,9 @@ trait Geo extends CommandExecutor {
     key: K,
     member: M,
     members: M*
-  ): ZIO[Any, RedisError, Chunk[Option[LongLat]]] = {
-    val command = RedisCommand(GeoPos, Tuple2(ArbitraryInput[K](), NonEmptyList(ArbitraryInput[M]())), GeoOutput)
+  ): IO[RedisError, Chunk[Option[LongLat]]] = {
+    val command =
+      RedisCommand(GeoPos, Tuple2(ArbitraryInput[K](), NonEmptyList(ArbitraryInput[M]())), GeoOutput)(executor, codec)
     command.run((key, (member, members.toList)))
   }
 
@@ -161,7 +162,7 @@ trait Geo extends CommandExecutor {
     withHash: Option[WithHash] = None,
     count: Option[Count] = None,
     order: Option[Order] = None
-  ): ZIO[Any, RedisError, Chunk[GeoView]] = {
+  ): IO[RedisError, Chunk[GeoView]] = {
     val command = RedisCommand(
       GeoRadius,
       Tuple9(
@@ -176,7 +177,7 @@ trait Geo extends CommandExecutor {
         OptionalInput(OrderInput)
       ),
       GeoRadiusOutput
-    )
+    )(executor, codec)
     command.run((key, center, radius, radiusUnit, withCoord, withDist, withHash, count, order))
   }
 
@@ -222,7 +223,7 @@ trait Geo extends CommandExecutor {
     withHash: Option[WithHash] = None,
     count: Option[Count] = None,
     order: Option[Order] = None
-  ): ZIO[Any, RedisError, Long] = {
+  ): IO[RedisError, Long] = {
     val command = RedisCommand(
       GeoRadius,
       Tuple11(
@@ -239,7 +240,7 @@ trait Geo extends CommandExecutor {
         OptionalInput(StoreDistInput)
       ),
       LongOutput
-    )
+    )(executor, codec)
     command.run(
       (key, center, radius, radiusUnit, withCoord, withDist, withHash, count, order, store.store, store.storeDist)
     )
@@ -280,7 +281,7 @@ trait Geo extends CommandExecutor {
     withHash: Option[WithHash] = None,
     count: Option[Count] = None,
     order: Option[Order] = None
-  ): ZIO[Any, RedisError, Chunk[GeoView]] = {
+  ): IO[RedisError, Chunk[GeoView]] = {
     val command = RedisCommand(
       GeoRadiusByMember,
       Tuple9(
@@ -295,7 +296,7 @@ trait Geo extends CommandExecutor {
         OptionalInput(OrderInput)
       ),
       GeoRadiusOutput
-    )
+    )(executor, codec)
     command.run((key, member, radius, radiusUnit, withCoord, withDist, withHash, count, order))
   }
 
@@ -341,7 +342,7 @@ trait Geo extends CommandExecutor {
     withHash: Option[WithHash] = None,
     count: Option[Count] = None,
     order: Option[Order] = None
-  ): ZIO[Any, RedisError, Long] = {
+  ): IO[RedisError, Long] = {
     val command = RedisCommand(
       GeoRadiusByMember,
       Tuple11(
@@ -358,7 +359,7 @@ trait Geo extends CommandExecutor {
         OptionalInput(StoreDistInput)
       ),
       LongOutput
-    )
+    )(executor, codec)
     command.run(
       (key, member, radius, radiusUnit, withCoord, withDist, withHash, count, order, store.store, store.storeDist)
     )

--- a/redis/src/main/scala/zio/redis/api/Hashes.scala
+++ b/redis/src/main/scala/zio/redis/api/Hashes.scala
@@ -23,7 +23,7 @@ import zio.redis.ResultBuilder._
 import zio.redis._
 import zio.schema.Schema
 
-trait Hashes {
+trait Hashes extends CommandExecutor {
   import Hashes._
 
   /**
@@ -38,7 +38,7 @@ trait Hashes {
    * @return
    *   number of fields removed from the hash.
    */
-  final def hDel[K: Schema, F: Schema](key: K, field: F, fields: F*): ZIO[Redis, RedisError, Long] = {
+  final def hDel[K: Schema, F: Schema](key: K, field: F, fields: F*): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(HDel, Tuple2(ArbitraryInput[K](), NonEmptyList(ArbitraryInput[F]())), LongOutput)
     command.run((key, (field, fields.toList)))
   }
@@ -53,7 +53,7 @@ trait Hashes {
    * @return
    *   true if the field exists, otherwise false.
    */
-  final def hExists[K: Schema, F: Schema](key: K, field: F): ZIO[Redis, RedisError, Boolean] = {
+  final def hExists[K: Schema, F: Schema](key: K, field: F): ZIO[Any, RedisError, Boolean] = {
     val command = RedisCommand(HExists, Tuple2(ArbitraryInput[K](), ArbitraryInput[F]()), BoolOutput)
     command.run((key, field))
   }
@@ -70,7 +70,7 @@ trait Hashes {
    */
   final def hGet[K: Schema, F: Schema](key: K, field: F): ResultBuilder1[Option] =
     new ResultBuilder1[Option] {
-      def returning[V: Schema]: ZIO[Redis, RedisError, Option[V]] =
+      def returning[V: Schema]: ZIO[Any, RedisError, Option[V]] =
         RedisCommand(HGet, Tuple2(ArbitraryInput[K](), ArbitraryInput[F]()), OptionalOutput(ArbitraryOutput[V]()))
           .run((key, field))
     }
@@ -84,7 +84,7 @@ trait Hashes {
    *   map of `field -> value` pairs under the key.
    */
   final def hGetAll[K: Schema](key: K): ResultBuilder2[Map] = new ResultBuilder2[Map] {
-    def returning[F: Schema, V: Schema]: ZIO[Redis, RedisError, Map[F, V]] = {
+    def returning[F: Schema, V: Schema]: ZIO[Any, RedisError, Map[F, V]] = {
       val command =
         RedisCommand(HGetAll, ArbitraryInput[K](), KeyValueOutput(ArbitraryOutput[F](), ArbitraryOutput[V]()))
       command.run(key)
@@ -104,7 +104,7 @@ trait Hashes {
    * @return
    *   integer value after incrementing, or error if the field is not an integer.
    */
-  final def hIncrBy[K: Schema, F: Schema](key: K, field: F, increment: Long): ZIO[Redis, RedisError, Long] = {
+  final def hIncrBy[K: Schema, F: Schema](key: K, field: F, increment: Long): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(HIncrBy, Tuple3(ArbitraryInput[K](), ArbitraryInput[F](), LongInput), LongOutput)
     command.run((key, field, increment))
   }
@@ -126,7 +126,7 @@ trait Hashes {
     key: K,
     field: F,
     increment: Double
-  ): ZIO[Redis, RedisError, Double] = {
+  ): ZIO[Any, RedisError, Double] = {
     val command =
       RedisCommand(HIncrByFloat, Tuple3(ArbitraryInput[K](), ArbitraryInput[F](), DoubleInput), DoubleOutput)
     command.run((key, field, increment))
@@ -142,7 +142,7 @@ trait Hashes {
    */
   final def hKeys[K: Schema](key: K): ResultBuilder1[Chunk] =
     new ResultBuilder1[Chunk] {
-      def returning[F: Schema]: ZIO[Redis, RedisError, Chunk[F]] =
+      def returning[F: Schema]: ZIO[Any, RedisError, Chunk[F]] =
         RedisCommand(HKeys, ArbitraryInput[K](), ChunkOutput(ArbitraryOutput[F]())).run(key)
     }
 
@@ -154,7 +154,7 @@ trait Hashes {
    * @return
    *   number of fields.
    */
-  final def hLen[K: Schema](key: K): ZIO[Redis, RedisError, Long] = {
+  final def hLen[K: Schema](key: K): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(HLen, ArbitraryInput[K](), LongOutput)
     command.run(key)
   }
@@ -177,7 +177,7 @@ trait Hashes {
     fields: F*
   ): ResultBuilder1[({ type lambda[x] = Chunk[Option[x]] })#lambda] =
     new ResultBuilder1[({ type lambda[x] = Chunk[Option[x]] })#lambda] {
-      def returning[V: Schema]: ZIO[Redis, RedisError, Chunk[Option[V]]] = {
+      def returning[V: Schema]: ZIO[Any, RedisError, Chunk[Option[V]]] = {
         val command = RedisCommand(
           HmGet,
           Tuple2(ArbitraryInput[K](), NonEmptyList(ArbitraryInput[F]())),
@@ -204,7 +204,7 @@ trait Hashes {
     key: K,
     pair: (F, V),
     pairs: (F, V)*
-  ): ZIO[Redis, RedisError, Unit] = {
+  ): ZIO[Any, RedisError, Unit] = {
     val command = RedisCommand(
       HmSet,
       Tuple2(ArbitraryInput[K](), NonEmptyList(Tuple2(ArbitraryInput[F](), ArbitraryInput[V]()))),
@@ -234,7 +234,7 @@ trait Hashes {
     count: Option[Count] = None
   ): ResultBuilder2[({ type lambda[x, y] = (Long, Chunk[(x, y)]) })#lambda] =
     new ResultBuilder2[({ type lambda[x, y] = (Long, Chunk[(x, y)]) })#lambda] {
-      def returning[F: Schema, V: Schema]: ZIO[Redis, RedisError, (Long, Chunk[(F, V)])] = {
+      def returning[F: Schema, V: Schema]: ZIO[Any, RedisError, (Long, Chunk[(F, V)])] = {
         val command = RedisCommand(
           HScan,
           Tuple4(ArbitraryInput[K](), LongInput, OptionalInput(PatternInput), OptionalInput(CountInput)),
@@ -260,7 +260,7 @@ trait Hashes {
     key: K,
     pair: (F, V),
     pairs: (F, V)*
-  ): ZIO[Redis, RedisError, Long] = {
+  ): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(
       HSet,
       Tuple2(ArbitraryInput[K](), NonEmptyList(Tuple2(ArbitraryInput[F](), ArbitraryInput[V]()))),
@@ -285,7 +285,7 @@ trait Hashes {
     key: K,
     field: F,
     value: V
-  ): ZIO[Redis, RedisError, Boolean] = {
+  ): ZIO[Any, RedisError, Boolean] = {
     val command =
       RedisCommand(HSetNx, Tuple3(ArbitraryInput[K](), ArbitraryInput[F](), ArbitraryInput[V]()), BoolOutput)
     command.run((key, field, value))
@@ -301,7 +301,7 @@ trait Hashes {
    * @return
    *   string length of the value in field, or zero if either field or key do not exist.
    */
-  final def hStrLen[K: Schema, F: Schema](key: K, field: F): ZIO[Redis, RedisError, Long] = {
+  final def hStrLen[K: Schema, F: Schema](key: K, field: F): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(HStrLen, Tuple2(ArbitraryInput[K](), ArbitraryInput[F]()), LongOutput)
     command.run((key, field))
   }
@@ -316,7 +316,7 @@ trait Hashes {
    */
   final def hVals[K: Schema](key: K): ResultBuilder1[Chunk] =
     new ResultBuilder1[Chunk] {
-      def returning[V: Schema]: ZIO[Redis, RedisError, Chunk[V]] =
+      def returning[V: Schema]: ZIO[Any, RedisError, Chunk[V]] =
         RedisCommand(HVals, ArbitraryInput[K](), ChunkOutput(ArbitraryOutput[V]())).run(key)
     }
 
@@ -330,7 +330,7 @@ trait Hashes {
    */
   final def hRandField[K: Schema](key: K): ResultBuilder1[Option] =
     new ResultBuilder1[Option] {
-      def returning[V: Schema]: ZIO[Redis, RedisError, Option[V]] =
+      def returning[V: Schema]: ZIO[Any, RedisError, Option[V]] =
         RedisCommand(HRandField, ArbitraryInput[K](), OptionalOutput(ArbitraryOutput[V]())).run(key)
     }
 
@@ -350,7 +350,7 @@ trait Hashes {
    */
   final def hRandField[K: Schema](key: K, count: Long, withValues: Boolean = false): ResultBuilder1[Chunk] =
     new ResultBuilder1[Chunk] {
-      def returning[V: Schema]: ZIO[Redis, RedisError, Chunk[V]] = {
+      def returning[V: Schema]: ZIO[Any, RedisError, Chunk[V]] = {
         val command = RedisCommand(
           HRandField,
           Tuple3(ArbitraryInput[K](), LongInput, OptionalInput(StringInput)),

--- a/redis/src/main/scala/zio/redis/api/HyperLogLog.scala
+++ b/redis/src/main/scala/zio/redis/api/HyperLogLog.scala
@@ -16,13 +16,13 @@
 
 package zio.redis.api
 
-import zio.ZIO
+import zio.IO
 import zio.redis.Input._
 import zio.redis.Output._
 import zio.redis._
 import zio.schema.Schema
 
-trait HyperLogLog extends CommandExecutor {
+trait HyperLogLog extends RedisEnvironment {
   import HyperLogLog._
 
   /**
@@ -37,8 +37,9 @@ trait HyperLogLog extends CommandExecutor {
    * @return
    *   boolean indicating if at least 1 HyperLogLog register was altered.
    */
-  final def pfAdd[K: Schema, V: Schema](key: K, element: V, elements: V*): ZIO[Any, RedisError, Boolean] = {
-    val command = RedisCommand(PfAdd, Tuple2(ArbitraryInput[K](), NonEmptyList(ArbitraryInput[V]())), BoolOutput)
+  final def pfAdd[K: Schema, V: Schema](key: K, element: V, elements: V*): IO[RedisError, Boolean] = {
+    val command =
+      RedisCommand(PfAdd, Tuple2(ArbitraryInput[K](), NonEmptyList(ArbitraryInput[V]())), BoolOutput)(executor, codec)
     command.run((key, (element, elements.toList)))
   }
 
@@ -52,8 +53,8 @@ trait HyperLogLog extends CommandExecutor {
    * @return
    *   approximate number of unique elements observed via PFADD.
    */
-  final def pfCount[K: Schema](key: K, keys: K*): ZIO[Any, RedisError, Long] = {
-    val command = RedisCommand(PfCount, NonEmptyList(ArbitraryInput[K]()), LongOutput)
+  final def pfCount[K: Schema](key: K, keys: K*): IO[RedisError, Long] = {
+    val command = RedisCommand(PfCount, NonEmptyList(ArbitraryInput[K]()), LongOutput)(executor, codec)
     command.run((key, keys.toList))
   }
 
@@ -67,8 +68,9 @@ trait HyperLogLog extends CommandExecutor {
    * @param sourceKeys
    *   additional keys to merge
    */
-  final def pfMerge[K: Schema](destKey: K, sourceKey: K, sourceKeys: K*): ZIO[Any, RedisError, Unit] = {
-    val command = RedisCommand(PfMerge, Tuple2(ArbitraryInput[K](), NonEmptyList(ArbitraryInput[K]())), UnitOutput)
+  final def pfMerge[K: Schema](destKey: K, sourceKey: K, sourceKeys: K*): IO[RedisError, Unit] = {
+    val command =
+      RedisCommand(PfMerge, Tuple2(ArbitraryInput[K](), NonEmptyList(ArbitraryInput[K]())), UnitOutput)(executor, codec)
     command.run((destKey, (sourceKey, sourceKeys.toList)))
   }
 }

--- a/redis/src/main/scala/zio/redis/api/HyperLogLog.scala
+++ b/redis/src/main/scala/zio/redis/api/HyperLogLog.scala
@@ -39,7 +39,7 @@ trait HyperLogLog extends RedisEnvironment {
    */
   final def pfAdd[K: Schema, V: Schema](key: K, element: V, elements: V*): IO[RedisError, Boolean] = {
     val command =
-      RedisCommand(PfAdd, Tuple2(ArbitraryInput[K](), NonEmptyList(ArbitraryInput[V]())), BoolOutput)(executor, codec)
+      RedisCommand(PfAdd, Tuple2(ArbitraryInput[K](), NonEmptyList(ArbitraryInput[V]())), BoolOutput, codec, executor)
     command.run((key, (element, elements.toList)))
   }
 
@@ -54,7 +54,7 @@ trait HyperLogLog extends RedisEnvironment {
    *   approximate number of unique elements observed via PFADD.
    */
   final def pfCount[K: Schema](key: K, keys: K*): IO[RedisError, Long] = {
-    val command = RedisCommand(PfCount, NonEmptyList(ArbitraryInput[K]()), LongOutput)(executor, codec)
+    val command = RedisCommand(PfCount, NonEmptyList(ArbitraryInput[K]()), LongOutput, codec, executor)
     command.run((key, keys.toList))
   }
 
@@ -70,7 +70,7 @@ trait HyperLogLog extends RedisEnvironment {
    */
   final def pfMerge[K: Schema](destKey: K, sourceKey: K, sourceKeys: K*): IO[RedisError, Unit] = {
     val command =
-      RedisCommand(PfMerge, Tuple2(ArbitraryInput[K](), NonEmptyList(ArbitraryInput[K]())), UnitOutput)(executor, codec)
+      RedisCommand(PfMerge, Tuple2(ArbitraryInput[K](), NonEmptyList(ArbitraryInput[K]())), UnitOutput, codec, executor)
     command.run((destKey, (sourceKey, sourceKeys.toList)))
   }
 }

--- a/redis/src/main/scala/zio/redis/api/HyperLogLog.scala
+++ b/redis/src/main/scala/zio/redis/api/HyperLogLog.scala
@@ -22,7 +22,7 @@ import zio.redis.Output._
 import zio.redis._
 import zio.schema.Schema
 
-trait HyperLogLog {
+trait HyperLogLog extends CommandExecutor {
   import HyperLogLog._
 
   /**
@@ -37,7 +37,7 @@ trait HyperLogLog {
    * @return
    *   boolean indicating if at least 1 HyperLogLog register was altered.
    */
-  final def pfAdd[K: Schema, V: Schema](key: K, element: V, elements: V*): ZIO[Redis, RedisError, Boolean] = {
+  final def pfAdd[K: Schema, V: Schema](key: K, element: V, elements: V*): ZIO[Any, RedisError, Boolean] = {
     val command = RedisCommand(PfAdd, Tuple2(ArbitraryInput[K](), NonEmptyList(ArbitraryInput[V]())), BoolOutput)
     command.run((key, (element, elements.toList)))
   }
@@ -52,7 +52,7 @@ trait HyperLogLog {
    * @return
    *   approximate number of unique elements observed via PFADD.
    */
-  final def pfCount[K: Schema](key: K, keys: K*): ZIO[Redis, RedisError, Long] = {
+  final def pfCount[K: Schema](key: K, keys: K*): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(PfCount, NonEmptyList(ArbitraryInput[K]()), LongOutput)
     command.run((key, keys.toList))
   }
@@ -67,7 +67,7 @@ trait HyperLogLog {
    * @param sourceKeys
    *   additional keys to merge
    */
-  final def pfMerge[K: Schema](destKey: K, sourceKey: K, sourceKeys: K*): ZIO[Redis, RedisError, Unit] = {
+  final def pfMerge[K: Schema](destKey: K, sourceKey: K, sourceKeys: K*): ZIO[Any, RedisError, Unit] = {
     val command = RedisCommand(PfMerge, Tuple2(ArbitraryInput[K](), NonEmptyList(ArbitraryInput[K]())), UnitOutput)
     command.run((destKey, (sourceKey, sourceKeys.toList)))
   }

--- a/redis/src/main/scala/zio/redis/api/Keys.scala
+++ b/redis/src/main/scala/zio/redis/api/Keys.scala
@@ -25,7 +25,7 @@ import zio.schema.Schema
 
 import java.time.Instant
 
-trait Keys {
+trait Keys extends CommandExecutor {
   import Keys.{Keys => _, _}
 
   /**
@@ -41,7 +41,7 @@ trait Keys {
    * @see
    *   [[unlink]]
    */
-  final def del[K: Schema](key: K, keys: K*): ZIO[Redis, RedisError, Long] = {
+  final def del[K: Schema](key: K, keys: K*): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(Del, NonEmptyList(ArbitraryInput[K]()), LongOutput)
     command.run((key, keys.toList))
   }
@@ -54,7 +54,7 @@ trait Keys {
    * @return
    *   bytes for value stored at key.
    */
-  final def dump[K: Schema](key: K): ZIO[Redis, RedisError, Chunk[Byte]] = {
+  final def dump[K: Schema](key: K): ZIO[Any, RedisError, Chunk[Byte]] = {
     val command = RedisCommand(Dump, ArbitraryInput[K](), BulkStringOutput)
     command.run(key)
   }
@@ -70,7 +70,7 @@ trait Keys {
    * @return
    *   The number of keys existing.
    */
-  final def exists[K: Schema](key: K, keys: K*): ZIO[Redis, RedisError, Long] = {
+  final def exists[K: Schema](key: K, keys: K*): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(Exists, NonEmptyList(ArbitraryInput[K]()), LongOutput)
     command.run((key, keys.toList))
   }
@@ -88,7 +88,7 @@ trait Keys {
    * @see
    *   [[expireAt]]
    */
-  final def expire[K: Schema](key: K, timeout: Duration): ZIO[Redis, RedisError, Boolean] = {
+  final def expire[K: Schema](key: K, timeout: Duration): ZIO[Any, RedisError, Boolean] = {
     val command = RedisCommand(Expire, Tuple2(ArbitraryInput[K](), DurationSecondsInput), BoolOutput)
     command.run((key, timeout))
   }
@@ -106,7 +106,7 @@ trait Keys {
    * @see
    *   [[expire]]
    */
-  final def expireAt[K: Schema](key: K, timestamp: Instant): ZIO[Redis, RedisError, Boolean] = {
+  final def expireAt[K: Schema](key: K, timestamp: Instant): ZIO[Any, RedisError, Boolean] = {
     val command = RedisCommand(ExpireAt, Tuple2(ArbitraryInput[K](), TimeSecondsInput), BoolOutput)
     command.run((key, timestamp))
   }
@@ -121,7 +121,7 @@ trait Keys {
    */
   final def keys(pattern: String): ResultBuilder1[Chunk] =
     new ResultBuilder1[Chunk] {
-      def returning[V: Schema]: ZIO[Redis, RedisError, Chunk[V]] =
+      def returning[V: Schema]: ZIO[Any, RedisError, Chunk[V]] =
         RedisCommand(Keys.Keys, StringInput, ChunkOutput(ArbitraryOutput[V]())).run(pattern)
     }
 
@@ -160,7 +160,7 @@ trait Keys {
     copy: Option[Copy] = None,
     replace: Option[Replace] = None,
     keys: Option[(K, List[K])]
-  ): ZIO[Redis, RedisError, String] = {
+  ): ZIO[Any, RedisError, String] = {
     val command = RedisCommand(
       Migrate,
       Tuple9(
@@ -190,7 +190,7 @@ trait Keys {
    * @return
    *   true if the key was moved.
    */
-  final def move[K: Schema](key: K, destinationDb: Long): ZIO[Redis, RedisError, Boolean] = {
+  final def move[K: Schema](key: K, destinationDb: Long): ZIO[Any, RedisError, Boolean] = {
     val command = RedisCommand(Move, Tuple2(ArbitraryInput[K](), LongInput), BoolOutput)
     command.run((key, destinationDb))
   }
@@ -203,7 +203,7 @@ trait Keys {
    * @return
    *   true if timeout was removed, false if key does not exist or does not have an associated timeout.
    */
-  final def persist[K: Schema](key: K): ZIO[Redis, RedisError, Boolean] = {
+  final def persist[K: Schema](key: K): ZIO[Any, RedisError, Boolean] = {
     val command = RedisCommand(Persist, ArbitraryInput[K](), BoolOutput)
     command.run(key)
   }
@@ -221,7 +221,7 @@ trait Keys {
    * @see
    *   [[pExpireAt]]
    */
-  final def pExpire[K: Schema](key: K, timeout: Duration): ZIO[Redis, RedisError, Boolean] = {
+  final def pExpire[K: Schema](key: K, timeout: Duration): ZIO[Any, RedisError, Boolean] = {
     val command = RedisCommand(PExpire, Tuple2(ArbitraryInput[K](), DurationMillisecondsInput), BoolOutput)
     command.run((key, timeout))
   }
@@ -239,7 +239,7 @@ trait Keys {
    * @see
    *   [[pExpire]]
    */
-  final def pExpireAt[K: Schema](key: K, timestamp: Instant): ZIO[Redis, RedisError, Boolean] = {
+  final def pExpireAt[K: Schema](key: K, timestamp: Instant): ZIO[Any, RedisError, Boolean] = {
     val command = RedisCommand(PExpireAt, Tuple2(ArbitraryInput[K](), TimeMillisecondsInput), BoolOutput)
     command.run((key, timestamp))
   }
@@ -252,7 +252,7 @@ trait Keys {
    * @return
    *   remaining time to live of a key that has a timeout, error otherwise.
    */
-  final def pTtl[K: Schema](key: K): ZIO[Redis, RedisError, Duration] = {
+  final def pTtl[K: Schema](key: K): ZIO[Any, RedisError, Duration] = {
     val command = RedisCommand(PTtl, ArbitraryInput[K](), DurationMillisecondsOutput)
     command.run(key)
   }
@@ -265,7 +265,7 @@ trait Keys {
    */
   final def randomKey: ResultBuilder1[Option] =
     new ResultBuilder1[Option] {
-      def returning[V: Schema]: ZIO[Redis, RedisError, Option[V]] =
+      def returning[V: Schema]: ZIO[Any, RedisError, Option[V]] =
         RedisCommand(RandomKey, NoInput, OptionalOutput(ArbitraryOutput[V]())).run(())
     }
 
@@ -279,7 +279,7 @@ trait Keys {
    * @return
    *   unit if successful, error otherwise.
    */
-  final def rename[K: Schema](key: K, newKey: K): ZIO[Redis, RedisError, Unit] = {
+  final def rename[K: Schema](key: K, newKey: K): ZIO[Any, RedisError, Unit] = {
     val command = RedisCommand(Rename, Tuple2(ArbitraryInput[K](), ArbitraryInput[K]()), UnitOutput)
     command.run((key, newKey))
   }
@@ -294,7 +294,7 @@ trait Keys {
    * @return
    *   true if key was renamed to newKey, false if newKey already exists.
    */
-  final def renameNx[K: Schema](key: K, newKey: K): ZIO[Redis, RedisError, Boolean] = {
+  final def renameNx[K: Schema](key: K, newKey: K): ZIO[Any, RedisError, Boolean] = {
     val command = RedisCommand(RenameNx, Tuple2(ArbitraryInput[K](), ArbitraryInput[K]()), BoolOutput)
     command.run((key, newKey))
   }
@@ -329,7 +329,7 @@ trait Keys {
     absTtl: Option[AbsTtl] = None,
     idleTime: Option[IdleTime] = None,
     freq: Option[Freq] = None
-  ): ZIO[Redis, RedisError, Unit] = {
+  ): ZIO[Any, RedisError, Unit] = {
     val command = RedisCommand(
       Restore,
       Tuple7(
@@ -369,7 +369,7 @@ trait Keys {
     `type`: Option[RedisType] = None
   ): ResultBuilder1[({ type lambda[x] = (Long, Chunk[x]) })#lambda] =
     new ResultBuilder1[({ type lambda[x] = (Long, Chunk[x]) })#lambda] {
-      def returning[K: Schema]: ZIO[Redis, RedisError, (Long, Chunk[K])] = {
+      def returning[K: Schema]: ZIO[Any, RedisError, (Long, Chunk[K])] = {
         val command = RedisCommand(
           Scan,
           Tuple4(LongInput, OptionalInput(PatternInput), OptionalInput(CountInput), OptionalInput(RedisTypeInput)),
@@ -406,7 +406,7 @@ trait Keys {
     alpha: Option[Alpha] = None
   ): ResultBuilder1[Chunk] =
     new ResultBuilder1[Chunk] {
-      def returning[V: Schema]: ZIO[Redis, RedisError, Chunk[V]] = {
+      def returning[V: Schema]: ZIO[Any, RedisError, Chunk[V]] = {
         val command = RedisCommand(
           Sort,
           Tuple6(
@@ -455,7 +455,7 @@ trait Keys {
     order: Order = Order.Ascending,
     get: Option[(String, List[String])] = None,
     alpha: Option[Alpha] = None
-  ): ZIO[Redis, RedisError, Long] = {
+  ): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(
       SortStore,
       Tuple7(
@@ -482,7 +482,7 @@ trait Keys {
    * @return
    *   The number of keys that were touched.
    */
-  final def touch[K: Schema](key: K, keys: K*): ZIO[Redis, RedisError, Long] = {
+  final def touch[K: Schema](key: K, keys: K*): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(Touch, NonEmptyList(ArbitraryInput[K]()), LongOutput)
     command.run((key, keys.toList))
   }
@@ -495,7 +495,7 @@ trait Keys {
    * @return
    *   remaining time to live of a key that has a timeout, error otherwise.
    */
-  final def ttl[K: Schema](key: K): ZIO[Redis, RedisError, Duration] = {
+  final def ttl[K: Schema](key: K): ZIO[Any, RedisError, Duration] = {
     val command = RedisCommand(Ttl, ArbitraryInput[K](), DurationSecondsOutput)
     command.run(key)
   }
@@ -508,7 +508,7 @@ trait Keys {
    * @return
    *   type of the value stored at key.
    */
-  final def typeOf[K: Schema](key: K): ZIO[Redis, RedisError, RedisType] = {
+  final def typeOf[K: Schema](key: K): ZIO[Any, RedisError, RedisType] = {
     val command = RedisCommand(TypeOf, ArbitraryInput[K](), TypeOutput)
     command.run(key)
   }
@@ -527,7 +527,7 @@ trait Keys {
    * @see
    *   [[del]]
    */
-  final def unlink[K: Schema](key: K, keys: K*): ZIO[Redis, RedisError, Long] = {
+  final def unlink[K: Schema](key: K, keys: K*): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(Unlink, NonEmptyList(ArbitraryInput[K]()), LongOutput)
     command.run((key, keys.toList))
   }
@@ -543,7 +543,7 @@ trait Keys {
    * @return
    *   the number of replicas reached both in case of failure and success.
    */
-  final def wait_(replicas: Long, timeout: Duration): ZIO[Redis, RedisError, Long] = {
+  final def wait_(replicas: Long, timeout: Duration): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(Wait, Tuple2(LongInput, LongInput), LongOutput)
     command.run((replicas, timeout.toMillis))
   }

--- a/redis/src/main/scala/zio/redis/api/Lists.scala
+++ b/redis/src/main/scala/zio/redis/api/Lists.scala
@@ -17,11 +17,10 @@
 package zio.redis.api
 
 import zio._
-import zio.redis.CommandExecutor
 import zio.redis.Input._
 import zio.redis.Output._
 import zio.redis.ResultBuilder._
-import zio.redis._
+import zio.redis.{CommandExecutor, _}
 import zio.schema.Schema
 
 trait Lists extends CommandExecutor {

--- a/redis/src/main/scala/zio/redis/api/Lists.scala
+++ b/redis/src/main/scala/zio/redis/api/Lists.scala
@@ -17,13 +17,14 @@
 package zio.redis.api
 
 import zio._
+import zio.redis.CommandExecutor
 import zio.redis.Input._
 import zio.redis.Output._
 import zio.redis.ResultBuilder._
 import zio.redis._
 import zio.schema.Schema
 
-trait Lists {
+trait Lists extends CommandExecutor {
   import Lists._
 
   /**
@@ -46,7 +47,7 @@ trait Lists {
     timeout: Duration
   ): ResultBuilder1[Option] =
     new ResultBuilder1[Option] {
-      def returning[V: Schema]: ZIO[Redis, RedisError, Option[V]] = {
+      def returning[V: Schema]: ZIO[Any, RedisError, Option[V]] = {
         val command = RedisCommand(
           BrPopLPush,
           Tuple3(ArbitraryInput[S](), ArbitraryInput[D](), DurationSecondsInput),
@@ -70,7 +71,7 @@ trait Lists {
    */
   final def lIndex[K: Schema](key: K, index: Long): ResultBuilder1[Option] =
     new ResultBuilder1[Option] {
-      def returning[V: Schema]: ZIO[Redis, RedisError, Option[V]] =
+      def returning[V: Schema]: ZIO[Any, RedisError, Option[V]] =
         RedisCommand(LIndex, Tuple2(ArbitraryInput[K](), LongInput), OptionalOutput(ArbitraryOutput[V]()))
           .run((key, index))
     }
@@ -83,7 +84,7 @@ trait Lists {
    * @return
    *   the length of the list at key.
    */
-  final def lLen[K: Schema](key: K): ZIO[Redis, RedisError, Long] = {
+  final def lLen[K: Schema](key: K): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(LLen, ArbitraryInput[K](), LongOutput)
     command.run(key)
   }
@@ -98,7 +99,7 @@ trait Lists {
    */
   final def lPop[K: Schema](key: K): ResultBuilder1[Option] =
     new ResultBuilder1[Option] {
-      def returning[V: Schema]: ZIO[Redis, RedisError, Option[V]] =
+      def returning[V: Schema]: ZIO[Any, RedisError, Option[V]] =
         RedisCommand(LPop, ArbitraryInput[K](), OptionalOutput(ArbitraryOutput[V]())).run(key)
     }
 
@@ -115,7 +116,7 @@ trait Lists {
    * @return
    *   the length of the list after the push operation.
    */
-  final def lPush[K: Schema, V: Schema](key: K, element: V, elements: V*): ZIO[Redis, RedisError, Long] = {
+  final def lPush[K: Schema, V: Schema](key: K, element: V, elements: V*): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(LPush, Tuple2(ArbitraryInput[K](), NonEmptyList(ArbitraryInput[V]())), LongOutput)
     command.run((key, (element, elements.toList)))
   }
@@ -133,7 +134,7 @@ trait Lists {
    * @return
    *   the length of the list after the push operation.
    */
-  final def lPushX[K: Schema, V: Schema](key: K, element: V, elements: V*): ZIO[Redis, RedisError, Long] = {
+  final def lPushX[K: Schema, V: Schema](key: K, element: V, elements: V*): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(LPushX, Tuple2(ArbitraryInput[K](), NonEmptyList(ArbitraryInput[V]())), LongOutput)
     command.run((key, (element, elements.toList)))
   }
@@ -151,7 +152,7 @@ trait Lists {
    */
   final def lRange[K: Schema](key: K, range: Range): ResultBuilder1[Chunk] =
     new ResultBuilder1[Chunk] {
-      def returning[V: Schema]: ZIO[Redis, RedisError, Chunk[V]] =
+      def returning[V: Schema]: ZIO[Any, RedisError, Chunk[V]] =
         RedisCommand(LRange, Tuple2(ArbitraryInput[K](), RangeInput), ChunkOutput(ArbitraryOutput[V]()))
           .run((key, range))
     }
@@ -173,7 +174,7 @@ trait Lists {
    * @return
    *   the number of removed elements.
    */
-  final def lRem[K: Schema](key: K, count: Long, element: String): ZIO[Redis, RedisError, Long] = {
+  final def lRem[K: Schema](key: K, count: Long, element: String): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(LRem, Tuple3(ArbitraryInput[K](), LongInput, StringInput), LongOutput)
     command.run((key, count, element))
   }
@@ -190,7 +191,7 @@ trait Lists {
    * @return
    *   the Unit value.
    */
-  final def lSet[K: Schema, V: Schema](key: K, index: Long, element: V): ZIO[Redis, RedisError, Unit] = {
+  final def lSet[K: Schema, V: Schema](key: K, index: Long, element: V): ZIO[Any, RedisError, Unit] = {
     val command = RedisCommand(LSet, Tuple3(ArbitraryInput[K](), LongInput, ArbitraryInput[V]()), UnitOutput)
     command.run((key, index, element))
   }
@@ -206,7 +207,7 @@ trait Lists {
    * @return
    *   the Unit value.
    */
-  final def lTrim[K: Schema](key: K, range: Range): ZIO[Redis, RedisError, Unit] = {
+  final def lTrim[K: Schema](key: K, range: Range): ZIO[Any, RedisError, Unit] = {
     val command = RedisCommand(LTrim, Tuple2(ArbitraryInput[K](), RangeInput), UnitOutput)
     command.run((key, range))
   }
@@ -221,7 +222,7 @@ trait Lists {
    */
   final def rPop[K: Schema](key: K): ResultBuilder1[Option] =
     new ResultBuilder1[Option] {
-      def returning[V: Schema]: ZIO[Redis, RedisError, Option[V]] =
+      def returning[V: Schema]: ZIO[Any, RedisError, Option[V]] =
         RedisCommand(RPop, ArbitraryInput[K](), OptionalOutput(ArbitraryOutput[V]())).run(key)
     }
 
@@ -239,7 +240,7 @@ trait Lists {
    */
   final def rPopLPush[S: Schema, D: Schema](source: S, destination: D): ResultBuilder1[Option] =
     new ResultBuilder1[Option] {
-      def returning[V: Schema]: ZIO[Redis, RedisError, Option[V]] =
+      def returning[V: Schema]: ZIO[Any, RedisError, Option[V]] =
         RedisCommand(RPopLPush, Tuple2(ArbitraryInput[S](), ArbitraryInput[D]()), OptionalOutput(ArbitraryOutput[V]()))
           .run((source, destination))
     }
@@ -257,7 +258,7 @@ trait Lists {
    * @return
    *   the length of the list after the push operation.
    */
-  final def rPush[K: Schema, V: Schema](key: K, element: V, elements: V*): ZIO[Redis, RedisError, Long] = {
+  final def rPush[K: Schema, V: Schema](key: K, element: V, elements: V*): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(RPush, Tuple2(ArbitraryInput[K](), NonEmptyList(ArbitraryInput[V]())), LongOutput)
     command.run((key, (element, elements.toList)))
   }
@@ -275,7 +276,7 @@ trait Lists {
    * @return
    *   the length of the list after the push operation.
    */
-  final def rPushX[K: Schema, V: Schema](key: K, element: V, elements: V*): ZIO[Redis, RedisError, Long] = {
+  final def rPushX[K: Schema, V: Schema](key: K, element: V, elements: V*): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(RPushX, Tuple2(ArbitraryInput[K](), NonEmptyList(ArbitraryInput[V]())), LongOutput)
     command.run((key, (element, elements.toList)))
   }
@@ -299,7 +300,7 @@ trait Lists {
     timeout: Duration
   ): ResultBuilder1[({ type lambda[x] = Option[(K, x)] })#lambda] =
     new ResultBuilder1[({ type lambda[x] = Option[(K, x)] })#lambda] {
-      def returning[V: Schema]: ZIO[Redis, RedisError, Option[(K, V)]] = {
+      def returning[V: Schema]: ZIO[Any, RedisError, Option[(K, V)]] = {
         val command = RedisCommand(
           BlPop,
           Tuple2(NonEmptyList(ArbitraryInput[K]()), DurationSecondsInput),
@@ -328,7 +329,7 @@ trait Lists {
     timeout: Duration
   ): ResultBuilder1[({ type lambda[x] = Option[(K, x)] })#lambda] =
     new ResultBuilder1[({ type lambda[x] = Option[(K, x)] })#lambda] {
-      def returning[V: Schema]: ZIO[Redis, RedisError, Option[(K, V)]] = {
+      def returning[V: Schema]: ZIO[Any, RedisError, Option[(K, V)]] = {
         val command = RedisCommand(
           BrPop,
           Tuple2(NonEmptyList(ArbitraryInput[K]()), DurationSecondsInput),
@@ -357,7 +358,7 @@ trait Lists {
     position: Position,
     pivot: V,
     element: V
-  ): ZIO[Redis, RedisError, Long] = {
+  ): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(
       LInsert,
       Tuple4(ArbitraryInput[K](), PositionInput, ArbitraryInput[V](), ArbitraryInput[V]()),
@@ -389,7 +390,7 @@ trait Lists {
     destinationSide: Side
   ): ResultBuilder1[Option] =
     new ResultBuilder1[Option] {
-      def returning[V: Schema]: ZIO[Redis, RedisError, Option[V]] = {
+      def returning[V: Schema]: ZIO[Any, RedisError, Option[V]] = {
         val command = RedisCommand(
           LMove,
           Tuple4(ArbitraryInput[S](), ArbitraryInput[D](), SideInput, SideInput),
@@ -426,7 +427,7 @@ trait Lists {
     timeout: Duration
   ): ResultBuilder1[Option] =
     new ResultBuilder1[Option] {
-      def returning[V: Schema]: ZIO[Redis, RedisError, Option[V]] = {
+      def returning[V: Schema]: ZIO[Any, RedisError, Option[V]] = {
         val command = RedisCommand(
           BlMove,
           Tuple5(ArbitraryInput[S](), ArbitraryInput[D](), SideInput, SideInput, DurationSecondsInput),
@@ -458,7 +459,7 @@ trait Lists {
     element: V,
     rank: Option[Rank] = None,
     maxLen: Option[ListMaxLen] = None
-  ): ZIO[Redis, RedisError, Option[Long]] = {
+  ): ZIO[Any, RedisError, Option[Long]] = {
     val command = RedisCommand(
       LPos,
       Tuple4(
@@ -497,7 +498,7 @@ trait Lists {
     count: Count,
     rank: Option[Rank] = None,
     maxLen: Option[ListMaxLen] = None
-  ): ZIO[Redis, RedisError, Chunk[Long]] = {
+  ): ZIO[Any, RedisError, Chunk[Long]] = {
     val command = RedisCommand(
       LPos,
       Tuple5(

--- a/redis/src/main/scala/zio/redis/api/Lists.scala
+++ b/redis/src/main/scala/zio/redis/api/Lists.scala
@@ -50,8 +50,10 @@ trait Lists extends RedisEnvironment {
         val command = RedisCommand(
           BrPopLPush,
           Tuple3(ArbitraryInput[S](), ArbitraryInput[D](), DurationSecondsInput),
-          OptionalOutput(ArbitraryOutput[V]())
-        )(executor, codec)
+          OptionalOutput(ArbitraryOutput[V]()),
+          codec,
+          executor
+        )
 
         command.run((source, destination, timeout))
       }
@@ -71,9 +73,12 @@ trait Lists extends RedisEnvironment {
   final def lIndex[K: Schema](key: K, index: Long): ResultBuilder1[Option] =
     new ResultBuilder1[Option] {
       def returning[V: Schema]: IO[RedisError, Option[V]] =
-        RedisCommand(LIndex, Tuple2(ArbitraryInput[K](), LongInput), OptionalOutput(ArbitraryOutput[V]()))(
-          executor,
-          codec
+        RedisCommand(
+          LIndex,
+          Tuple2(ArbitraryInput[K](), LongInput),
+          OptionalOutput(ArbitraryOutput[V]()),
+          codec,
+          executor
         )
           .run((key, index))
     }
@@ -87,7 +92,7 @@ trait Lists extends RedisEnvironment {
    *   the length of the list at key.
    */
   final def lLen[K: Schema](key: K): IO[RedisError, Long] = {
-    val command = RedisCommand(LLen, ArbitraryInput[K](), LongOutput)(executor, codec)
+    val command = RedisCommand(LLen, ArbitraryInput[K](), LongOutput, codec, executor)
     command.run(key)
   }
 
@@ -102,7 +107,7 @@ trait Lists extends RedisEnvironment {
   final def lPop[K: Schema](key: K): ResultBuilder1[Option] =
     new ResultBuilder1[Option] {
       def returning[V: Schema]: IO[RedisError, Option[V]] =
-        RedisCommand(LPop, ArbitraryInput[K](), OptionalOutput(ArbitraryOutput[V]()))(executor, codec).run(key)
+        RedisCommand(LPop, ArbitraryInput[K](), OptionalOutput(ArbitraryOutput[V]()), codec, executor).run(key)
     }
 
   /**
@@ -120,7 +125,7 @@ trait Lists extends RedisEnvironment {
    */
   final def lPush[K: Schema, V: Schema](key: K, element: V, elements: V*): IO[RedisError, Long] = {
     val command =
-      RedisCommand(LPush, Tuple2(ArbitraryInput[K](), NonEmptyList(ArbitraryInput[V]())), LongOutput)(executor, codec)
+      RedisCommand(LPush, Tuple2(ArbitraryInput[K](), NonEmptyList(ArbitraryInput[V]())), LongOutput, codec, executor)
     command.run((key, (element, elements.toList)))
   }
 
@@ -139,7 +144,7 @@ trait Lists extends RedisEnvironment {
    */
   final def lPushX[K: Schema, V: Schema](key: K, element: V, elements: V*): IO[RedisError, Long] = {
     val command =
-      RedisCommand(LPushX, Tuple2(ArbitraryInput[K](), NonEmptyList(ArbitraryInput[V]())), LongOutput)(executor, codec)
+      RedisCommand(LPushX, Tuple2(ArbitraryInput[K](), NonEmptyList(ArbitraryInput[V]())), LongOutput, codec, executor)
     command.run((key, (element, elements.toList)))
   }
 
@@ -157,9 +162,12 @@ trait Lists extends RedisEnvironment {
   final def lRange[K: Schema](key: K, range: Range): ResultBuilder1[Chunk] =
     new ResultBuilder1[Chunk] {
       def returning[V: Schema]: IO[RedisError, Chunk[V]] =
-        RedisCommand(LRange, Tuple2(ArbitraryInput[K](), RangeInput), ChunkOutput(ArbitraryOutput[V]()))(
-          executor,
-          codec
+        RedisCommand(
+          LRange,
+          Tuple2(ArbitraryInput[K](), RangeInput),
+          ChunkOutput(ArbitraryOutput[V]()),
+          codec,
+          executor
         )
           .run((key, range))
     }
@@ -182,7 +190,7 @@ trait Lists extends RedisEnvironment {
    *   the number of removed elements.
    */
   final def lRem[K: Schema](key: K, count: Long, element: String): IO[RedisError, Long] = {
-    val command = RedisCommand(LRem, Tuple3(ArbitraryInput[K](), LongInput, StringInput), LongOutput)(executor, codec)
+    val command = RedisCommand(LRem, Tuple3(ArbitraryInput[K](), LongInput, StringInput), LongOutput, codec, executor)
     command.run((key, count, element))
   }
 
@@ -200,7 +208,7 @@ trait Lists extends RedisEnvironment {
    */
   final def lSet[K: Schema, V: Schema](key: K, index: Long, element: V): IO[RedisError, Unit] = {
     val command =
-      RedisCommand(LSet, Tuple3(ArbitraryInput[K](), LongInput, ArbitraryInput[V]()), UnitOutput)(executor, codec)
+      RedisCommand(LSet, Tuple3(ArbitraryInput[K](), LongInput, ArbitraryInput[V]()), UnitOutput, codec, executor)
     command.run((key, index, element))
   }
 
@@ -216,7 +224,7 @@ trait Lists extends RedisEnvironment {
    *   the Unit value.
    */
   final def lTrim[K: Schema](key: K, range: Range): IO[RedisError, Unit] = {
-    val command = RedisCommand(LTrim, Tuple2(ArbitraryInput[K](), RangeInput), UnitOutput)(executor, codec)
+    val command = RedisCommand(LTrim, Tuple2(ArbitraryInput[K](), RangeInput), UnitOutput, codec, executor)
     command.run((key, range))
   }
 
@@ -231,7 +239,7 @@ trait Lists extends RedisEnvironment {
   final def rPop[K: Schema](key: K): ResultBuilder1[Option] =
     new ResultBuilder1[Option] {
       def returning[V: Schema]: IO[RedisError, Option[V]] =
-        RedisCommand(RPop, ArbitraryInput[K](), OptionalOutput(ArbitraryOutput[V]()))(executor, codec).run(key)
+        RedisCommand(RPop, ArbitraryInput[K](), OptionalOutput(ArbitraryOutput[V]()), codec, executor).run(key)
     }
 
   /**
@@ -249,9 +257,12 @@ trait Lists extends RedisEnvironment {
   final def rPopLPush[S: Schema, D: Schema](source: S, destination: D): ResultBuilder1[Option] =
     new ResultBuilder1[Option] {
       def returning[V: Schema]: IO[RedisError, Option[V]] =
-        RedisCommand(RPopLPush, Tuple2(ArbitraryInput[S](), ArbitraryInput[D]()), OptionalOutput(ArbitraryOutput[V]()))(
-          executor,
-          codec
+        RedisCommand(
+          RPopLPush,
+          Tuple2(ArbitraryInput[S](), ArbitraryInput[D]()),
+          OptionalOutput(ArbitraryOutput[V]()),
+          codec,
+          executor
         )
           .run((source, destination))
     }
@@ -271,7 +282,7 @@ trait Lists extends RedisEnvironment {
    */
   final def rPush[K: Schema, V: Schema](key: K, element: V, elements: V*): IO[RedisError, Long] = {
     val command =
-      RedisCommand(RPush, Tuple2(ArbitraryInput[K](), NonEmptyList(ArbitraryInput[V]())), LongOutput)(executor, codec)
+      RedisCommand(RPush, Tuple2(ArbitraryInput[K](), NonEmptyList(ArbitraryInput[V]())), LongOutput, codec, executor)
     command.run((key, (element, elements.toList)))
   }
 
@@ -290,7 +301,7 @@ trait Lists extends RedisEnvironment {
    */
   final def rPushX[K: Schema, V: Schema](key: K, element: V, elements: V*): IO[RedisError, Long] = {
     val command =
-      RedisCommand(RPushX, Tuple2(ArbitraryInput[K](), NonEmptyList(ArbitraryInput[V]())), LongOutput)(executor, codec)
+      RedisCommand(RPushX, Tuple2(ArbitraryInput[K](), NonEmptyList(ArbitraryInput[V]())), LongOutput, codec, executor)
     command.run((key, (element, elements.toList)))
   }
 
@@ -317,8 +328,10 @@ trait Lists extends RedisEnvironment {
         val command = RedisCommand(
           BlPop,
           Tuple2(NonEmptyList(ArbitraryInput[K]()), DurationSecondsInput),
-          OptionalOutput(Tuple2Output(ArbitraryOutput[K](), ArbitraryOutput[V]()))
-        )(executor, codec)
+          OptionalOutput(Tuple2Output(ArbitraryOutput[K](), ArbitraryOutput[V]())),
+          codec,
+          executor
+        )
         command.run(((key, keys.toList), timeout))
       }
     }
@@ -346,8 +359,10 @@ trait Lists extends RedisEnvironment {
         val command = RedisCommand(
           BrPop,
           Tuple2(NonEmptyList(ArbitraryInput[K]()), DurationSecondsInput),
-          OptionalOutput(Tuple2Output(ArbitraryOutput[K](), ArbitraryOutput[V]()))
-        )(executor, codec)
+          OptionalOutput(Tuple2Output(ArbitraryOutput[K](), ArbitraryOutput[V]())),
+          codec,
+          executor
+        )
         command.run(((key, keys.toList), timeout))
       }
     }
@@ -375,8 +390,10 @@ trait Lists extends RedisEnvironment {
     val command = RedisCommand(
       LInsert,
       Tuple4(ArbitraryInput[K](), PositionInput, ArbitraryInput[V](), ArbitraryInput[V]()),
-      LongOutput
-    )(executor, codec)
+      LongOutput,
+      codec,
+      executor
+    )
     command.run((key, position, pivot, element))
   }
 
@@ -407,8 +424,10 @@ trait Lists extends RedisEnvironment {
         val command = RedisCommand(
           LMove,
           Tuple4(ArbitraryInput[S](), ArbitraryInput[D](), SideInput, SideInput),
-          OptionalOutput(ArbitraryOutput[V]())
-        )(executor, codec)
+          OptionalOutput(ArbitraryOutput[V]()),
+          codec,
+          executor
+        )
         command.run((source, destination, sourceSide, destinationSide))
       }
     }
@@ -444,8 +463,10 @@ trait Lists extends RedisEnvironment {
         val command = RedisCommand(
           BlMove,
           Tuple5(ArbitraryInput[S](), ArbitraryInput[D](), SideInput, SideInput, DurationSecondsInput),
-          OptionalOutput(ArbitraryOutput[V]())
-        )(executor, codec)
+          OptionalOutput(ArbitraryOutput[V]()),
+          codec,
+          executor
+        )
 
         command.run((source, destination, sourceSide, destinationSide, timeout))
       }
@@ -481,8 +502,10 @@ trait Lists extends RedisEnvironment {
         OptionalInput(RankInput),
         OptionalInput(ListMaxLenInput)
       ),
-      OptionalOutput(LongOutput)
-    )(executor, codec)
+      OptionalOutput(LongOutput),
+      codec,
+      executor
+    )
 
     command.run((key, element, rank, maxLen))
   }
@@ -521,8 +544,10 @@ trait Lists extends RedisEnvironment {
         OptionalInput(RankInput),
         OptionalInput(ListMaxLenInput)
       ),
-      ChunkOutput(LongOutput)
-    )(executor, codec)
+      ChunkOutput(LongOutput),
+      codec,
+      executor
+    )
 
     command.run((key, element, count, rank, maxLen))
   }

--- a/redis/src/main/scala/zio/redis/api/Scripting.scala
+++ b/redis/src/main/scala/zio/redis/api/Scripting.scala
@@ -44,7 +44,7 @@ trait Scripting extends RedisEnvironment {
     args: Chunk[A]
   ): ResultOutputBuilder = new ResultOutputBuilder {
     def returning[R: Output]: IO[RedisError, R] = {
-      val command = RedisCommand(Eval, EvalInput(Input[K], Input[A]), Output[R])(executor, codec)
+      val command = RedisCommand(Eval, EvalInput(Input[K], Input[A]), Output[R], codec, executor)
       command.run((script, keys, args))
     }
   }
@@ -69,7 +69,7 @@ trait Scripting extends RedisEnvironment {
     args: Chunk[A]
   ): ResultOutputBuilder = new ResultOutputBuilder {
     def returning[R: Output]: IO[RedisError, R] = {
-      val command = RedisCommand(EvalSha, EvalInput(Input[K], Input[A]), Output[R])(executor, codec)
+      val command = RedisCommand(EvalSha, EvalInput(Input[K], Input[A]), Output[R], codec, executor)
       command.run((sha1, keys, args))
     }
   }
@@ -86,7 +86,7 @@ trait Scripting extends RedisEnvironment {
    *   otherwise false is returned.
    */
   def scriptExists(sha1: String, sha1s: String*): IO[RedisError, Chunk[Boolean]] = {
-    val command = RedisCommand(ScriptExists, NonEmptyList(StringInput), ChunkOutput(BoolOutput))(executor, codec)
+    val command = RedisCommand(ScriptExists, NonEmptyList(StringInput), ChunkOutput(BoolOutput), codec, executor)
     command.run((sha1, sha1s.toList))
   }
 
@@ -100,7 +100,7 @@ trait Scripting extends RedisEnvironment {
    *   the SHA1 digest of the script added into the script cache.
    */
   def scriptLoad(script: String): IO[RedisError, String] = {
-    val command = RedisCommand(ScriptLoad, StringInput, MultiStringOutput)(executor, codec)
+    val command = RedisCommand(ScriptLoad, StringInput, MultiStringOutput, codec, executor)
     command.run(script)
   }
 }

--- a/redis/src/main/scala/zio/redis/api/Scripting.scala
+++ b/redis/src/main/scala/zio/redis/api/Scripting.scala
@@ -22,7 +22,7 @@ import zio.redis.Output._
 import zio.redis.ResultBuilder.ResultOutputBuilder
 import zio.redis._
 
-trait Scripting {
+trait Scripting extends CommandExecutor {
   import Scripting._
 
   /**
@@ -43,7 +43,7 @@ trait Scripting {
     keys: Chunk[K],
     args: Chunk[A]
   ): ResultOutputBuilder = new ResultOutputBuilder {
-    def returning[R: Output]: ZIO[Redis, RedisError, R] = {
+    def returning[R: Output]: ZIO[Any, RedisError, R] = {
       val command = RedisCommand(Eval, EvalInput(Input[K], Input[A]), Output[R])
       command.run((script, keys, args))
     }
@@ -68,7 +68,7 @@ trait Scripting {
     keys: Chunk[K],
     args: Chunk[A]
   ): ResultOutputBuilder = new ResultOutputBuilder {
-    def returning[R: Output]: ZIO[Redis, RedisError, R] = {
+    def returning[R: Output]: ZIO[Any, RedisError, R] = {
       val command = RedisCommand(EvalSha, EvalInput(Input[K], Input[A]), Output[R])
       command.run((sha1, keys, args))
     }
@@ -85,7 +85,7 @@ trait Scripting {
    *   for every corresponding SHA1 digest of a script that actually exists in the script cache, an true is returned,
    *   otherwise false is returned.
    */
-  def scriptExists(sha1: String, sha1s: String*): ZIO[Redis, RedisError, Chunk[Boolean]] = {
+  def scriptExists(sha1: String, sha1s: String*): ZIO[Any, RedisError, Chunk[Boolean]] = {
     val command = RedisCommand(ScriptExists, NonEmptyList(StringInput), ChunkOutput(BoolOutput))
     command.run((sha1, sha1s.toList))
   }
@@ -99,7 +99,7 @@ trait Scripting {
    * @return
    *   the SHA1 digest of the script added into the script cache.
    */
-  def scriptLoad(script: String): ZIO[Redis, RedisError, String] = {
+  def scriptLoad(script: String): ZIO[Any, RedisError, String] = {
     val command = RedisCommand(ScriptLoad, StringInput, MultiStringOutput)
     command.run(script)
   }

--- a/redis/src/main/scala/zio/redis/api/Scripting.scala
+++ b/redis/src/main/scala/zio/redis/api/Scripting.scala
@@ -22,7 +22,7 @@ import zio.redis.Output._
 import zio.redis.ResultBuilder.ResultOutputBuilder
 import zio.redis._
 
-trait Scripting extends CommandExecutor {
+trait Scripting extends RedisEnvironment {
   import Scripting._
 
   /**
@@ -43,8 +43,8 @@ trait Scripting extends CommandExecutor {
     keys: Chunk[K],
     args: Chunk[A]
   ): ResultOutputBuilder = new ResultOutputBuilder {
-    def returning[R: Output]: ZIO[Any, RedisError, R] = {
-      val command = RedisCommand(Eval, EvalInput(Input[K], Input[A]), Output[R])
+    def returning[R: Output]: IO[RedisError, R] = {
+      val command = RedisCommand(Eval, EvalInput(Input[K], Input[A]), Output[R])(executor, codec)
       command.run((script, keys, args))
     }
   }
@@ -68,8 +68,8 @@ trait Scripting extends CommandExecutor {
     keys: Chunk[K],
     args: Chunk[A]
   ): ResultOutputBuilder = new ResultOutputBuilder {
-    def returning[R: Output]: ZIO[Any, RedisError, R] = {
-      val command = RedisCommand(EvalSha, EvalInput(Input[K], Input[A]), Output[R])
+    def returning[R: Output]: IO[RedisError, R] = {
+      val command = RedisCommand(EvalSha, EvalInput(Input[K], Input[A]), Output[R])(executor, codec)
       command.run((sha1, keys, args))
     }
   }
@@ -85,8 +85,8 @@ trait Scripting extends CommandExecutor {
    *   for every corresponding SHA1 digest of a script that actually exists in the script cache, an true is returned,
    *   otherwise false is returned.
    */
-  def scriptExists(sha1: String, sha1s: String*): ZIO[Any, RedisError, Chunk[Boolean]] = {
-    val command = RedisCommand(ScriptExists, NonEmptyList(StringInput), ChunkOutput(BoolOutput))
+  def scriptExists(sha1: String, sha1s: String*): IO[RedisError, Chunk[Boolean]] = {
+    val command = RedisCommand(ScriptExists, NonEmptyList(StringInput), ChunkOutput(BoolOutput))(executor, codec)
     command.run((sha1, sha1s.toList))
   }
 
@@ -99,8 +99,8 @@ trait Scripting extends CommandExecutor {
    * @return
    *   the SHA1 digest of the script added into the script cache.
    */
-  def scriptLoad(script: String): ZIO[Any, RedisError, String] = {
-    val command = RedisCommand(ScriptLoad, StringInput, MultiStringOutput)
+  def scriptLoad(script: String): IO[RedisError, String] = {
+    val command = RedisCommand(ScriptLoad, StringInput, MultiStringOutput)(executor, codec)
     command.run(script)
   }
 }

--- a/redis/src/main/scala/zio/redis/api/Sets.scala
+++ b/redis/src/main/scala/zio/redis/api/Sets.scala
@@ -41,7 +41,7 @@ trait Sets extends RedisEnvironment {
    */
   final def sAdd[K: Schema, M: Schema](key: K, member: M, members: M*): IO[RedisError, Long] = {
     val command =
-      RedisCommand(SAdd, Tuple2(ArbitraryInput[K](), NonEmptyList(ArbitraryInput[M]())), LongOutput)(executor, codec)
+      RedisCommand(SAdd, Tuple2(ArbitraryInput[K](), NonEmptyList(ArbitraryInput[M]())), LongOutput, codec, executor)
     command.run((key, (member, members.toList)))
   }
 
@@ -54,7 +54,7 @@ trait Sets extends RedisEnvironment {
    *   Returns the cardinality (number of elements) of the set, or 0 if key does not exist.
    */
   final def sCard[K: Schema](key: K): IO[RedisError, Long] = {
-    val command = RedisCommand(SCard, ArbitraryInput[K](), LongOutput)(executor, codec)
+    val command = RedisCommand(SCard, ArbitraryInput[K](), LongOutput, codec, executor)
     command.run(key)
   }
 
@@ -71,7 +71,7 @@ trait Sets extends RedisEnvironment {
   final def sDiff[K: Schema](key: K, keys: K*): ResultBuilder1[Chunk] =
     new ResultBuilder1[Chunk] {
       def returning[R: Schema]: IO[RedisError, Chunk[R]] =
-        RedisCommand(SDiff, NonEmptyList(ArbitraryInput[K]()), ChunkOutput(ArbitraryOutput[R]()))(executor, codec)
+        RedisCommand(SDiff, NonEmptyList(ArbitraryInput[K]()), ChunkOutput(ArbitraryOutput[R]()), codec, executor)
           .run((key, keys.toList))
     }
 
@@ -88,9 +88,12 @@ trait Sets extends RedisEnvironment {
    *   Returns the number of elements in the resulting set.
    */
   final def sDiffStore[D: Schema, K: Schema](destination: D, key: K, keys: K*): IO[RedisError, Long] = {
-    val command = RedisCommand(SDiffStore, Tuple2(ArbitraryInput[D](), NonEmptyList(ArbitraryInput[K]())), LongOutput)(
-      executor,
-      codec
+    val command = RedisCommand(
+      SDiffStore,
+      Tuple2(ArbitraryInput[D](), NonEmptyList(ArbitraryInput[K]())),
+      LongOutput,
+      codec,
+      executor
     )
     command.run((destination, (key, keys.toList)))
   }
@@ -108,7 +111,7 @@ trait Sets extends RedisEnvironment {
   final def sInter[K: Schema](destination: K, keys: K*): ResultBuilder1[Chunk] =
     new ResultBuilder1[Chunk] {
       def returning[R: Schema]: IO[RedisError, Chunk[R]] =
-        RedisCommand(SInter, NonEmptyList(ArbitraryInput[K]()), ChunkOutput(ArbitraryOutput[R]()))(executor, codec)
+        RedisCommand(SInter, NonEmptyList(ArbitraryInput[K]()), ChunkOutput(ArbitraryOutput[R]()), codec, executor)
           .run((destination, keys.toList))
     }
 
@@ -129,9 +132,12 @@ trait Sets extends RedisEnvironment {
     key: K,
     keys: K*
   ): IO[RedisError, Long] = {
-    val command = RedisCommand(SInterStore, Tuple2(ArbitraryInput[D](), NonEmptyList(ArbitraryInput[K]())), LongOutput)(
-      executor,
-      codec
+    val command = RedisCommand(
+      SInterStore,
+      Tuple2(ArbitraryInput[D](), NonEmptyList(ArbitraryInput[K]())),
+      LongOutput,
+      codec,
+      executor
     )
     command.run((destination, (key, keys.toList)))
   }
@@ -148,7 +154,7 @@ trait Sets extends RedisEnvironment {
    *   exist.
    */
   final def sIsMember[K: Schema, M: Schema](key: K, member: M): IO[RedisError, Boolean] = {
-    val command = RedisCommand(SIsMember, Tuple2(ArbitraryInput[K](), ArbitraryInput[M]()), BoolOutput)(executor, codec)
+    val command = RedisCommand(SIsMember, Tuple2(ArbitraryInput[K](), ArbitraryInput[M]()), BoolOutput, codec, executor)
     command.run((key, member))
   }
 
@@ -163,7 +169,7 @@ trait Sets extends RedisEnvironment {
   final def sMembers[K: Schema](key: K): ResultBuilder1[Chunk] =
     new ResultBuilder1[Chunk] {
       def returning[R: Schema]: IO[RedisError, Chunk[R]] =
-        RedisCommand(SMembers, ArbitraryInput[K](), ChunkOutput(ArbitraryOutput[R]()))(executor, codec).run(key)
+        RedisCommand(SMembers, ArbitraryInput[K](), ChunkOutput(ArbitraryOutput[R]()), codec, executor).run(key)
     }
 
   /**
@@ -186,8 +192,10 @@ trait Sets extends RedisEnvironment {
     val command = RedisCommand(
       SMove,
       Tuple3(ArbitraryInput[S](), ArbitraryInput[D](), ArbitraryInput[M]()),
-      BoolOutput
-    )(executor, codec)
+      BoolOutput,
+      codec,
+      executor
+    )
     command.run((source, destination, member))
   }
 
@@ -207,8 +215,10 @@ trait Sets extends RedisEnvironment {
         val command = RedisCommand(
           SPop,
           Tuple2(ArbitraryInput[K](), OptionalInput(LongInput)),
-          MultiStringChunkOutput(ArbitraryOutput[R]())
-        )(executor, codec)
+          MultiStringChunkOutput(ArbitraryOutput[R]()),
+          codec,
+          executor
+        )
         command.run((key, count))
       }
     }
@@ -229,8 +239,10 @@ trait Sets extends RedisEnvironment {
         val command = RedisCommand(
           SRandMember,
           Tuple2(ArbitraryInput[K](), OptionalInput(LongInput)),
-          MultiStringChunkOutput(ArbitraryOutput[R]())
-        )(executor, codec)
+          MultiStringChunkOutput(ArbitraryOutput[R]()),
+          codec,
+          executor
+        )
         command.run((key, count))
       }
     }
@@ -249,7 +261,7 @@ trait Sets extends RedisEnvironment {
    */
   final def sRem[K: Schema, M: Schema](key: K, member: M, members: M*): IO[RedisError, Long] = {
     val command =
-      RedisCommand(SRem, Tuple2(ArbitraryInput[K](), NonEmptyList(ArbitraryInput[M]())), LongOutput)(executor, codec)
+      RedisCommand(SRem, Tuple2(ArbitraryInput[K](), NonEmptyList(ArbitraryInput[M]())), LongOutput, codec, executor)
     command.run((key, (member, members.toList)))
   }
 
@@ -281,8 +293,10 @@ trait Sets extends RedisEnvironment {
         val command = RedisCommand(
           SScan,
           Tuple4(ArbitraryInput[K](), LongInput, OptionalInput(PatternInput), OptionalInput(CountInput)),
-          Tuple2Output(MultiStringOutput.map(_.toLong), ChunkOutput(ArbitraryOutput[R]()))
-        )(executor, codec)
+          Tuple2Output(MultiStringOutput.map(_.toLong), ChunkOutput(ArbitraryOutput[R]())),
+          codec,
+          executor
+        )
         command.run((key, cursor, pattern.map(Pattern(_)), count))
       }
     }
@@ -300,7 +314,7 @@ trait Sets extends RedisEnvironment {
   final def sUnion[K: Schema](key: K, keys: K*): ResultBuilder1[Chunk] =
     new ResultBuilder1[Chunk] {
       def returning[R: Schema]: IO[RedisError, Chunk[R]] =
-        RedisCommand(SUnion, NonEmptyList(ArbitraryInput[K]()), ChunkOutput(ArbitraryOutput[R]()))(executor, codec)
+        RedisCommand(SUnion, NonEmptyList(ArbitraryInput[K]()), ChunkOutput(ArbitraryOutput[R]()), codec, executor)
           .run((key, keys.toList))
     }
 
@@ -321,9 +335,12 @@ trait Sets extends RedisEnvironment {
     key: K,
     keys: K*
   ): IO[RedisError, Long] = {
-    val command = RedisCommand(SUnionStore, Tuple2(ArbitraryInput[D](), NonEmptyList(ArbitraryInput[K]())), LongOutput)(
-      executor,
-      codec
+    val command = RedisCommand(
+      SUnionStore,
+      Tuple2(ArbitraryInput[D](), NonEmptyList(ArbitraryInput[K]())),
+      LongOutput,
+      codec,
+      executor
     )
     command.run((destination, (key, keys.toList)))
   }

--- a/redis/src/main/scala/zio/redis/api/Sets.scala
+++ b/redis/src/main/scala/zio/redis/api/Sets.scala
@@ -23,7 +23,7 @@ import zio.redis.ResultBuilder._
 import zio.redis._
 import zio.schema.Schema
 
-trait Sets {
+trait Sets extends CommandExecutor {
   import Sets._
 
   /**
@@ -39,7 +39,7 @@ trait Sets {
    *   Returns the number of elements that were added to the set, not including all the elements already present into
    *   the set.
    */
-  final def sAdd[K: Schema, M: Schema](key: K, member: M, members: M*): ZIO[Redis, RedisError, Long] = {
+  final def sAdd[K: Schema, M: Schema](key: K, member: M, members: M*): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(SAdd, Tuple2(ArbitraryInput[K](), NonEmptyList(ArbitraryInput[M]())), LongOutput)
     command.run((key, (member, members.toList)))
   }
@@ -52,7 +52,7 @@ trait Sets {
    * @return
    *   Returns the cardinality (number of elements) of the set, or 0 if key does not exist.
    */
-  final def sCard[K: Schema](key: K): ZIO[Redis, RedisError, Long] = {
+  final def sCard[K: Schema](key: K): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(SCard, ArbitraryInput[K](), LongOutput)
     command.run(key)
   }
@@ -69,7 +69,7 @@ trait Sets {
    */
   final def sDiff[K: Schema](key: K, keys: K*): ResultBuilder1[Chunk] =
     new ResultBuilder1[Chunk] {
-      def returning[R: Schema]: ZIO[Redis, RedisError, Chunk[R]] =
+      def returning[R: Schema]: ZIO[Any, RedisError, Chunk[R]] =
         RedisCommand(SDiff, NonEmptyList(ArbitraryInput[K]()), ChunkOutput(ArbitraryOutput[R]()))
           .run((key, keys.toList))
     }
@@ -86,7 +86,7 @@ trait Sets {
    * @return
    *   Returns the number of elements in the resulting set.
    */
-  final def sDiffStore[D: Schema, K: Schema](destination: D, key: K, keys: K*): ZIO[Redis, RedisError, Long] = {
+  final def sDiffStore[D: Schema, K: Schema](destination: D, key: K, keys: K*): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(SDiffStore, Tuple2(ArbitraryInput[D](), NonEmptyList(ArbitraryInput[K]())), LongOutput)
     command.run((destination, (key, keys.toList)))
   }
@@ -103,7 +103,7 @@ trait Sets {
    */
   final def sInter[K: Schema](destination: K, keys: K*): ResultBuilder1[Chunk] =
     new ResultBuilder1[Chunk] {
-      def returning[R: Schema]: ZIO[Redis, RedisError, Chunk[R]] =
+      def returning[R: Schema]: ZIO[Any, RedisError, Chunk[R]] =
         RedisCommand(SInter, NonEmptyList(ArbitraryInput[K]()), ChunkOutput(ArbitraryOutput[R]()))
           .run((destination, keys.toList))
     }
@@ -124,7 +124,7 @@ trait Sets {
     destination: D,
     key: K,
     keys: K*
-  ): ZIO[Redis, RedisError, Long] = {
+  ): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(SInterStore, Tuple2(ArbitraryInput[D](), NonEmptyList(ArbitraryInput[K]())), LongOutput)
     command.run((destination, (key, keys.toList)))
   }
@@ -140,7 +140,7 @@ trait Sets {
    *   Returns 1 if the element is a member of the set. 0 if the element is not a member of the set, or if key does not
    *   exist.
    */
-  final def sIsMember[K: Schema, M: Schema](key: K, member: M): ZIO[Redis, RedisError, Boolean] = {
+  final def sIsMember[K: Schema, M: Schema](key: K, member: M): ZIO[Any, RedisError, Boolean] = {
     val command = RedisCommand(SIsMember, Tuple2(ArbitraryInput[K](), ArbitraryInput[M]()), BoolOutput)
     command.run((key, member))
   }
@@ -155,7 +155,7 @@ trait Sets {
    */
   final def sMembers[K: Schema](key: K): ResultBuilder1[Chunk] =
     new ResultBuilder1[Chunk] {
-      def returning[R: Schema]: ZIO[Redis, RedisError, Chunk[R]] =
+      def returning[R: Schema]: ZIO[Any, RedisError, Chunk[R]] =
         RedisCommand(SMembers, ArbitraryInput[K](), ChunkOutput(ArbitraryOutput[R]())).run(key)
     }
 
@@ -175,7 +175,7 @@ trait Sets {
     source: S,
     destination: D,
     member: M
-  ): ZIO[Redis, RedisError, Boolean] = {
+  ): ZIO[Any, RedisError, Boolean] = {
     val command = RedisCommand(SMove, Tuple3(ArbitraryInput[S](), ArbitraryInput[D](), ArbitraryInput[M]()), BoolOutput)
     command.run((source, destination, member))
   }
@@ -192,7 +192,7 @@ trait Sets {
    */
   final def sPop[K: Schema](key: K, count: Option[Long] = None): ResultBuilder1[Chunk] =
     new ResultBuilder1[Chunk] {
-      def returning[R: Schema]: ZIO[Redis, RedisError, Chunk[R]] = {
+      def returning[R: Schema]: ZIO[Any, RedisError, Chunk[R]] = {
         val command = RedisCommand(
           SPop,
           Tuple2(ArbitraryInput[K](), OptionalInput(LongInput)),
@@ -214,7 +214,7 @@ trait Sets {
    */
   final def sRandMember[K: Schema](key: K, count: Option[Long] = None): ResultBuilder1[Chunk] =
     new ResultBuilder1[Chunk] {
-      def returning[R: Schema]: ZIO[Redis, RedisError, Chunk[R]] = {
+      def returning[R: Schema]: ZIO[Any, RedisError, Chunk[R]] = {
         val command = RedisCommand(
           SRandMember,
           Tuple2(ArbitraryInput[K](), OptionalInput(LongInput)),
@@ -236,7 +236,7 @@ trait Sets {
    * @return
    *   Returns the number of members that were removed from the set, not including non existing members.
    */
-  final def sRem[K: Schema, M: Schema](key: K, member: M, members: M*): ZIO[Redis, RedisError, Long] = {
+  final def sRem[K: Schema, M: Schema](key: K, member: M, members: M*): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(SRem, Tuple2(ArbitraryInput[K](), NonEmptyList(ArbitraryInput[M]())), LongOutput)
     command.run((key, (member, members.toList)))
   }
@@ -265,7 +265,7 @@ trait Sets {
     count: Option[Count] = None
   ): ResultBuilder1[({ type lambda[x] = (Long, Chunk[x]) })#lambda] =
     new ResultBuilder1[({ type lambda[x] = (Long, Chunk[x]) })#lambda] {
-      def returning[R: Schema]: ZIO[Redis, RedisError, (Long, Chunk[R])] = {
+      def returning[R: Schema]: ZIO[Any, RedisError, (Long, Chunk[R])] = {
         val command = RedisCommand(
           SScan,
           Tuple4(ArbitraryInput[K](), LongInput, OptionalInput(PatternInput), OptionalInput(CountInput)),
@@ -287,7 +287,7 @@ trait Sets {
    */
   final def sUnion[K: Schema](key: K, keys: K*): ResultBuilder1[Chunk] =
     new ResultBuilder1[Chunk] {
-      def returning[R: Schema]: ZIO[Redis, RedisError, Chunk[R]] =
+      def returning[R: Schema]: ZIO[Any, RedisError, Chunk[R]] =
         RedisCommand(SUnion, NonEmptyList(ArbitraryInput[K]()), ChunkOutput(ArbitraryOutput[R]()))
           .run((key, keys.toList))
     }
@@ -308,7 +308,7 @@ trait Sets {
     destination: D,
     key: K,
     keys: K*
-  ): ZIO[Redis, RedisError, Long] = {
+  ): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(SUnionStore, Tuple2(ArbitraryInput[D](), NonEmptyList(ArbitraryInput[K]())), LongOutput)
     command.run((destination, (key, keys.toList)))
   }

--- a/redis/src/main/scala/zio/redis/api/SortedSets.scala
+++ b/redis/src/main/scala/zio/redis/api/SortedSets.scala
@@ -23,7 +23,7 @@ import zio.redis.ResultBuilder._
 import zio.redis._
 import zio.schema.Schema
 
-trait SortedSets {
+trait SortedSets extends CommandExecutor {
   import SortedSets._
 
   /**
@@ -46,7 +46,7 @@ trait SortedSets {
     keys: K*
   ): ResultBuilder1[({ type lambda[x] = Option[(K, MemberScore[x])] })#lambda] =
     new ResultBuilder1[({ type lambda[x] = Option[(K, MemberScore[x])] })#lambda] {
-      def returning[M: Schema]: ZIO[Redis, RedisError, Option[(K, MemberScore[M])]] = {
+      def returning[M: Schema]: ZIO[Any, RedisError, Option[(K, MemberScore[M])]] = {
         val memberScoreOutput =
           Tuple3Output(ArbitraryOutput[K](), ArbitraryOutput[M](), DoubleOutput).map { case (k, m, s) =>
             (k, MemberScore(s, m))
@@ -80,7 +80,7 @@ trait SortedSets {
     keys: K*
   ): ResultBuilder1[({ type lambda[x] = Option[(K, MemberScore[x])] })#lambda] =
     new ResultBuilder1[({ type lambda[x] = Option[(K, MemberScore[x])] })#lambda] {
-      def returning[M: Schema]: ZIO[Redis, RedisError, Option[(K, MemberScore[M])]] = {
+      def returning[M: Schema]: ZIO[Any, RedisError, Option[(K, MemberScore[M])]] = {
         val memberScoreOutput =
           Tuple3Output(ArbitraryOutput[K](), ArbitraryOutput[M](), DoubleOutput).map { case (k, m, s) =>
             (k, MemberScore(s, m))
@@ -114,7 +114,7 @@ trait SortedSets {
   final def zAdd[K: Schema, M: Schema](key: K, update: Option[Update] = None, change: Option[Changed] = None)(
     memberScore: MemberScore[M],
     memberScores: MemberScore[M]*
-  ): ZIO[Redis, RedisError, Long] = {
+  ): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(
       ZAdd,
       Tuple4(
@@ -151,7 +151,7 @@ trait SortedSets {
     increment: Increment,
     memberScore: MemberScore[M],
     memberScores: MemberScore[M]*
-  ): ZIO[Redis, RedisError, Option[Double]] = {
+  ): ZIO[Any, RedisError, Option[Double]] = {
     val command = RedisCommand(
       ZAdd,
       Tuple5(
@@ -174,7 +174,7 @@ trait SortedSets {
    * @return
    *   The cardinality (number of elements) of the sorted set, or 0 if key does not exist.
    */
-  final def zCard[K: Schema](key: K): ZIO[Redis, RedisError, Long] = {
+  final def zCard[K: Schema](key: K): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(ZCard, ArbitraryInput[K](), LongOutput)
     command.run(key)
   }
@@ -189,7 +189,7 @@ trait SortedSets {
    * @return
    *   the number of elements in the specified score range.
    */
-  final def zCount[K: Schema](key: K, range: Range): ZIO[Redis, RedisError, Long] = {
+  final def zCount[K: Schema](key: K, range: Range): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(ZCount, Tuple2(ArbitraryInput[K](), RangeInput), LongOutput)
     command.run((key, range))
   }
@@ -212,7 +212,7 @@ trait SortedSets {
     keys: K*
   ): ResultBuilder1[Chunk] =
     new ResultBuilder1[Chunk] {
-      def returning[M: Schema]: ZIO[Redis, RedisError, Chunk[M]] = {
+      def returning[M: Schema]: ZIO[Any, RedisError, Chunk[M]] = {
         val command =
           RedisCommand(
             ZDiff,
@@ -244,7 +244,7 @@ trait SortedSets {
     keys: K*
   ): ResultBuilder1[MemberScores] =
     new ResultBuilder1[MemberScores] {
-      def returning[M: Schema]: ZIO[Redis, RedisError, Chunk[MemberScore[M]]] = {
+      def returning[M: Schema]: ZIO[Any, RedisError, Chunk[MemberScore[M]]] = {
         val command =
           RedisCommand(
             ZDiff,
@@ -279,7 +279,7 @@ trait SortedSets {
     inputKeysNum: Long,
     key: K,
     keys: K*
-  ): ZIO[Redis, RedisError, Long] = {
+  ): ZIO[Any, RedisError, Long] = {
     val command =
       RedisCommand(
         ZDiffStore,
@@ -309,7 +309,7 @@ trait SortedSets {
     key: K,
     increment: Long,
     member: M
-  ): ZIO[Redis, RedisError, Double] = {
+  ): ZIO[Any, RedisError, Double] = {
     val command = RedisCommand(ZIncrBy, Tuple3(ArbitraryInput[K](), LongInput, ArbitraryInput[M]()), DoubleOutput)
     command.run((key, increment, member))
   }
@@ -337,7 +337,7 @@ trait SortedSets {
     weights: Option[::[Double]] = None
   ): ResultBuilder1[Chunk] =
     new ResultBuilder1[Chunk] {
-      def returning[M: Schema]: ZIO[Redis, RedisError, Chunk[M]] = {
+      def returning[M: Schema]: ZIO[Any, RedisError, Chunk[M]] = {
         val command = RedisCommand(
           ZInter,
           Tuple4(
@@ -375,7 +375,7 @@ trait SortedSets {
     weights: Option[::[Double]] = None
   ): ResultBuilder1[MemberScores] =
     new ResultBuilder1[MemberScores] {
-      def returning[M: Schema]: ZIO[Redis, RedisError, Chunk[MemberScore[M]]] = {
+      def returning[M: Schema]: ZIO[Any, RedisError, Chunk[MemberScore[M]]] = {
         val command = RedisCommand(
           ZInter,
           Tuple5(
@@ -415,7 +415,7 @@ trait SortedSets {
   final def zInterStore[DK: Schema, K: Schema](destination: DK, inputKeysNum: Long, key: K, keys: K*)(
     aggregate: Option[Aggregate] = None,
     weights: Option[::[Double]] = None
-  ): ZIO[Redis, RedisError, Long] = {
+  ): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(
       ZInterStore,
       Tuple5(
@@ -440,7 +440,7 @@ trait SortedSets {
    * @return
    *   The number of elements in the specified score range.
    */
-  final def zLexCount[K: Schema](key: K, lexRange: LexRange): ZIO[Redis, RedisError, Long] = {
+  final def zLexCount[K: Schema](key: K, lexRange: LexRange): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(
       ZLexCount,
       Tuple3(ArbitraryInput[K](), ArbitraryInput[String](), ArbitraryInput[String]()),
@@ -466,7 +466,7 @@ trait SortedSets {
     count: Option[Long] = None
   ): ResultBuilder1[MemberScores] =
     new ResultBuilder1[MemberScores] {
-      def returning[M: Schema]: ZIO[Redis, RedisError, Chunk[MemberScore[M]]] = {
+      def returning[M: Schema]: ZIO[Any, RedisError, Chunk[MemberScore[M]]] = {
         val command = RedisCommand(
           ZPopMax,
           Tuple2(ArbitraryInput[K](), OptionalInput(LongInput)),
@@ -494,7 +494,7 @@ trait SortedSets {
     count: Option[Long] = None
   ): ResultBuilder1[MemberScores] =
     new ResultBuilder1[MemberScores] {
-      def returning[M: Schema]: ZIO[Redis, RedisError, Chunk[MemberScore[M]]] = {
+      def returning[M: Schema]: ZIO[Any, RedisError, Chunk[MemberScore[M]]] = {
         val command = RedisCommand(
           ZPopMin,
           Tuple2(ArbitraryInput[K](), OptionalInput(LongInput)),
@@ -517,7 +517,7 @@ trait SortedSets {
    */
   final def zRange[K: Schema](key: K, range: Range): ResultBuilder1[Chunk] =
     new ResultBuilder1[Chunk] {
-      def returning[M: Schema]: ZIO[Redis, RedisError, Chunk[M]] = {
+      def returning[M: Schema]: ZIO[Any, RedisError, Chunk[M]] = {
         val command = RedisCommand(
           ZRange,
           Tuple2(ArbitraryInput[K](), RangeInput),
@@ -542,7 +542,7 @@ trait SortedSets {
     range: Range
   ): ResultBuilder1[MemberScores] =
     new ResultBuilder1[MemberScores] {
-      def returning[M: Schema]: ZIO[Redis, RedisError, Chunk[MemberScore[M]]] = {
+      def returning[M: Schema]: ZIO[Any, RedisError, Chunk[MemberScore[M]]] = {
         val command = RedisCommand(
           ZRange,
           Tuple3(ArbitraryInput[K](), RangeInput, ArbitraryInput[String]()),
@@ -572,7 +572,7 @@ trait SortedSets {
     limit: Option[Limit] = None
   ): ResultBuilder1[Chunk] =
     new ResultBuilder1[Chunk] {
-      def returning[M: Schema]: ZIO[Redis, RedisError, Chunk[M]] = {
+      def returning[M: Schema]: ZIO[Any, RedisError, Chunk[M]] = {
         val command = RedisCommand(
           ZRangeByLex,
           Tuple4(ArbitraryInput[K](), ArbitraryInput[String](), ArbitraryInput[String](), OptionalInput(LimitInput)),
@@ -601,7 +601,7 @@ trait SortedSets {
     limit: Option[Limit] = None
   ): ResultBuilder1[Chunk] =
     new ResultBuilder1[Chunk] {
-      def returning[M: Schema]: ZIO[Redis, RedisError, Chunk[M]] = {
+      def returning[M: Schema]: ZIO[Any, RedisError, Chunk[M]] = {
         val command = RedisCommand(
           ZRangeByScore,
           Tuple4(ArbitraryInput[K](), ArbitraryInput[String](), ArbitraryInput[String](), OptionalInput(LimitInput)),
@@ -630,7 +630,7 @@ trait SortedSets {
     limit: Option[Limit] = None
   ): ResultBuilder1[MemberScores] =
     new ResultBuilder1[MemberScores] {
-      def returning[M: Schema]: ZIO[Redis, RedisError, Chunk[MemberScore[M]]] = {
+      def returning[M: Schema]: ZIO[Any, RedisError, Chunk[MemberScore[M]]] = {
         val command = RedisCommand(
           ZRangeByScore,
           Tuple5(
@@ -657,7 +657,7 @@ trait SortedSets {
    * @return
    *   The rank of member in the sorted set stored at key, with the scores ordered from low to high.
    */
-  final def zRank[K: Schema, M: Schema](key: K, member: M): ZIO[Redis, RedisError, Option[Long]] = {
+  final def zRank[K: Schema, M: Schema](key: K, member: M): ZIO[Any, RedisError, Option[Long]] = {
     val command = RedisCommand(ZRank, Tuple2(ArbitraryInput[K](), ArbitraryInput[M]()), OptionalOutput(LongOutput))
     command.run((key, member))
   }
@@ -678,7 +678,7 @@ trait SortedSets {
     key: K,
     firstMember: M,
     restMembers: M*
-  ): ZIO[Redis, RedisError, Long] = {
+  ): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(ZRem, Tuple2(ArbitraryInput[K](), NonEmptyList(ArbitraryInput[M]())), LongOutput)
     command.run((key, (firstMember, restMembers.toList)))
   }
@@ -693,7 +693,7 @@ trait SortedSets {
    * @return
    *   The number of elements removed.
    */
-  final def zRemRangeByLex[K: Schema](key: K, lexRange: LexRange): ZIO[Redis, RedisError, Long] = {
+  final def zRemRangeByLex[K: Schema](key: K, lexRange: LexRange): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(
       ZRemRangeByLex,
       Tuple3(ArbitraryInput[K](), ArbitraryInput[String](), ArbitraryInput[String]()),
@@ -712,7 +712,7 @@ trait SortedSets {
    * @return
    *   The number of elements removed.
    */
-  final def zRemRangeByRank[K: Schema](key: K, range: Range): ZIO[Redis, RedisError, Long] = {
+  final def zRemRangeByRank[K: Schema](key: K, range: Range): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(ZRemRangeByRank, Tuple2(ArbitraryInput[K](), RangeInput), LongOutput)
     command.run((key, range))
   }
@@ -727,7 +727,7 @@ trait SortedSets {
    * @return
    *   The number of elements removed.
    */
-  final def zRemRangeByScore[K: Schema](key: K, scoreRange: ScoreRange): ZIO[Redis, RedisError, Long] = {
+  final def zRemRangeByScore[K: Schema](key: K, scoreRange: ScoreRange): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(
       ZRemRangeByScore,
       Tuple3(ArbitraryInput[K](), ArbitraryInput[String](), ArbitraryInput[String]()),
@@ -748,7 +748,7 @@ trait SortedSets {
    */
   final def zRevRange[K: Schema](key: K, range: Range): ResultBuilder1[Chunk] =
     new ResultBuilder1[Chunk] {
-      def returning[M: Schema]: ZIO[Redis, RedisError, Chunk[M]] = {
+      def returning[M: Schema]: ZIO[Any, RedisError, Chunk[M]] = {
         val command = RedisCommand(
           ZRevRange,
           Tuple2(ArbitraryInput[K](), RangeInput),
@@ -773,7 +773,7 @@ trait SortedSets {
     range: Range
   ): ResultBuilder1[MemberScores] =
     new ResultBuilder1[MemberScores] {
-      def returning[M: Schema]: ZIO[Redis, RedisError, Chunk[MemberScore[M]]] = {
+      def returning[M: Schema]: ZIO[Any, RedisError, Chunk[MemberScore[M]]] = {
         val command = RedisCommand(
           ZRevRange,
           Tuple3(ArbitraryInput[K](), RangeInput, ArbitraryInput[String]()),
@@ -803,7 +803,7 @@ trait SortedSets {
     limit: Option[Limit] = None
   ): ResultBuilder1[Chunk] =
     new ResultBuilder1[Chunk] {
-      def returning[M: Schema]: ZIO[Redis, RedisError, Chunk[M]] = {
+      def returning[M: Schema]: ZIO[Any, RedisError, Chunk[M]] = {
         val command = RedisCommand(
           ZRevRangeByLex,
           Tuple4(ArbitraryInput[K](), ArbitraryInput[String](), ArbitraryInput[String](), OptionalInput(LimitInput)),
@@ -832,7 +832,7 @@ trait SortedSets {
     limit: Option[Limit] = None
   ): ResultBuilder1[Chunk] =
     new ResultBuilder1[Chunk] {
-      def returning[M: Schema]: ZIO[Redis, RedisError, Chunk[M]] = {
+      def returning[M: Schema]: ZIO[Any, RedisError, Chunk[M]] = {
         val command = RedisCommand(
           ZRevRangeByScore,
           Tuple4(
@@ -866,7 +866,7 @@ trait SortedSets {
     limit: Option[Limit] = None
   ): ResultBuilder1[MemberScores] =
     new ResultBuilder1[MemberScores] {
-      def returning[M: Schema]: ZIO[Redis, RedisError, Chunk[MemberScore[M]]] = {
+      def returning[M: Schema]: ZIO[Any, RedisError, Chunk[MemberScore[M]]] = {
         val command = RedisCommand(
           ZRevRangeByScore,
           Tuple5(
@@ -893,7 +893,7 @@ trait SortedSets {
    * @return
    *   The rank of member.
    */
-  final def zRevRank[K: Schema, M: Schema](key: K, member: M): ZIO[Redis, RedisError, Option[Long]] = {
+  final def zRevRank[K: Schema, M: Schema](key: K, member: M): ZIO[Any, RedisError, Option[Long]] = {
     val command = RedisCommand(ZRevRank, Tuple2(ArbitraryInput[K](), ArbitraryInput[M]()), OptionalOutput(LongOutput))
     command.run((key, member))
   }
@@ -919,7 +919,7 @@ trait SortedSets {
     count: Option[Count] = None
   ): ResultBuilder1[({ type lambda[x] = (Long, MemberScores[x]) })#lambda] =
     new ResultBuilder1[({ type lambda[x] = (Long, MemberScores[x]) })#lambda] {
-      def returning[M: Schema]: ZIO[Redis, RedisError, (Long, Chunk[MemberScore[M]])] = {
+      def returning[M: Schema]: ZIO[Any, RedisError, (Long, Chunk[MemberScore[M]])] = {
         val memberScoresOutput =
           ChunkTuple2Output(ArbitraryOutput[M](), DoubleOutput).map(_.map { case (m, s) => MemberScore(s, m) })
         val command = RedisCommand(
@@ -941,7 +941,7 @@ trait SortedSets {
    * @return
    *   The score of member (a double precision floating point number.
    */
-  final def zScore[K: Schema, M: Schema](key: K, member: M): ZIO[Redis, RedisError, Option[Double]] = {
+  final def zScore[K: Schema, M: Schema](key: K, member: M): ZIO[Any, RedisError, Option[Double]] = {
     val command = RedisCommand(ZScore, Tuple2(ArbitraryInput[K](), ArbitraryInput[M]()), OptionalOutput(DoubleOutput))
     command.run((key, member))
   }
@@ -969,7 +969,7 @@ trait SortedSets {
     aggregate: Option[Aggregate] = None
   ): ResultBuilder1[Chunk] =
     new ResultBuilder1[Chunk] {
-      def returning[M: Schema]: ZIO[Redis, RedisError, Chunk[M]] = {
+      def returning[M: Schema]: ZIO[Any, RedisError, Chunk[M]] = {
         val command =
           RedisCommand(
             ZUnion,
@@ -1008,7 +1008,7 @@ trait SortedSets {
     aggregate: Option[Aggregate] = None
   ): ResultBuilder1[MemberScores] =
     new ResultBuilder1[MemberScores] {
-      def returning[M: Schema]: ZIO[Redis, RedisError, Chunk[MemberScore[M]]] = {
+      def returning[M: Schema]: ZIO[Any, RedisError, Chunk[MemberScore[M]]] = {
         val command =
           RedisCommand(
             ZUnion,
@@ -1049,7 +1049,7 @@ trait SortedSets {
   final def zUnionStore[DK: Schema, K: Schema](destination: DK, inputKeysNum: Long, key: K, keys: K*)(
     weights: Option[::[Double]] = None,
     aggregate: Option[Aggregate] = None
-  ): ZIO[Redis, RedisError, Long] = {
+  ): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(
       ZUnionStore,
       Tuple5(
@@ -1074,7 +1074,7 @@ trait SortedSets {
    * @return
    *   List of scores or None associated with the specified member values (a double precision floating point number).
    */
-  final def zMScore[K: Schema](key: K, keys: K*): ZIO[Redis, RedisError, Chunk[Option[Double]]] = {
+  final def zMScore[K: Schema](key: K, keys: K*): ZIO[Any, RedisError, Chunk[Option[Double]]] = {
     val command = RedisCommand(Zmscore, NonEmptyList(ArbitraryInput[K]()), ChunkOutput(OptionalOutput(DoubleOutput)))
     command.run((key, keys.toList))
   }
@@ -1089,7 +1089,7 @@ trait SortedSets {
    */
   final def zRandMember[K: Schema](key: K): ResultBuilder1[Option] =
     new ResultBuilder1[Option] {
-      def returning[R: Schema]: ZIO[Redis, RedisError, Option[R]] =
+      def returning[R: Schema]: ZIO[Any, RedisError, Option[R]] =
         RedisCommand(ZRandMember, ArbitraryInput[K](), OptionalOutput(ArbitraryOutput[R]())).run(key)
     }
 
@@ -1109,7 +1109,7 @@ trait SortedSets {
     count: Long
   ): ResultBuilder1[Chunk] =
     new ResultBuilder1[Chunk] {
-      def returning[M: Schema]: ZIO[Redis, RedisError, Chunk[M]] = {
+      def returning[M: Schema]: ZIO[Any, RedisError, Chunk[M]] = {
         val command = RedisCommand(
           ZRandMember,
           Tuple2(ArbitraryInput[K](), LongInput),
@@ -1137,7 +1137,7 @@ trait SortedSets {
     count: Long
   ): ResultBuilder1[MemberScores] =
     new ResultBuilder1[MemberScores] {
-      def returning[M: Schema]: ZIO[Redis, RedisError, Chunk[MemberScore[M]]] = {
+      def returning[M: Schema]: ZIO[Any, RedisError, Chunk[MemberScore[M]]] = {
         val command = RedisCommand(
           ZRandMember,
           Tuple3(ArbitraryInput[K](), LongInput, ArbitraryInput[String]()),

--- a/redis/src/main/scala/zio/redis/api/SortedSets.scala
+++ b/redis/src/main/scala/zio/redis/api/SortedSets.scala
@@ -54,8 +54,10 @@ trait SortedSets extends RedisEnvironment {
         val command = RedisCommand(
           BzPopMax,
           Tuple2(NonEmptyList(ArbitraryInput[K]()), DurationSecondsInput),
-          OptionalOutput(memberScoreOutput)
-        )(executor, codec)
+          OptionalOutput(memberScoreOutput),
+          codec,
+          executor
+        )
         command.run(((key, keys.toList), timeout))
       }
     }
@@ -88,8 +90,10 @@ trait SortedSets extends RedisEnvironment {
         val command = RedisCommand(
           BzPopMin,
           Tuple2(NonEmptyList(ArbitraryInput[K]()), DurationSecondsInput),
-          OptionalOutput(memberScoreOutput)
-        )(executor, codec)
+          OptionalOutput(memberScoreOutput),
+          codec,
+          executor
+        )
         command.run(((key, keys.toList), timeout))
       }
     }
@@ -123,8 +127,10 @@ trait SortedSets extends RedisEnvironment {
         OptionalInput(ChangedInput),
         NonEmptyList(MemberScoreInput[M]())
       ),
-      LongOutput
-    )(executor, codec)
+      LongOutput,
+      codec,
+      executor
+    )
     command.run((key, update, change, (memberScore, memberScores.toList)))
   }
 
@@ -161,8 +167,10 @@ trait SortedSets extends RedisEnvironment {
         IncrementInput,
         NonEmptyList(MemberScoreInput[M]())
       ),
-      OptionalOutput(DoubleOutput)
-    )(executor, codec)
+      OptionalOutput(DoubleOutput),
+      codec,
+      executor
+    )
     command.run((key, update, change, increment, (memberScore, memberScores.toList)))
   }
 
@@ -175,7 +183,7 @@ trait SortedSets extends RedisEnvironment {
    *   The cardinality (number of elements) of the sorted set, or 0 if key does not exist.
    */
   final def zCard[K: Schema](key: K): IO[RedisError, Long] = {
-    val command = RedisCommand(ZCard, ArbitraryInput[K](), LongOutput)(executor, codec)
+    val command = RedisCommand(ZCard, ArbitraryInput[K](), LongOutput, codec, executor)
     command.run(key)
   }
 
@@ -190,7 +198,7 @@ trait SortedSets extends RedisEnvironment {
    *   the number of elements in the specified score range.
    */
   final def zCount[K: Schema](key: K, range: Range): IO[RedisError, Long] = {
-    val command = RedisCommand(ZCount, Tuple2(ArbitraryInput[K](), RangeInput), LongOutput)(executor, codec)
+    val command = RedisCommand(ZCount, Tuple2(ArbitraryInput[K](), RangeInput), LongOutput, codec, executor)
     command.run((key, range))
   }
 
@@ -220,8 +228,10 @@ trait SortedSets extends RedisEnvironment {
               LongInput,
               NonEmptyList(ArbitraryInput[K]())
             ),
-            ChunkOutput(ArbitraryOutput[M]())
-          )(executor, codec)
+            ChunkOutput(ArbitraryOutput[M]()),
+            codec,
+            executor
+          )
         command.run((inputKeysNum, (key, keys.toList)))
       }
     }
@@ -254,8 +264,10 @@ trait SortedSets extends RedisEnvironment {
               ArbitraryInput[String]()
             ),
             ChunkTuple2Output(ArbitraryOutput[M](), DoubleOutput)
-              .map(_.map { case (m, s) => MemberScore(s, m) })
-          )(executor, codec)
+              .map(_.map { case (m, s) => MemberScore(s, m) }),
+            codec,
+            executor
+          )
         command.run((inputKeysNum, (key, keys.toList), WithScores.stringify))
       }
     }
@@ -288,8 +300,10 @@ trait SortedSets extends RedisEnvironment {
           LongInput,
           NonEmptyList(ArbitraryInput[K]())
         ),
-        LongOutput
-      )(executor, codec)
+        LongOutput,
+        codec,
+        executor
+      )
     command.run((destination, inputKeysNum, (key, keys.toList)))
   }
 
@@ -311,7 +325,7 @@ trait SortedSets extends RedisEnvironment {
     member: M
   ): IO[RedisError, Double] = {
     val command =
-      RedisCommand(ZIncrBy, Tuple3(ArbitraryInput[K](), LongInput, ArbitraryInput[M]()), DoubleOutput)(executor, codec)
+      RedisCommand(ZIncrBy, Tuple3(ArbitraryInput[K](), LongInput, ArbitraryInput[M]()), DoubleOutput, codec, executor)
     command.run((key, increment, member))
   }
 
@@ -347,8 +361,10 @@ trait SortedSets extends RedisEnvironment {
             OptionalInput(AggregateInput),
             OptionalInput(WeightsInput)
           ),
-          ChunkOutput(ArbitraryOutput[M]())
-        )(executor, codec)
+          ChunkOutput(ArbitraryOutput[M]()),
+          codec,
+          executor
+        )
         command.run((inputKeysNum, (key, keys.toList), aggregate, weights))
       }
     }
@@ -387,8 +403,10 @@ trait SortedSets extends RedisEnvironment {
             ArbitraryInput[String]()
           ),
           ChunkTuple2Output(ArbitraryOutput[M](), DoubleOutput)
-            .map(_.map { case (m, s) => MemberScore(s, m) })
-        )(executor, codec)
+            .map(_.map { case (m, s) => MemberScore(s, m) }),
+          codec,
+          executor
+        )
         command.run((inputKeysNum, (key, keys.toList), aggregate, weights, WithScores.stringify))
       }
     }
@@ -426,8 +444,10 @@ trait SortedSets extends RedisEnvironment {
         OptionalInput(AggregateInput),
         OptionalInput(WeightsInput)
       ),
-      LongOutput
-    )(executor, codec)
+      LongOutput,
+      codec,
+      executor
+    )
     command.run((destination, inputKeysNum, (key, keys.toList), aggregate, weights))
   }
 
@@ -445,8 +465,10 @@ trait SortedSets extends RedisEnvironment {
     val command = RedisCommand(
       ZLexCount,
       Tuple3(ArbitraryInput[K](), ArbitraryInput[String](), ArbitraryInput[String]()),
-      LongOutput
-    )(executor, codec)
+      LongOutput,
+      codec,
+      executor
+    )
     command.run((key, lexRange.min.stringify, lexRange.max.stringify))
   }
 
@@ -472,8 +494,10 @@ trait SortedSets extends RedisEnvironment {
           ZPopMax,
           Tuple2(ArbitraryInput[K](), OptionalInput(LongInput)),
           ChunkTuple2Output(ArbitraryOutput[M](), DoubleOutput)
-            .map(_.map { case (m, s) => MemberScore(s, m) })
-        )(executor, codec)
+            .map(_.map { case (m, s) => MemberScore(s, m) }),
+          codec,
+          executor
+        )
         command.run((key, count))
       }
     }
@@ -500,8 +524,10 @@ trait SortedSets extends RedisEnvironment {
           ZPopMin,
           Tuple2(ArbitraryInput[K](), OptionalInput(LongInput)),
           ChunkTuple2Output(ArbitraryOutput[M](), DoubleOutput)
-            .map(_.map { case (m, s) => MemberScore(s, m) })
-        )(executor, codec)
+            .map(_.map { case (m, s) => MemberScore(s, m) }),
+          codec,
+          executor
+        )
         command.run((key, count))
       }
     }
@@ -522,8 +548,10 @@ trait SortedSets extends RedisEnvironment {
         val command = RedisCommand(
           ZRange,
           Tuple2(ArbitraryInput[K](), RangeInput),
-          ChunkOutput(ArbitraryOutput[M]())
-        )(executor, codec)
+          ChunkOutput(ArbitraryOutput[M]()),
+          codec,
+          executor
+        )
         command.run((key, range))
       }
     }
@@ -548,8 +576,10 @@ trait SortedSets extends RedisEnvironment {
           ZRange,
           Tuple3(ArbitraryInput[K](), RangeInput, ArbitraryInput[String]()),
           ChunkTuple2Output(ArbitraryOutput[M](), DoubleOutput)
-            .map(_.map { case (m, s) => MemberScore(s, m) })
-        )(executor, codec)
+            .map(_.map { case (m, s) => MemberScore(s, m) }),
+          codec,
+          executor
+        )
         command.run((key, range, WithScores.stringify))
       }
     }
@@ -577,8 +607,10 @@ trait SortedSets extends RedisEnvironment {
         val command = RedisCommand(
           ZRangeByLex,
           Tuple4(ArbitraryInput[K](), ArbitraryInput[String](), ArbitraryInput[String](), OptionalInput(LimitInput)),
-          ChunkOutput(ArbitraryOutput[M]())
-        )(executor, codec)
+          ChunkOutput(ArbitraryOutput[M]()),
+          codec,
+          executor
+        )
         command.run((key, lexRange.min.stringify, lexRange.max.stringify, limit))
       }
     }
@@ -606,8 +638,10 @@ trait SortedSets extends RedisEnvironment {
         val command = RedisCommand(
           ZRangeByScore,
           Tuple4(ArbitraryInput[K](), ArbitraryInput[String](), ArbitraryInput[String](), OptionalInput(LimitInput)),
-          ChunkOutput(ArbitraryOutput[M]())
-        )(executor, codec)
+          ChunkOutput(ArbitraryOutput[M]()),
+          codec,
+          executor
+        )
         command.run((key, scoreRange.min.stringify, scoreRange.max.stringify, limit))
       }
     }
@@ -642,8 +676,10 @@ trait SortedSets extends RedisEnvironment {
             OptionalInput(LimitInput)
           ),
           ChunkTuple2Output(ArbitraryOutput[M](), DoubleOutput)
-            .map(_.map { case (m, s) => MemberScore(s, m) })
-        )(executor, codec)
+            .map(_.map { case (m, s) => MemberScore(s, m) }),
+          codec,
+          executor
+        )
         command.run((key, scoreRange.min.stringify, scoreRange.max.stringify, WithScores.stringify, limit))
       }
     }
@@ -660,7 +696,7 @@ trait SortedSets extends RedisEnvironment {
    */
   final def zRank[K: Schema, M: Schema](key: K, member: M): IO[RedisError, Option[Long]] = {
     val command =
-      RedisCommand(ZRank, Tuple2(ArbitraryInput[K](), ArbitraryInput[M]()), OptionalOutput(LongOutput))(executor, codec)
+      RedisCommand(ZRank, Tuple2(ArbitraryInput[K](), ArbitraryInput[M]()), OptionalOutput(LongOutput), codec, executor)
     command.run((key, member))
   }
 
@@ -682,7 +718,7 @@ trait SortedSets extends RedisEnvironment {
     restMembers: M*
   ): IO[RedisError, Long] = {
     val command =
-      RedisCommand(ZRem, Tuple2(ArbitraryInput[K](), NonEmptyList(ArbitraryInput[M]())), LongOutput)(executor, codec)
+      RedisCommand(ZRem, Tuple2(ArbitraryInput[K](), NonEmptyList(ArbitraryInput[M]())), LongOutput, codec, executor)
     command.run((key, (firstMember, restMembers.toList)))
   }
 
@@ -700,8 +736,10 @@ trait SortedSets extends RedisEnvironment {
     val command = RedisCommand(
       ZRemRangeByLex,
       Tuple3(ArbitraryInput[K](), ArbitraryInput[String](), ArbitraryInput[String]()),
-      LongOutput
-    )(executor, codec)
+      LongOutput,
+      codec,
+      executor
+    )
     command.run((key, lexRange.min.stringify, lexRange.max.stringify))
   }
 
@@ -716,7 +754,7 @@ trait SortedSets extends RedisEnvironment {
    *   The number of elements removed.
    */
   final def zRemRangeByRank[K: Schema](key: K, range: Range): IO[RedisError, Long] = {
-    val command = RedisCommand(ZRemRangeByRank, Tuple2(ArbitraryInput[K](), RangeInput), LongOutput)(executor, codec)
+    val command = RedisCommand(ZRemRangeByRank, Tuple2(ArbitraryInput[K](), RangeInput), LongOutput, codec, executor)
     command.run((key, range))
   }
 
@@ -734,8 +772,10 @@ trait SortedSets extends RedisEnvironment {
     val command = RedisCommand(
       ZRemRangeByScore,
       Tuple3(ArbitraryInput[K](), ArbitraryInput[String](), ArbitraryInput[String]()),
-      LongOutput
-    )(executor, codec)
+      LongOutput,
+      codec,
+      executor
+    )
     command.run((key, scoreRange.min.stringify, scoreRange.max.stringify))
   }
 
@@ -755,8 +795,10 @@ trait SortedSets extends RedisEnvironment {
         val command = RedisCommand(
           ZRevRange,
           Tuple2(ArbitraryInput[K](), RangeInput),
-          ChunkOutput(ArbitraryOutput[M]())
-        )(executor, codec)
+          ChunkOutput(ArbitraryOutput[M]()),
+          codec,
+          executor
+        )
         command.run((key, range))
       }
     }
@@ -781,8 +823,10 @@ trait SortedSets extends RedisEnvironment {
           ZRevRange,
           Tuple3(ArbitraryInput[K](), RangeInput, ArbitraryInput[String]()),
           ChunkTuple2Output(ArbitraryOutput[M](), DoubleOutput)
-            .map(_.map { case (m, s) => MemberScore(s, m) })
-        )(executor, codec)
+            .map(_.map { case (m, s) => MemberScore(s, m) }),
+          codec,
+          executor
+        )
         command.run((key, range, WithScores.stringify))
       }
     }
@@ -810,8 +854,10 @@ trait SortedSets extends RedisEnvironment {
         val command = RedisCommand(
           ZRevRangeByLex,
           Tuple4(ArbitraryInput[K](), ArbitraryInput[String](), ArbitraryInput[String](), OptionalInput(LimitInput)),
-          ChunkOutput(ArbitraryOutput[M]())
-        )(executor, codec)
+          ChunkOutput(ArbitraryOutput[M]()),
+          codec,
+          executor
+        )
         command.run((key, lexRange.max.stringify, lexRange.min.stringify, limit))
       }
     }
@@ -844,8 +890,10 @@ trait SortedSets extends RedisEnvironment {
             ArbitraryInput[String](),
             OptionalInput(LimitInput)
           ),
-          ChunkOutput(ArbitraryOutput[M]())
-        )(executor, codec)
+          ChunkOutput(ArbitraryOutput[M]()),
+          codec,
+          executor
+        )
         command.run((key, scoreRange.max.stringify, scoreRange.min.stringify, limit))
       }
     }
@@ -880,8 +928,10 @@ trait SortedSets extends RedisEnvironment {
             OptionalInput(LimitInput)
           ),
           ChunkTuple2Output(ArbitraryOutput[M](), DoubleOutput)
-            .map(_.map { case (m, s) => MemberScore(s, m) })
-        )(executor, codec)
+            .map(_.map { case (m, s) => MemberScore(s, m) }),
+          codec,
+          executor
+        )
         command.run((key, scoreRange.max.stringify, scoreRange.min.stringify, WithScores.stringify, limit))
       }
     }
@@ -897,9 +947,12 @@ trait SortedSets extends RedisEnvironment {
    *   The rank of member.
    */
   final def zRevRank[K: Schema, M: Schema](key: K, member: M): IO[RedisError, Option[Long]] = {
-    val command = RedisCommand(ZRevRank, Tuple2(ArbitraryInput[K](), ArbitraryInput[M]()), OptionalOutput(LongOutput))(
-      executor,
-      codec
+    val command = RedisCommand(
+      ZRevRank,
+      Tuple2(ArbitraryInput[K](), ArbitraryInput[M]()),
+      OptionalOutput(LongOutput),
+      codec,
+      executor
     )
     command.run((key, member))
   }
@@ -931,8 +984,10 @@ trait SortedSets extends RedisEnvironment {
         val command = RedisCommand(
           ZScan,
           Tuple4(ArbitraryInput[K](), LongInput, OptionalInput(PatternInput), OptionalInput(CountInput)),
-          Tuple2Output(MultiStringOutput.map(_.toLong), memberScoresOutput)
-        )(executor, codec)
+          Tuple2Output(MultiStringOutput.map(_.toLong), memberScoresOutput),
+          codec,
+          executor
+        )
         command.run((key, cursor, pattern.map(Pattern(_)), count))
       }
     }
@@ -948,9 +1003,12 @@ trait SortedSets extends RedisEnvironment {
    *   The score of member (a double precision floating point number.
    */
   final def zScore[K: Schema, M: Schema](key: K, member: M): IO[RedisError, Option[Double]] = {
-    val command = RedisCommand(ZScore, Tuple2(ArbitraryInput[K](), ArbitraryInput[M]()), OptionalOutput(DoubleOutput))(
-      executor,
-      codec
+    val command = RedisCommand(
+      ZScore,
+      Tuple2(ArbitraryInput[K](), ArbitraryInput[M]()),
+      OptionalOutput(DoubleOutput),
+      codec,
+      executor
     )
     command.run((key, member))
   }
@@ -988,8 +1046,10 @@ trait SortedSets extends RedisEnvironment {
               OptionalInput(WeightsInput),
               OptionalInput(AggregateInput)
             ),
-            ChunkOutput(ArbitraryOutput[M]())
-          )(executor, codec)
+            ChunkOutput(ArbitraryOutput[M]()),
+            codec,
+            executor
+          )
         command.run((inputKeysNum, (key, keys.toList), weights, aggregate))
       }
     }
@@ -1029,8 +1089,10 @@ trait SortedSets extends RedisEnvironment {
               ArbitraryInput[String]()
             ),
             ChunkTuple2Output(ArbitraryOutput[M](), DoubleOutput)
-              .map(_.map { case (m, s) => MemberScore(s, m) })
-          )(executor, codec)
+              .map(_.map { case (m, s) => MemberScore(s, m) }),
+            codec,
+            executor
+          )
         command.run((inputKeysNum, (key, keys.toList), weights, aggregate, WithScores.stringify))
       }
     }
@@ -1068,8 +1130,10 @@ trait SortedSets extends RedisEnvironment {
         OptionalInput(WeightsInput),
         OptionalInput(AggregateInput)
       ),
-      LongOutput
-    )(executor, codec)
+      LongOutput,
+      codec,
+      executor
+    )
     command.run((destination, inputKeysNum, (key, keys.toList), weights, aggregate))
   }
 
@@ -1084,9 +1148,12 @@ trait SortedSets extends RedisEnvironment {
    *   List of scores or None associated with the specified member values (a double precision floating point number).
    */
   final def zMScore[K: Schema](key: K, keys: K*): IO[RedisError, Chunk[Option[Double]]] = {
-    val command = RedisCommand(Zmscore, NonEmptyList(ArbitraryInput[K]()), ChunkOutput(OptionalOutput(DoubleOutput)))(
-      executor,
-      codec
+    val command = RedisCommand(
+      Zmscore,
+      NonEmptyList(ArbitraryInput[K]()),
+      ChunkOutput(OptionalOutput(DoubleOutput)),
+      codec,
+      executor
     )
     command.run((key, keys.toList))
   }
@@ -1102,7 +1169,7 @@ trait SortedSets extends RedisEnvironment {
   final def zRandMember[K: Schema](key: K): ResultBuilder1[Option] =
     new ResultBuilder1[Option] {
       def returning[R: Schema]: IO[RedisError, Option[R]] =
-        RedisCommand(ZRandMember, ArbitraryInput[K](), OptionalOutput(ArbitraryOutput[R]()))(executor, codec).run(key)
+        RedisCommand(ZRandMember, ArbitraryInput[K](), OptionalOutput(ArbitraryOutput[R]()), codec, executor).run(key)
     }
 
   /**
@@ -1125,8 +1192,10 @@ trait SortedSets extends RedisEnvironment {
         val command = RedisCommand(
           ZRandMember,
           Tuple2(ArbitraryInput[K](), LongInput),
-          ZRandMemberOutput(ArbitraryOutput[M]())
-        )(executor, codec)
+          ZRandMemberOutput(ArbitraryOutput[M]()),
+          codec,
+          executor
+        )
         command.run((key, count))
       }
     }
@@ -1154,8 +1223,10 @@ trait SortedSets extends RedisEnvironment {
           ZRandMember,
           Tuple3(ArbitraryInput[K](), LongInput, ArbitraryInput[String]()),
           ZRandMemberTuple2Output(ArbitraryOutput[M](), DoubleOutput)
-            .map(_.map { case (m, s) => MemberScore(s, m) })
-        )(executor, codec)
+            .map(_.map { case (m, s) => MemberScore(s, m) }),
+          codec,
+          executor
+        )
 
         command.run((key, count, WithScores.stringify))
       }

--- a/redis/src/main/scala/zio/redis/api/Streams.scala
+++ b/redis/src/main/scala/zio/redis/api/Streams.scala
@@ -23,7 +23,7 @@ import zio.redis.ResultBuilder._
 import zio.redis._
 import zio.schema.Schema
 
-trait Streams {
+trait Streams extends CommandExecutor {
   import StreamInfoWithFull._
   import Streams._
   import XGroupCommand._
@@ -47,7 +47,7 @@ trait Streams {
     group: G,
     id: I,
     ids: I*
-  ): ZIO[Redis, RedisError, Long] = {
+  ): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(
       XAck,
       Tuple3(ArbitraryInput[SK](), ArbitraryInput[G](), NonEmptyList(ArbitraryInput[I]())),
@@ -77,7 +77,7 @@ trait Streams {
     pairs: (K, V)*
   ): ResultBuilder1[Id] =
     new ResultBuilder1[Id] {
-      def returning[R: Schema]: ZIO[Redis, RedisError, Id[R]] = {
+      def returning[R: Schema]: ZIO[Any, RedisError, Id[R]] = {
         val command = RedisCommand(
           XAdd,
           Tuple4(
@@ -103,7 +103,7 @@ trait Streams {
   final def xInfoStream[SK: Schema](
     key: SK
   ): ResultBuilder3[StreamInfo] = new ResultBuilder3[StreamInfo] {
-    def returning[RI: Schema, RK: Schema, RV: Schema]: ZIO[Redis, RedisError, StreamInfo[RI, RK, RV]] = {
+    def returning[RI: Schema, RK: Schema, RV: Schema]: ZIO[Any, RedisError, StreamInfo[RI, RK, RV]] = {
       val command = RedisCommand(XInfoStream, ArbitraryInput[SK](), StreamInfoOutput[RI, RK, RV]())
       command.run(key)
     }
@@ -120,7 +120,7 @@ trait Streams {
   final def xInfoStreamFull[SK: Schema](
     key: SK
   ): ResultBuilder3[FullStreamInfo] = new ResultBuilder3[FullStreamInfo] {
-    def returning[RI: Schema, RK: Schema, RV: Schema]: ZIO[Redis, RedisError, FullStreamInfo[RI, RK, RV]] = {
+    def returning[RI: Schema, RK: Schema, RV: Schema]: ZIO[Any, RedisError, FullStreamInfo[RI, RK, RV]] = {
       val command = RedisCommand(
         XInfoStream,
         Tuple2(ArbitraryInput[SK](), ArbitraryInput[String]()),
@@ -144,7 +144,7 @@ trait Streams {
     key: SK,
     count: Long
   ): ResultBuilder3[FullStreamInfo] = new ResultBuilder3[FullStreamInfo] {
-    def returning[RI: Schema, RK: Schema, RV: Schema]: ZIO[Redis, RedisError, FullStreamInfo[RI, RK, RV]] = {
+    def returning[RI: Schema, RK: Schema, RV: Schema]: ZIO[Any, RedisError, FullStreamInfo[RI, RK, RV]] = {
       val command = RedisCommand(
         XInfoStream,
         Tuple3(ArbitraryInput[SK](), ArbitraryInput[String](), CountInput),
@@ -162,7 +162,7 @@ trait Streams {
    * @return
    *   List of consumer groups associated with the stream stored at the specified key.
    */
-  final def xInfoGroups[SK: Schema](key: SK): ZIO[Redis, RedisError, Chunk[StreamGroupsInfo]] = {
+  final def xInfoGroups[SK: Schema](key: SK): ZIO[Any, RedisError, Chunk[StreamGroupsInfo]] = {
     val command = RedisCommand(XInfoGroups, ArbitraryInput[SK](), StreamGroupsInfoOutput)
     command.run(key)
   }
@@ -180,7 +180,7 @@ trait Streams {
   final def xInfoConsumers[SK: Schema, SG: Schema](
     key: SK,
     group: SG
-  ): ZIO[Redis, RedisError, Chunk[StreamConsumersInfo]] = {
+  ): ZIO[Any, RedisError, Chunk[StreamConsumersInfo]] = {
     val command =
       RedisCommand(XInfoConsumers, Tuple2(ArbitraryInput[SK](), ArbitraryInput[SG]()), StreamConsumersInfoOutput)
     command.run((key, group))
@@ -214,7 +214,7 @@ trait Streams {
     pairs: (K, V)*
   ): ResultBuilder1[Id] =
     new ResultBuilder1[Id] {
-      def returning[R: Schema]: ZIO[Redis, RedisError, Id[R]] = {
+      def returning[R: Schema]: ZIO[Any, RedisError, Id[R]] = {
         val command = RedisCommand(
           XAdd,
           Tuple4(
@@ -267,7 +267,7 @@ trait Streams {
     force: Boolean = false
   )(id: I, ids: I*): ResultBuilder2[({ type lambda[x, y] = StreamEntries[I, x, y] })#lambda] =
     new ResultBuilder2[({ type lambda[x, y] = StreamEntries[I, x, y] })#lambda] {
-      def returning[RK: Schema, RV: Schema]: ZIO[Redis, RedisError, StreamEntries[I, RK, RV]] = {
+      def returning[RK: Schema, RV: Schema]: ZIO[Any, RedisError, StreamEntries[I, RK, RV]] = {
         val command = RedisCommand(
           XClaim,
           Tuple9(
@@ -326,7 +326,7 @@ trait Streams {
     force: Boolean = false
   )(id: I, ids: I*): ResultBuilder1[Chunk] =
     new ResultBuilder1[Chunk] {
-      def returning[R: Schema]: ZIO[Redis, RedisError, Chunk[R]] = {
+      def returning[R: Schema]: ZIO[Any, RedisError, Chunk[R]] = {
         val command = RedisCommand(
           XClaim,
           Tuple10(
@@ -360,7 +360,7 @@ trait Streams {
    * @return
    *   the number of entries deleted.
    */
-  final def xDel[SK: Schema, I: Schema](key: SK, id: I, ids: I*): ZIO[Redis, RedisError, Long] = {
+  final def xDel[SK: Schema, I: Schema](key: SK, id: I, ids: I*): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(XDel, Tuple2(ArbitraryInput[SK](), NonEmptyList(ArbitraryInput[I]())), LongOutput)
     command.run((key, (id, ids.toList)))
   }
@@ -382,7 +382,7 @@ trait Streams {
     group: SG,
     id: I,
     mkStream: Boolean = false
-  ): ZIO[Redis, RedisError, Unit] = {
+  ): ZIO[Any, RedisError, Unit] = {
     val command = RedisCommand(XGroup, XGroupCreateInput[SK, SG, I](), UnitOutput)
     command.run(Create(key, group, id, mkStream))
   }
@@ -401,7 +401,7 @@ trait Streams {
     key: SK,
     group: SG,
     id: I
-  ): ZIO[Redis, RedisError, Unit] = {
+  ): ZIO[Any, RedisError, Unit] = {
     val command = RedisCommand(XGroup, XGroupSetIdInput[SK, SG, I](), UnitOutput)
     command.run(SetId(key, group, id))
   }
@@ -416,7 +416,7 @@ trait Streams {
    * @return
    *   flag that indicates if the deletion was successful.
    */
-  final def xGroupDestroy[SK: Schema, SG: Schema](key: SK, group: SG): ZIO[Redis, RedisError, Boolean] =
+  final def xGroupDestroy[SK: Schema, SG: Schema](key: SK, group: SG): ZIO[Any, RedisError, Boolean] =
     RedisCommand(XGroup, XGroupDestroyInput[SK, SG](), BoolOutput).run(Destroy(key, group))
 
   /**
@@ -435,7 +435,7 @@ trait Streams {
     key: SK,
     group: SG,
     consumer: SC
-  ): ZIO[Redis, RedisError, Boolean] = {
+  ): ZIO[Any, RedisError, Boolean] = {
     val command = RedisCommand(XGroup, XGroupCreateConsumerInput[SK, SG, SC](), BoolOutput)
     command.run(CreateConsumer(key, group, consumer))
   }
@@ -456,7 +456,7 @@ trait Streams {
     key: SK,
     group: SG,
     consumer: SC
-  ): ZIO[Redis, RedisError, Long] = {
+  ): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(XGroup, XGroupDelConsumerInput[SK, SG, SC](), LongOutput)
     command.run(DelConsumer(key, group, consumer))
   }
@@ -469,7 +469,7 @@ trait Streams {
    * @return
    *   the number of entries inside a stream.
    */
-  final def xLen[SK: Schema](key: SK): ZIO[Redis, RedisError, Long] = {
+  final def xLen[SK: Schema](key: SK): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(XLen, ArbitraryInput[SK](), LongOutput)
     command.run(key)
   }
@@ -484,7 +484,7 @@ trait Streams {
    * @return
    *   summary about the pending messages in a given consumer group.
    */
-  final def xPending[SK: Schema, SG: Schema](key: SK, group: SG): ZIO[Redis, RedisError, PendingInfo] = {
+  final def xPending[SK: Schema, SG: Schema](key: SK, group: SG): ZIO[Any, RedisError, PendingInfo] = {
     val command = RedisCommand(
       XPending,
       Tuple3(ArbitraryInput[SK](), ArbitraryInput[SG](), OptionalInput(IdleInput)),
@@ -521,7 +521,7 @@ trait Streams {
     count: Long,
     consumer: Option[SC] = None,
     idle: Option[Duration] = None
-  ): ZIO[Redis, RedisError, Chunk[PendingMessage]] = {
+  ): ZIO[Any, RedisError, Chunk[PendingMessage]] = {
     val command = RedisCommand(
       XPending,
       Tuple7(
@@ -556,7 +556,7 @@ trait Streams {
     end: I
   ): ResultBuilder2[({ type lambda[x, y] = StreamEntries[I, x, y] })#lambda] =
     new ResultBuilder2[({ type lambda[x, y] = StreamEntries[I, x, y] })#lambda] {
-      def returning[RK: Schema, RV: Schema]: ZIO[Redis, RedisError, StreamEntries[I, RK, RV]] = {
+      def returning[RK: Schema, RV: Schema]: ZIO[Any, RedisError, StreamEntries[I, RK, RV]] = {
         val command = RedisCommand(
           XRange,
           Tuple4(ArbitraryInput[SK](), ArbitraryInput[I](), ArbitraryInput[I](), OptionalInput(CountInput)),
@@ -587,7 +587,7 @@ trait Streams {
     count: Long
   ): ResultBuilder2[({ type lambda[x, y] = StreamEntries[I, x, y] })#lambda] =
     new ResultBuilder2[({ type lambda[x, y] = StreamEntries[I, x, y] })#lambda] {
-      def returning[RK: Schema, RV: Schema]: ZIO[Redis, RedisError, StreamEntries[I, RK, RV]] = {
+      def returning[RK: Schema, RV: Schema]: ZIO[Any, RedisError, StreamEntries[I, RK, RV]] = {
         val command = RedisCommand(
           XRange,
           Tuple4(ArbitraryInput[SK](), ArbitraryInput[I](), ArbitraryInput[I](), OptionalInput(CountInput)),
@@ -619,7 +619,7 @@ trait Streams {
     streams: (SK, I)*
   ): ResultBuilder2[({ type lambda[x, y] = StreamChunks[SK, I, x, y] })#lambda] =
     new ResultBuilder2[({ type lambda[x, y] = StreamChunks[SK, I, x, y] })#lambda] {
-      def returning[RK: Schema, RV: Schema]: ZIO[Redis, RedisError, StreamChunks[SK, I, RK, RV]] = {
+      def returning[RK: Schema, RV: Schema]: ZIO[Any, RedisError, StreamChunks[SK, I, RK, RV]] = {
         val command = RedisCommand(
           XRead,
           Tuple3(OptionalInput(CountInput), OptionalInput(BlockInput), StreamsInput[SK, I]()),
@@ -660,7 +660,7 @@ trait Streams {
     streams: (SK, I)*
   ): ResultBuilder2[({ type lambda[x, y] = StreamChunks[SK, I, x, y] })#lambda] =
     new ResultBuilder2[({ type lambda[x, y] = StreamChunks[SK, I, x, y] })#lambda] {
-      def returning[RK: Schema, RV: Schema]: ZIO[Redis, RedisError, StreamChunks[SK, I, RK, RV]] = {
+      def returning[RK: Schema, RV: Schema]: ZIO[Any, RedisError, StreamChunks[SK, I, RK, RV]] = {
         val command = RedisCommand(
           XReadGroup,
           Tuple6(
@@ -696,7 +696,7 @@ trait Streams {
     start: I
   ): ResultBuilder2[({ type lambda[x, y] = StreamEntries[I, x, y] })#lambda] =
     new ResultBuilder2[({ type lambda[x, y] = StreamEntries[I, x, y] })#lambda] {
-      def returning[RK: Schema, RV: Schema]: ZIO[Redis, RedisError, StreamEntries[I, RK, RV]] = {
+      def returning[RK: Schema, RV: Schema]: ZIO[Any, RedisError, StreamEntries[I, RK, RV]] = {
         val command = RedisCommand(
           XRevRange,
           Tuple4(ArbitraryInput[SK](), ArbitraryInput[I](), ArbitraryInput[I](), OptionalInput(CountInput)),
@@ -727,7 +727,7 @@ trait Streams {
     count: Long
   ): ResultBuilder2[({ type lambda[x, y] = StreamEntries[I, x, y] })#lambda] =
     new ResultBuilder2[({ type lambda[x, y] = StreamEntries[I, x, y] })#lambda] {
-      def returning[RK: Schema, RV: Schema]: ZIO[Redis, RedisError, StreamEntries[I, RK, RV]] = {
+      def returning[RK: Schema, RV: Schema]: ZIO[Any, RedisError, StreamEntries[I, RK, RV]] = {
         val command = RedisCommand(
           XRevRange,
           Tuple4(ArbitraryInput[SK](), ArbitraryInput[I](), ArbitraryInput[I](), OptionalInput(CountInput)),
@@ -753,7 +753,7 @@ trait Streams {
     key: SK,
     count: Long,
     approximate: Boolean = false
-  ): ZIO[Redis, RedisError, Long] = {
+  ): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(XTrim, Tuple2(ArbitraryInput[SK](), StreamMaxLenInput), LongOutput)
     command.run((key, StreamMaxLen(approximate, count)))
   }

--- a/redis/src/main/scala/zio/redis/api/Strings.scala
+++ b/redis/src/main/scala/zio/redis/api/Strings.scala
@@ -39,7 +39,7 @@ trait Strings extends RedisEnvironment {
    *   Returns the length of the string after the append operation.
    */
   final def append[K: Schema, V: Schema](key: K, value: V): IO[RedisError, Long] = {
-    val command = RedisCommand(Append, Tuple2(ArbitraryInput[K](), ArbitraryInput[V]()), LongOutput)(executor, codec)
+    val command = RedisCommand(Append, Tuple2(ArbitraryInput[K](), ArbitraryInput[V]()), LongOutput, codec, executor)
     command.run((key, value))
   }
 
@@ -55,7 +55,7 @@ trait Strings extends RedisEnvironment {
    */
   final def bitCount[K: Schema](key: K, range: Option[Range] = None): IO[RedisError, Long] = {
     val command =
-      RedisCommand(BitCount, Tuple2(ArbitraryInput[K](), OptionalInput(RangeInput)), LongOutput)(executor, codec)
+      RedisCommand(BitCount, Tuple2(ArbitraryInput[K](), OptionalInput(RangeInput)), LongOutput, codec, executor)
     command.run((key, range))
   }
 
@@ -79,8 +79,10 @@ trait Strings extends RedisEnvironment {
     val command = RedisCommand(
       BitField,
       Tuple2(ArbitraryInput[K](), NonEmptyList(BitFieldCommandInput)),
-      ChunkOutput(OptionalOutput(LongOutput))
-    )(executor, codec)
+      ChunkOutput(OptionalOutput(LongOutput)),
+      codec,
+      executor
+    )
     command.run((key, (bitFieldCommand, bitFieldCommands.toList)))
   }
 
@@ -108,8 +110,10 @@ trait Strings extends RedisEnvironment {
       RedisCommand(
         BitOp,
         Tuple3(BitOperationInput, ArbitraryInput[D](), NonEmptyList(ArbitraryInput[S]())),
-        LongOutput
-      )(executor, codec)
+        LongOutput,
+        codec,
+        executor
+      )
     command.run((operation, destKey, (srcKey, srcKeys.toList)))
   }
 
@@ -131,9 +135,12 @@ trait Strings extends RedisEnvironment {
     range: Option[BitPosRange] = None
   ): IO[RedisError, Long] = {
     val command =
-      RedisCommand(BitPos, Tuple3(ArbitraryInput[K](), BoolInput, OptionalInput(BitPosRangeInput)), LongOutput)(
-        executor,
-        codec
+      RedisCommand(
+        BitPos,
+        Tuple3(ArbitraryInput[K](), BoolInput, OptionalInput(BitPosRangeInput)),
+        LongOutput,
+        codec,
+        executor
       )
     command.run((key, bit, range))
   }
@@ -147,7 +154,7 @@ trait Strings extends RedisEnvironment {
    *   Returns the value of key after the decrement.
    */
   final def decr[K: Schema](key: K): IO[RedisError, Long] = {
-    val command = RedisCommand(Decr, ArbitraryInput[K](), LongOutput)(executor, codec)
+    val command = RedisCommand(Decr, ArbitraryInput[K](), LongOutput, codec, executor)
     command.run(key)
   }
 
@@ -162,7 +169,7 @@ trait Strings extends RedisEnvironment {
    *   Returns the value of key after the decrement.
    */
   final def decrBy[K: Schema](key: K, decrement: Long): IO[RedisError, Long] = {
-    val command = RedisCommand(DecrBy, Tuple2(ArbitraryInput[K](), LongInput), LongOutput)(executor, codec)
+    val command = RedisCommand(DecrBy, Tuple2(ArbitraryInput[K](), LongInput), LongOutput, codec, executor)
     command.run((key, decrement))
   }
 
@@ -177,7 +184,7 @@ trait Strings extends RedisEnvironment {
   final def get[K: Schema](key: K): ResultBuilder1[Option] =
     new ResultBuilder1[Option] {
       def returning[R: Schema]: IO[RedisError, Option[R]] =
-        RedisCommand(Get, ArbitraryInput[K](), OptionalOutput(ArbitraryOutput[R]()))(executor, codec).run(key)
+        RedisCommand(Get, ArbitraryInput[K](), OptionalOutput(ArbitraryOutput[R]()), codec, executor).run(key)
     }
 
   /**
@@ -191,7 +198,7 @@ trait Strings extends RedisEnvironment {
    *   Returns the bit value stored at offset.
    */
   final def getBit[K: Schema](key: K, offset: Long): IO[RedisError, Long] = {
-    val command = RedisCommand(GetBit, Tuple2(ArbitraryInput[K](), LongInput), LongOutput)(executor, codec)
+    val command = RedisCommand(GetBit, Tuple2(ArbitraryInput[K](), LongInput), LongOutput, codec, executor)
     command.run((key, offset))
   }
 
@@ -208,9 +215,12 @@ trait Strings extends RedisEnvironment {
   final def getRange[K: Schema](key: K, range: Range): ResultBuilder1[Option] =
     new ResultBuilder1[Option] {
       def returning[R: Schema]: IO[RedisError, Option[R]] =
-        RedisCommand(GetRange, Tuple2(ArbitraryInput[K](), RangeInput), OptionalOutput(ArbitraryOutput[R]()))(
-          executor,
-          codec
+        RedisCommand(
+          GetRange,
+          Tuple2(ArbitraryInput[K](), RangeInput),
+          OptionalOutput(ArbitraryOutput[R]()),
+          codec,
+          executor
         )
           .run((key, range))
     }
@@ -228,9 +238,12 @@ trait Strings extends RedisEnvironment {
   final def getSet[K: Schema, V: Schema](key: K, value: V): ResultBuilder1[Option] =
     new ResultBuilder1[Option] {
       def returning[R: Schema]: IO[RedisError, Option[R]] =
-        RedisCommand(GetSet, Tuple2(ArbitraryInput[K](), ArbitraryInput[V]()), OptionalOutput(ArbitraryOutput[R]()))(
-          executor,
-          codec
+        RedisCommand(
+          GetSet,
+          Tuple2(ArbitraryInput[K](), ArbitraryInput[V]()),
+          OptionalOutput(ArbitraryOutput[R]()),
+          codec,
+          executor
         )
           .run((key, value))
     }
@@ -246,7 +259,7 @@ trait Strings extends RedisEnvironment {
   final def getDel[K: Schema](key: K): ResultBuilder1[Option] =
     new ResultBuilder1[Option] {
       def returning[R: Schema]: IO[RedisError, Option[R]] =
-        RedisCommand(GetDel, ArbitraryInput[K](), OptionalOutput(ArbitraryOutput[R]()))(executor, codec).run(key)
+        RedisCommand(GetDel, ArbitraryInput[K](), OptionalOutput(ArbitraryOutput[R]()), codec, executor).run(key)
     }
 
   /**
@@ -265,7 +278,7 @@ trait Strings extends RedisEnvironment {
   final def getEx[K: Schema](key: K, expire: Expire, expireTime: Duration): ResultBuilder1[Option] =
     new ResultBuilder1[Option] {
       def returning[R: Schema]: IO[RedisError, Option[R]] =
-        RedisCommand(GetEx, GetExInput[K](), OptionalOutput(ArbitraryOutput[R]()))(executor, codec)
+        RedisCommand(GetEx, GetExInput[K](), OptionalOutput(ArbitraryOutput[R]()), codec, executor)
           .run((key, expire, expireTime))
     }
 
@@ -285,7 +298,7 @@ trait Strings extends RedisEnvironment {
   final def getEx[K: Schema](key: K, expiredAt: ExpiredAt, timestamp: Instant): ResultBuilder1[Option] =
     new ResultBuilder1[Option] {
       def returning[R: Schema]: IO[RedisError, Option[R]] =
-        RedisCommand(GetEx, GetExAtInput[K](), OptionalOutput(ArbitraryOutput[R]()))(executor, codec)
+        RedisCommand(GetEx, GetExAtInput[K](), OptionalOutput(ArbitraryOutput[R]()), codec, executor)
           .run((key, expiredAt, timestamp))
     }
 
@@ -302,7 +315,7 @@ trait Strings extends RedisEnvironment {
   final def getEx[K: Schema](key: K, persist: Boolean): ResultBuilder1[Option] =
     new ResultBuilder1[Option] {
       def returning[R: Schema]: IO[RedisError, Option[R]] =
-        RedisCommand(GetEx, GetExPersistInput[K](), OptionalOutput(ArbitraryOutput[R]()))(executor, codec)
+        RedisCommand(GetEx, GetExPersistInput[K](), OptionalOutput(ArbitraryOutput[R]()), codec, executor)
           .run((key, persist))
     }
 
@@ -315,7 +328,7 @@ trait Strings extends RedisEnvironment {
    *   Returns the value of key after the increment.
    */
   final def incr[K: Schema](key: K): IO[RedisError, Long] = {
-    val command = RedisCommand(Incr, ArbitraryInput[K](), LongOutput)(executor, codec)
+    val command = RedisCommand(Incr, ArbitraryInput[K](), LongOutput, codec, executor)
     command.run(key)
   }
 
@@ -331,7 +344,7 @@ trait Strings extends RedisEnvironment {
    */
   final def incrBy[K: Schema](key: K, increment: Long): IO[RedisError, Long] = {
     val command =
-      RedisCommand(IncrBy, Tuple2(ArbitraryInput[K](), LongInput), LongOutput)(executor, codec)
+      RedisCommand(IncrBy, Tuple2(ArbitraryInput[K](), LongInput), LongOutput, codec, executor)
     command.run((key, increment))
   }
 
@@ -346,7 +359,7 @@ trait Strings extends RedisEnvironment {
    *   Returns the value of key after the increment.
    */
   final def incrByFloat[K: Schema](key: K, increment: Double): IO[RedisError, Double] = {
-    val command = RedisCommand(IncrByFloat, Tuple2(ArbitraryInput[K](), DoubleInput), DoubleOutput)(executor, codec)
+    val command = RedisCommand(IncrByFloat, Tuple2(ArbitraryInput[K](), DoubleInput), DoubleOutput, codec, executor)
     command.run((key, increment))
   }
 
@@ -367,9 +380,12 @@ trait Strings extends RedisEnvironment {
     new ResultBuilder1[({ type lambda[x] = Chunk[Option[x]] })#lambda] {
       def returning[V: Schema]: IO[RedisError, Chunk[Option[V]]] = {
         val command =
-          RedisCommand(MGet, NonEmptyList(ArbitraryInput[K]()), ChunkOutput(OptionalOutput(ArbitraryOutput[V]())))(
-            executor,
-            codec
+          RedisCommand(
+            MGet,
+            NonEmptyList(ArbitraryInput[K]()),
+            ChunkOutput(OptionalOutput(ArbitraryOutput[V]())),
+            codec,
+            executor
           )
         command.run((key, keys.toList))
       }
@@ -385,7 +401,7 @@ trait Strings extends RedisEnvironment {
    */
   final def mSet[K: Schema, V: Schema](keyValue: (K, V), keyValues: (K, V)*): IO[RedisError, Unit] = {
     val command =
-      RedisCommand(MSet, NonEmptyList(Tuple2(ArbitraryInput[K](), ArbitraryInput[V]())), UnitOutput)(executor, codec)
+      RedisCommand(MSet, NonEmptyList(Tuple2(ArbitraryInput[K](), ArbitraryInput[V]())), UnitOutput, codec, executor)
     command.run((keyValue, keyValues.toList))
   }
 
@@ -404,7 +420,7 @@ trait Strings extends RedisEnvironment {
     keyValues: (K, V)*
   ): IO[RedisError, Boolean] = {
     val command =
-      RedisCommand(MSetNx, NonEmptyList(Tuple2(ArbitraryInput[K](), ArbitraryInput[V]())), BoolOutput)(executor, codec)
+      RedisCommand(MSetNx, NonEmptyList(Tuple2(ArbitraryInput[K](), ArbitraryInput[V]())), BoolOutput, codec, executor)
     command.run((keyValue, keyValues.toList))
   }
 
@@ -424,9 +440,12 @@ trait Strings extends RedisEnvironment {
     value: V
   ): IO[RedisError, Unit] = {
     val command =
-      RedisCommand(PSetEx, Tuple3(ArbitraryInput[K](), DurationMillisecondsInput, ArbitraryInput[V]()), UnitOutput)(
-        executor,
-        codec
+      RedisCommand(
+        PSetEx,
+        Tuple3(ArbitraryInput[K](), DurationMillisecondsInput, ArbitraryInput[V]()),
+        UnitOutput,
+        codec,
+        executor
       )
     command.run((key, milliseconds, value))
   }
@@ -462,7 +481,7 @@ trait Strings extends RedisEnvironment {
       OptionalInput(UpdateInput),
       OptionalInput(KeepTtlInput)
     )
-    val command = RedisCommand(Set, input, SetOutput)(executor, codec)
+    val command = RedisCommand(Set, input, SetOutput, codec, executor)
     command.run((key, value, expireTime, update, keepTtl))
   }
 
@@ -479,7 +498,7 @@ trait Strings extends RedisEnvironment {
    *   Returns the original bit value stored at offset.
    */
   final def setBit[K: Schema](key: K, offset: Long, value: Boolean): IO[RedisError, Boolean] = {
-    val command = RedisCommand(SetBit, Tuple3(ArbitraryInput[K](), LongInput, BoolInput), BoolOutput)(executor, codec)
+    val command = RedisCommand(SetBit, Tuple3(ArbitraryInput[K](), LongInput, BoolInput), BoolOutput, codec, executor)
     command.run((key, offset, value))
   }
 
@@ -499,9 +518,12 @@ trait Strings extends RedisEnvironment {
     value: V
   ): IO[RedisError, Unit] = {
     val command =
-      RedisCommand(SetEx, Tuple3(ArbitraryInput[K](), DurationSecondsInput, ArbitraryInput[V]()), UnitOutput)(
-        executor,
-        codec
+      RedisCommand(
+        SetEx,
+        Tuple3(ArbitraryInput[K](), DurationSecondsInput, ArbitraryInput[V]()),
+        UnitOutput,
+        codec,
+        executor
       )
     command.run((key, expiration, value))
   }
@@ -517,7 +539,7 @@ trait Strings extends RedisEnvironment {
    *   Returns 1 if the key was set. 0 if the key was not set.
    */
   final def setNx[K: Schema, V: Schema](key: K, value: V): IO[RedisError, Boolean] = {
-    val command = RedisCommand(SetNx, Tuple2(ArbitraryInput[K](), ArbitraryInput[V]()), BoolOutput)(executor, codec)
+    val command = RedisCommand(SetNx, Tuple2(ArbitraryInput[K](), ArbitraryInput[V]()), BoolOutput, codec, executor)
     command.run((key, value))
   }
 
@@ -535,7 +557,7 @@ trait Strings extends RedisEnvironment {
    */
   final def setRange[K: Schema, V: Schema](key: K, offset: Long, value: V): IO[RedisError, Long] = {
     val command =
-      RedisCommand(SetRange, Tuple3(ArbitraryInput[K](), LongInput, ArbitraryInput[V]()), LongOutput)(executor, codec)
+      RedisCommand(SetRange, Tuple3(ArbitraryInput[K](), LongInput, ArbitraryInput[V]()), LongOutput, codec, executor)
     command.run((key, offset, value))
   }
 
@@ -548,7 +570,7 @@ trait Strings extends RedisEnvironment {
    *   Returns the length of the string.
    */
   final def strLen[K: Schema](key: K): IO[RedisError, Long] = {
-    val command = RedisCommand(StrLen, ArbitraryInput[K](), LongOutput)(executor, codec)
+    val command = RedisCommand(StrLen, ArbitraryInput[K](), LongOutput, codec, executor)
     command.run(key)
   }
 
@@ -583,8 +605,10 @@ trait Strings extends RedisEnvironment {
         ArbitraryInput[K](),
         OptionalInput(StralgoLcsQueryTypeInput)
       ),
-      StrAlgoLcsOutput
-    )(executor, codec)
+      StrAlgoLcsOutput,
+      codec,
+      executor
+    )
     redisCommand.run((command.stringify, keyA, keyB, lcsQueryType))
   }
 }

--- a/redis/src/main/scala/zio/redis/api/Strings.scala
+++ b/redis/src/main/scala/zio/redis/api/Strings.scala
@@ -25,7 +25,7 @@ import zio.schema.Schema
 
 import java.time.Instant
 
-trait Strings {
+trait Strings extends CommandExecutor {
   import Strings._
 
   /**
@@ -38,7 +38,7 @@ trait Strings {
    * @return
    *   Returns the length of the string after the append operation.
    */
-  final def append[K: Schema, V: Schema](key: K, value: V): ZIO[Redis, RedisError, Long] = {
+  final def append[K: Schema, V: Schema](key: K, value: V): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(Append, Tuple2(ArbitraryInput[K](), ArbitraryInput[V]()), LongOutput)
     command.run((key, value))
   }
@@ -53,7 +53,7 @@ trait Strings {
    * @return
    *   Returns the number of bits set to 1.
    */
-  final def bitCount[K: Schema](key: K, range: Option[Range] = None): ZIO[Redis, RedisError, Long] = {
+  final def bitCount[K: Schema](key: K, range: Option[Range] = None): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(BitCount, Tuple2(ArbitraryInput[K](), OptionalInput(RangeInput)), LongOutput)
     command.run((key, range))
   }
@@ -74,7 +74,7 @@ trait Strings {
     key: K,
     bitFieldCommand: BitFieldCommand,
     bitFieldCommands: BitFieldCommand*
-  ): ZIO[Redis, RedisError, Chunk[Option[Long]]] = {
+  ): ZIO[Any, RedisError, Chunk[Option[Long]]] = {
     val command = RedisCommand(
       BitField,
       Tuple2(ArbitraryInput[K](), NonEmptyList(BitFieldCommandInput)),
@@ -102,7 +102,7 @@ trait Strings {
     destKey: D,
     srcKey: S,
     srcKeys: S*
-  ): ZIO[Redis, RedisError, Long] = {
+  ): ZIO[Any, RedisError, Long] = {
     val command =
       RedisCommand(BitOp, Tuple3(BitOperationInput, ArbitraryInput[D](), NonEmptyList(ArbitraryInput[S]())), LongOutput)
     command.run((operation, destKey, (srcKey, srcKeys.toList)))
@@ -124,7 +124,7 @@ trait Strings {
     key: K,
     bit: Boolean,
     range: Option[BitPosRange] = None
-  ): ZIO[Redis, RedisError, Long] = {
+  ): ZIO[Any, RedisError, Long] = {
     val command =
       RedisCommand(BitPos, Tuple3(ArbitraryInput[K](), BoolInput, OptionalInput(BitPosRangeInput)), LongOutput)
     command.run((key, bit, range))
@@ -138,7 +138,7 @@ trait Strings {
    * @return
    *   Returns the value of key after the decrement.
    */
-  final def decr[K: Schema](key: K): ZIO[Redis, RedisError, Long] = {
+  final def decr[K: Schema](key: K): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(Decr, ArbitraryInput[K](), LongOutput)
     command.run(key)
   }
@@ -153,7 +153,7 @@ trait Strings {
    * @return
    *   Returns the value of key after the decrement.
    */
-  final def decrBy[K: Schema](key: K, decrement: Long): ZIO[Redis, RedisError, Long] = {
+  final def decrBy[K: Schema](key: K, decrement: Long): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(DecrBy, Tuple2(ArbitraryInput[K](), LongInput), LongOutput)
     command.run((key, decrement))
   }
@@ -168,7 +168,7 @@ trait Strings {
    */
   final def get[K: Schema](key: K): ResultBuilder1[Option] =
     new ResultBuilder1[Option] {
-      def returning[R: Schema]: ZIO[Redis, RedisError, Option[R]] =
+      def returning[R: Schema]: ZIO[Any, RedisError, Option[R]] =
         RedisCommand(Get, ArbitraryInput[K](), OptionalOutput(ArbitraryOutput[R]())).run(key)
     }
 
@@ -182,7 +182,7 @@ trait Strings {
    * @return
    *   Returns the bit value stored at offset.
    */
-  final def getBit[K: Schema](key: K, offset: Long): ZIO[Redis, RedisError, Long] = {
+  final def getBit[K: Schema](key: K, offset: Long): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(GetBit, Tuple2(ArbitraryInput[K](), LongInput), LongOutput)
     command.run((key, offset))
   }
@@ -199,7 +199,7 @@ trait Strings {
    */
   final def getRange[K: Schema](key: K, range: Range): ResultBuilder1[Option] =
     new ResultBuilder1[Option] {
-      def returning[R: Schema]: ZIO[Redis, RedisError, Option[R]] =
+      def returning[R: Schema]: ZIO[Any, RedisError, Option[R]] =
         RedisCommand(GetRange, Tuple2(ArbitraryInput[K](), RangeInput), OptionalOutput(ArbitraryOutput[R]()))
           .run((key, range))
     }
@@ -216,7 +216,7 @@ trait Strings {
    */
   final def getSet[K: Schema, V: Schema](key: K, value: V): ResultBuilder1[Option] =
     new ResultBuilder1[Option] {
-      def returning[R: Schema]: ZIO[Redis, RedisError, Option[R]] =
+      def returning[R: Schema]: ZIO[Any, RedisError, Option[R]] =
         RedisCommand(GetSet, Tuple2(ArbitraryInput[K](), ArbitraryInput[V]()), OptionalOutput(ArbitraryOutput[R]()))
           .run((key, value))
     }
@@ -231,7 +231,7 @@ trait Strings {
    */
   final def getDel[K: Schema](key: K): ResultBuilder1[Option] =
     new ResultBuilder1[Option] {
-      def returning[R: Schema]: ZIO[Redis, RedisError, Option[R]] =
+      def returning[R: Schema]: ZIO[Any, RedisError, Option[R]] =
         RedisCommand(GetDel, ArbitraryInput[K](), OptionalOutput(ArbitraryOutput[R]())).run(key)
     }
 
@@ -250,7 +250,7 @@ trait Strings {
    */
   final def getEx[K: Schema](key: K, expire: Expire, expireTime: Duration): ResultBuilder1[Option] =
     new ResultBuilder1[Option] {
-      def returning[R: Schema]: ZIO[Redis, RedisError, Option[R]] =
+      def returning[R: Schema]: ZIO[Any, RedisError, Option[R]] =
         RedisCommand(GetEx, GetExInput[K](), OptionalOutput(ArbitraryOutput[R]())).run((key, expire, expireTime))
     }
 
@@ -269,7 +269,7 @@ trait Strings {
    */
   final def getEx[K: Schema](key: K, expiredAt: ExpiredAt, timestamp: Instant): ResultBuilder1[Option] =
     new ResultBuilder1[Option] {
-      def returning[R: Schema]: ZIO[Redis, RedisError, Option[R]] =
+      def returning[R: Schema]: ZIO[Any, RedisError, Option[R]] =
         RedisCommand(GetEx, GetExAtInput[K](), OptionalOutput(ArbitraryOutput[R]())).run((key, expiredAt, timestamp))
     }
 
@@ -285,7 +285,7 @@ trait Strings {
    */
   final def getEx[K: Schema](key: K, persist: Boolean): ResultBuilder1[Option] =
     new ResultBuilder1[Option] {
-      def returning[R: Schema]: ZIO[Redis, RedisError, Option[R]] =
+      def returning[R: Schema]: ZIO[Any, RedisError, Option[R]] =
         RedisCommand(GetEx, GetExPersistInput[K](), OptionalOutput(ArbitraryOutput[R]())).run((key, persist))
     }
 
@@ -297,7 +297,7 @@ trait Strings {
    * @return
    *   Returns the value of key after the increment.
    */
-  final def incr[K: Schema](key: K): ZIO[Redis, RedisError, Long] = {
+  final def incr[K: Schema](key: K): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(Incr, ArbitraryInput[K](), LongOutput)
     command.run(key)
   }
@@ -312,7 +312,7 @@ trait Strings {
    * @return
    *   Returns the value of key after the increment.
    */
-  final def incrBy[K: Schema](key: K, increment: Long): ZIO[Redis, RedisError, Long] = {
+  final def incrBy[K: Schema](key: K, increment: Long): ZIO[Any, RedisError, Long] = {
     val command =
       RedisCommand(IncrBy, Tuple2(ArbitraryInput[K](), LongInput), LongOutput)
     command.run((key, increment))
@@ -328,7 +328,7 @@ trait Strings {
    * @return
    *   Returns the value of key after the increment.
    */
-  final def incrByFloat[K: Schema](key: K, increment: Double): ZIO[Redis, RedisError, Double] = {
+  final def incrByFloat[K: Schema](key: K, increment: Double): ZIO[Any, RedisError, Double] = {
     val command = RedisCommand(IncrByFloat, Tuple2(ArbitraryInput[K](), DoubleInput), DoubleOutput)
     command.run((key, increment))
   }
@@ -348,7 +348,7 @@ trait Strings {
     keys: K*
   ): ResultBuilder1[({ type lambda[x] = Chunk[Option[x]] })#lambda] =
     new ResultBuilder1[({ type lambda[x] = Chunk[Option[x]] })#lambda] {
-      def returning[V: Schema]: ZIO[Redis, RedisError, Chunk[Option[V]]] = {
+      def returning[V: Schema]: ZIO[Any, RedisError, Chunk[Option[V]]] = {
         val command =
           RedisCommand(MGet, NonEmptyList(ArbitraryInput[K]()), ChunkOutput(OptionalOutput(ArbitraryOutput[V]())))
         command.run((key, keys.toList))
@@ -363,7 +363,7 @@ trait Strings {
    * @param keyValues
    *   Subsequent tuples of key values
    */
-  final def mSet[K: Schema, V: Schema](keyValue: (K, V), keyValues: (K, V)*): ZIO[Redis, RedisError, Unit] = {
+  final def mSet[K: Schema, V: Schema](keyValue: (K, V), keyValues: (K, V)*): ZIO[Any, RedisError, Unit] = {
     val command = RedisCommand(MSet, NonEmptyList(Tuple2(ArbitraryInput[K](), ArbitraryInput[V]())), UnitOutput)
     command.run((keyValue, keyValues.toList))
   }
@@ -381,7 +381,7 @@ trait Strings {
   final def mSetNx[K: Schema, V: Schema](
     keyValue: (K, V),
     keyValues: (K, V)*
-  ): ZIO[Redis, RedisError, Boolean] = {
+  ): ZIO[Any, RedisError, Boolean] = {
     val command = RedisCommand(MSetNx, NonEmptyList(Tuple2(ArbitraryInput[K](), ArbitraryInput[V]())), BoolOutput)
     command.run((keyValue, keyValues.toList))
   }
@@ -400,7 +400,7 @@ trait Strings {
     key: K,
     milliseconds: Duration,
     value: V
-  ): ZIO[Redis, RedisError, Unit] = {
+  ): ZIO[Any, RedisError, Unit] = {
     val command =
       RedisCommand(PSetEx, Tuple3(ArbitraryInput[K](), DurationMillisecondsInput, ArbitraryInput[V]()), UnitOutput)
     command.run((key, milliseconds, value))
@@ -429,7 +429,7 @@ trait Strings {
     expireTime: Option[Duration] = None,
     update: Option[Update] = None,
     keepTtl: Option[KeepTtl] = None
-  ): ZIO[Redis, RedisError, Boolean] = {
+  ): ZIO[Any, RedisError, Boolean] = {
     val input = Tuple5(
       ArbitraryInput[K](),
       ArbitraryInput[V](),
@@ -453,7 +453,7 @@ trait Strings {
    * @return
    *   Returns the original bit value stored at offset.
    */
-  final def setBit[K: Schema](key: K, offset: Long, value: Boolean): ZIO[Redis, RedisError, Boolean] = {
+  final def setBit[K: Schema](key: K, offset: Long, value: Boolean): ZIO[Any, RedisError, Boolean] = {
     val command = RedisCommand(SetBit, Tuple3(ArbitraryInput[K](), LongInput, BoolInput), BoolOutput)
     command.run((key, offset, value))
   }
@@ -472,7 +472,7 @@ trait Strings {
     key: K,
     expiration: Duration,
     value: V
-  ): ZIO[Redis, RedisError, Unit] = {
+  ): ZIO[Any, RedisError, Unit] = {
     val command =
       RedisCommand(SetEx, Tuple3(ArbitraryInput[K](), DurationSecondsInput, ArbitraryInput[V]()), UnitOutput)
     command.run((key, expiration, value))
@@ -488,7 +488,7 @@ trait Strings {
    * @return
    *   Returns 1 if the key was set. 0 if the key was not set.
    */
-  final def setNx[K: Schema, V: Schema](key: K, value: V): ZIO[Redis, RedisError, Boolean] = {
+  final def setNx[K: Schema, V: Schema](key: K, value: V): ZIO[Any, RedisError, Boolean] = {
     val command = RedisCommand(SetNx, Tuple2(ArbitraryInput[K](), ArbitraryInput[V]()), BoolOutput)
     command.run((key, value))
   }
@@ -505,7 +505,7 @@ trait Strings {
    * @return
    *   Returns the length of the string after it was modified by the command.
    */
-  final def setRange[K: Schema, V: Schema](key: K, offset: Long, value: V): ZIO[Redis, RedisError, Long] = {
+  final def setRange[K: Schema, V: Schema](key: K, offset: Long, value: V): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(SetRange, Tuple3(ArbitraryInput[K](), LongInput, ArbitraryInput[V]()), LongOutput)
     command.run((key, offset, value))
   }
@@ -518,7 +518,7 @@ trait Strings {
    * @return
    *   Returns the length of the string.
    */
-  final def strLen[K: Schema](key: K): ZIO[Redis, RedisError, Long] = {
+  final def strLen[K: Schema](key: K): ZIO[Any, RedisError, Long] = {
     val command = RedisCommand(StrLen, ArbitraryInput[K](), LongOutput)
     command.run(key)
   }
@@ -545,7 +545,7 @@ trait Strings {
     keyA: K,
     keyB: K,
     lcsQueryType: Option[StrAlgoLcsQueryType] = None
-  ): ZIO[Redis, RedisError, LcsOutput] = {
+  ): ZIO[Any, RedisError, LcsOutput] = {
     val redisCommand = RedisCommand(
       StrAlgoLcs,
       Tuple4(

--- a/redis/src/main/scala/zio/redis/codecs/CRC16.scala
+++ b/redis/src/main/scala/zio/redis/codecs/CRC16.scala
@@ -1,4 +1,4 @@
-package zio.redis.codec
+package zio.redis.codecs
 
 import zio.Chunk
 

--- a/redis/src/main/scala/zio/redis/codecs/StringUtf8Codec.scala
+++ b/redis/src/main/scala/zio/redis/codecs/StringUtf8Codec.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package zio.redis.codec
+package zio.redis.codecs
 
 import zio.redis.RedisError.CodecError
 import zio.schema.Schema

--- a/redis/src/main/scala/zio/redis/package.scala
+++ b/redis/src/main/scala/zio/redis/package.scala
@@ -17,19 +17,7 @@
 package zio
 
 package object redis
-    extends api.Connection
-    with api.Geo
-    with api.Hashes
-    with api.HyperLogLog
-    with api.Keys
-    with api.Lists
-    with api.Sets
-    with api.Strings
-    with api.SortedSets
-    with api.Streams
-    with api.Scripting
-    with api.Cluster
-    with options.Connection
+    extends options.Connection
     with options.Geo
     with options.Keys
     with options.Shared

--- a/redis/src/test/scala/zio/redis/ClusterExecutorSpec.scala
+++ b/redis/src/test/scala/zio/redis/ClusterExecutorSpec.scala
@@ -9,63 +9,58 @@ object ClusterExecutorSpec extends BaseSpec {
   def spec: Spec[TestEnvironment, Any] =
     suite("cluster executor")(
       test("check cluster responsiveness when ASK redirect happens") {
-        ZIO.serviceWithZIO[Redis] { redis =>
-          import redis._
-          for {
-            initSlots       <- slots
-            key             <- uuid
-            value1          <- get(key).returning[String]
-            keySlot          = Slot(CRC16.get(Chunk.fromArray(key.getBytes)).toLong % SlotsAmount)
-            (sourcePart, id) = initSlots.zipWithIndex.find { case (p, _) => p.slotRange.contains(keySlot) }.get
-            sourceMaster     = sourcePart.master
-            destPart         = initSlots((id + 1) % initSlots.size)
-            destMaster       = destPart.master
-            destMasterConn   = getRedisNodeLayer(destMaster.address)
-            _                = ZIO.logDebug(s"$key _____ Importing $keySlot to ${destMaster.id} - ${destMaster.address}")
-            _               <- ZIO.serviceWithZIO[Redis](_.setSlotImporting(keySlot, sourceMaster.id)).provideLayer(destMasterConn)
-            _                = ZIO.logDebug(s"$key _____ Migrating $keySlot from ${sourceMaster.id}- ${sourceMaster.address}")
-            sourceMasterConn = getRedisNodeLayer(sourceMaster.address)
-            _               <- ZIO.serviceWithZIO[Redis](_.setSlotMigrating(keySlot, destMaster.id)).provideLayer(sourceMasterConn)
-            value2          <- get(key).returning[String] // have to redirect without error ASK
-            value3          <- get(key).returning[String] // have to redirect without creating new connection
-            _               <- ZIO.serviceWithZIO[Redis](_.setSlotStable(keySlot)).provideLayer(destMasterConn)
-          } yield {
-            assertTrue(value1 == value2) && assertTrue(value2 == value3)
-          }
+        for {
+          redis           <- ZIO.service[Redis]
+          initSlots       <- redis.slots
+          key             <- uuid
+          value1          <- redis.get(key).returning[String]
+          keySlot          = Slot(CRC16.get(Chunk.fromArray(key.getBytes)).toLong % SlotsAmount)
+          (sourcePart, id) = initSlots.zipWithIndex.find { case (p, _) => p.slotRange.contains(keySlot) }.get
+          sourceMaster     = sourcePart.master
+          destPart         = initSlots((id + 1) % initSlots.size)
+          destMaster       = destPart.master
+          destMasterConn   = getRedisNodeLayer(destMaster.address)
+          _                = ZIO.logDebug(s"$key _____ Importing $keySlot to ${destMaster.id} - ${destMaster.address}")
+          _               <- ZIO.serviceWithZIO[Redis](_.setSlotImporting(keySlot, sourceMaster.id)).provideLayer(destMasterConn)
+          _                = ZIO.logDebug(s"$key _____ Migrating $keySlot from ${sourceMaster.id}- ${sourceMaster.address}")
+          sourceMasterConn = getRedisNodeLayer(sourceMaster.address)
+          _               <- ZIO.serviceWithZIO[Redis](_.setSlotMigrating(keySlot, destMaster.id)).provideLayer(sourceMasterConn)
+          value2          <- redis.get(key).returning[String] // have to redirect without error ASK
+          value3          <- redis.get(key).returning[String] // have to redirect without creating new connection
+          _               <- ZIO.serviceWithZIO[Redis](_.setSlotStable(keySlot)).provideLayer(destMasterConn)
+        } yield {
+          assertTrue(value1 == value2) && assertTrue(value2 == value3)
         }
       },
       test("check client responsiveness when Moved redirect happened") {
-        ZIO.serviceWithZIO[Redis] { redis =>
-          import redis._
-
-          for {
-            initSlots       <- slots
-            key             <- uuid
-            _               <- set(key, "value")
-            value1          <- get(key).returning[String]
-            keySlot          = Slot(CRC16.get(Chunk.fromArray(key.getBytes)).toLong % SlotsAmount)
-            (sourcePart, id) = initSlots.zipWithIndex.find { case (p, _) => p.slotRange.contains(keySlot) }.get
-            sourceMaster     = sourcePart.master
-            destPart         = initSlots((id + 1) % initSlots.size)
-            destMaster       = destPart.master
-            destMasterConn   = getRedisNodeLayer(destMaster.address)
-            _               <- ZIO.logDebug(s"$key _____ Importing $keySlot to ${destMaster.id}")
-            _               <- ZIO.serviceWithZIO[Redis](_.setSlotImporting(keySlot, sourceMaster.id)).provideLayer(destMasterConn)
-            _               <- ZIO.logDebug(s"$key _____ Migrating $keySlot from ${sourceMaster.id}")
-            sourceMasterConn = getRedisNodeLayer(sourceMaster.address)
-            _               <- ZIO.serviceWithZIO[Redis](_.setSlotMigrating(keySlot, destMaster.id)).provideLayer(sourceMasterConn)
-            _ <- ZIO
-                   .serviceWithZIO[Redis](
-                     _.migrate(destMaster.address.host, destMaster.address.port.toLong, key, 0, 5.seconds, keys = None)
-                   )
-                   .provideLayer(sourceMasterConn)
-            _      <- ZIO.serviceWithZIO[Redis](_.setSlotNode(keySlot, destMaster.id)).provideLayer(destMasterConn)
-            _      <- ZIO.serviceWithZIO[Redis](_.setSlotNode(keySlot, destMaster.id)).provideLayer(sourceMasterConn)
-            value2 <- get(key).returning[String] // have to refresh connection
-            value3 <- get(key).returning[String] // have to get value without refreshing connection
-          } yield {
-            assertTrue(value1 == value2) && assertTrue(value2 == value3)
-          }
+        for {
+          redis           <- ZIO.service[Redis]
+          initSlots       <- redis.slots
+          key             <- uuid
+          _               <- redis.set(key, "value")
+          value1          <- redis.get(key).returning[String]
+          keySlot          = Slot(CRC16.get(Chunk.fromArray(key.getBytes)).toLong % SlotsAmount)
+          (sourcePart, id) = initSlots.zipWithIndex.find { case (p, _) => p.slotRange.contains(keySlot) }.get
+          sourceMaster     = sourcePart.master
+          destPart         = initSlots((id + 1) % initSlots.size)
+          destMaster       = destPart.master
+          destMasterConn   = getRedisNodeLayer(destMaster.address)
+          _               <- ZIO.logDebug(s"$key _____ Importing $keySlot to ${destMaster.id}")
+          _               <- ZIO.serviceWithZIO[Redis](_.setSlotImporting(keySlot, sourceMaster.id)).provideLayer(destMasterConn)
+          _               <- ZIO.logDebug(s"$key _____ Migrating $keySlot from ${sourceMaster.id}")
+          sourceMasterConn = getRedisNodeLayer(sourceMaster.address)
+          _               <- ZIO.serviceWithZIO[Redis](_.setSlotMigrating(keySlot, destMaster.id)).provideLayer(sourceMasterConn)
+          _ <- ZIO
+                 .serviceWithZIO[Redis](
+                   _.migrate(destMaster.address.host, destMaster.address.port.toLong, key, 0, 5.seconds, keys = None)
+                 )
+                 .provideLayer(sourceMasterConn)
+          _      <- ZIO.serviceWithZIO[Redis](_.setSlotNode(keySlot, destMaster.id)).provideLayer(destMasterConn)
+          _      <- ZIO.serviceWithZIO[Redis](_.setSlotNode(keySlot, destMaster.id)).provideLayer(sourceMasterConn)
+          value2 <- redis.get(key).returning[String] // have to refresh connection
+          value3 <- redis.get(key).returning[String] // have to get value without refreshing connection
+        } yield {
+          assertTrue(value1 == value2) && assertTrue(value2 == value3)
         }
       }
     ).provideLayerShared(ClusterLayer)

--- a/redis/src/test/scala/zio/redis/ClusterExecutorSpec.scala
+++ b/redis/src/test/scala/zio/redis/ClusterExecutorSpec.scala
@@ -1,6 +1,6 @@
 package zio.redis
 
-import zio.redis.codec.CRC16
+import zio.redis.codecs.CRC16
 import zio.redis.options.Cluster.{Slot, SlotsAmount}
 import zio.test._
 import zio.{Chunk, Layer, ZIO, ZLayer, durationInt}
@@ -9,53 +9,63 @@ object ClusterExecutorSpec extends BaseSpec {
   def spec: Spec[TestEnvironment, Any] =
     suite("cluster executor")(
       test("check cluster responsiveness when ASK redirect happens") {
-        for {
-          initSlots       <- slots
-          key             <- uuid
-          value1          <- get(key).returning[String]
-          keySlot          = Slot(CRC16.get(Chunk.fromArray(key.getBytes)).toLong % SlotsAmount)
-          (sourcePart, id) = initSlots.zipWithIndex.find { case (p, _) => p.slotRange.contains(keySlot) }.get
-          sourceMaster     = sourcePart.master
-          destPart         = initSlots((id + 1) % initSlots.size)
-          destMaster       = destPart.master
-          destMasterConn   = getRedisNodeLayer(destMaster.address)
-          _                = ZIO.logDebug(s"$key _____ Importing $keySlot to ${destMaster.id} - ${destMaster.address}")
-          _               <- setSlotImporting(keySlot, sourceMaster.id).provideLayer(destMasterConn)
-          _                = ZIO.logDebug(s"$key _____ Migrating $keySlot from ${sourceMaster.id}- ${sourceMaster.address}")
-          sourceMasterConn = getRedisNodeLayer(sourceMaster.address)
-          _               <- setSlotMigrating(keySlot, destMaster.id).provideLayer(sourceMasterConn)
-          value2          <- get(key).returning[String] // have to redirect without error ASK
-          value3          <- get(key).returning[String] // have to redirect without creating new connection
-          _               <- setSlotStable(keySlot).provideLayer(destMasterConn)
-        } yield {
-          assertTrue(value1 == value2) && assertTrue(value2 == value3)
+        ZIO.serviceWithZIO[Redis] { redis =>
+          import redis._
+          for {
+            initSlots       <- slots
+            key             <- uuid
+            value1          <- get(key).returning[String]
+            keySlot          = Slot(CRC16.get(Chunk.fromArray(key.getBytes)).toLong % SlotsAmount)
+            (sourcePart, id) = initSlots.zipWithIndex.find { case (p, _) => p.slotRange.contains(keySlot) }.get
+            sourceMaster     = sourcePart.master
+            destPart         = initSlots((id + 1) % initSlots.size)
+            destMaster       = destPart.master
+            destMasterConn   = getRedisNodeLayer(destMaster.address)
+            _                = ZIO.logDebug(s"$key _____ Importing $keySlot to ${destMaster.id} - ${destMaster.address}")
+            _               <- ZIO.serviceWithZIO[Redis](_.setSlotImporting(keySlot, sourceMaster.id)).provideLayer(destMasterConn)
+            _                = ZIO.logDebug(s"$key _____ Migrating $keySlot from ${sourceMaster.id}- ${sourceMaster.address}")
+            sourceMasterConn = getRedisNodeLayer(sourceMaster.address)
+            _               <- ZIO.serviceWithZIO[Redis](_.setSlotMigrating(keySlot, destMaster.id)).provideLayer(sourceMasterConn)
+            value2          <- get(key).returning[String] // have to redirect without error ASK
+            value3          <- get(key).returning[String] // have to redirect without creating new connection
+            _               <- ZIO.serviceWithZIO[Redis](_.setSlotStable(keySlot)).provideLayer(destMasterConn)
+          } yield {
+            assertTrue(value1 == value2) && assertTrue(value2 == value3)
+          }
         }
       },
       test("check client responsiveness when Moved redirect happened") {
-        for {
-          initSlots       <- slots
-          key             <- uuid
-          _               <- set(key, "value")
-          value1          <- get(key).returning[String]
-          keySlot          = Slot(CRC16.get(Chunk.fromArray(key.getBytes)).toLong % SlotsAmount)
-          (sourcePart, id) = initSlots.zipWithIndex.find { case (p, _) => p.slotRange.contains(keySlot) }.get
-          sourceMaster     = sourcePart.master
-          destPart         = initSlots((id + 1) % initSlots.size)
-          destMaster       = destPart.master
-          destMasterConn   = getRedisNodeLayer(destMaster.address)
-          _               <- ZIO.logDebug(s"$key _____ Importing $keySlot to ${destMaster.id}")
-          _               <- setSlotImporting(keySlot, sourceMaster.id).provideLayer(destMasterConn)
-          _               <- ZIO.logDebug(s"$key _____ Migrating $keySlot from ${sourceMaster.id}")
-          sourceMasterConn = getRedisNodeLayer(sourceMaster.address)
-          _               <- setSlotMigrating(keySlot, destMaster.id).provideLayer(sourceMasterConn)
-          _ <- migrate(destMaster.address.host, destMaster.address.port.toLong, key, 0, 5.seconds, keys = None)
-                 .provideLayer(sourceMasterConn)
-          _      <- setSlotNode(keySlot, destMaster.id).provideLayer(destMasterConn)
-          _      <- setSlotNode(keySlot, destMaster.id).provideLayer(sourceMasterConn)
-          value2 <- get(key).returning[String] // have to refresh connection
-          value3 <- get(key).returning[String] // have to get value without refreshing connection
-        } yield {
-          assertTrue(value1 == value2) && assertTrue(value2 == value3)
+        ZIO.serviceWithZIO[Redis] { redis =>
+          import redis._
+
+          for {
+            initSlots       <- slots
+            key             <- uuid
+            _               <- set(key, "value")
+            value1          <- get(key).returning[String]
+            keySlot          = Slot(CRC16.get(Chunk.fromArray(key.getBytes)).toLong % SlotsAmount)
+            (sourcePart, id) = initSlots.zipWithIndex.find { case (p, _) => p.slotRange.contains(keySlot) }.get
+            sourceMaster     = sourcePart.master
+            destPart         = initSlots((id + 1) % initSlots.size)
+            destMaster       = destPart.master
+            destMasterConn   = getRedisNodeLayer(destMaster.address)
+            _               <- ZIO.logDebug(s"$key _____ Importing $keySlot to ${destMaster.id}")
+            _               <- ZIO.serviceWithZIO[Redis](_.setSlotImporting(keySlot, sourceMaster.id)).provideLayer(destMasterConn)
+            _               <- ZIO.logDebug(s"$key _____ Migrating $keySlot from ${sourceMaster.id}")
+            sourceMasterConn = getRedisNodeLayer(sourceMaster.address)
+            _               <- ZIO.serviceWithZIO[Redis](_.setSlotMigrating(keySlot, destMaster.id)).provideLayer(sourceMasterConn)
+            _ <- ZIO
+                   .serviceWithZIO[Redis](
+                     _.migrate(destMaster.address.host, destMaster.address.port.toLong, key, 0, 5.seconds, keys = None)
+                   )
+                   .provideLayer(sourceMasterConn)
+            _      <- ZIO.serviceWithZIO[Redis](_.setSlotNode(keySlot, destMaster.id)).provideLayer(destMasterConn)
+            _      <- ZIO.serviceWithZIO[Redis](_.setSlotNode(keySlot, destMaster.id)).provideLayer(sourceMasterConn)
+            value2 <- get(key).returning[String] // have to refresh connection
+            value3 <- get(key).returning[String] // have to get value without refreshing connection
+          } yield {
+            assertTrue(value1 == value2) && assertTrue(value2 == value3)
+          }
         }
       }
     ).provideLayerShared(ClusterLayer)

--- a/redis/src/test/scala/zio/redis/ClusterSpec.scala
+++ b/redis/src/test/scala/zio/redis/ClusterSpec.scala
@@ -1,5 +1,6 @@
 package zio.redis
 
+import zio.ZIO
 import zio.test.Assertion._
 import zio.test._
 
@@ -9,7 +10,7 @@ trait ClusterSpec extends BaseSpec {
       suite("slots")(
         test("get cluster slots") {
           for {
-            res <- slots
+            res <- ZIO.serviceWithZIO[Redis](_.slots)
           } yield {
             val addresses    = (5000 to 5005).map(port => RedisUri("127.0.0.1", port))
             val resAddresses = res.map(_.master.address) ++ res.flatMap(_.slaves.map(_.address))

--- a/redis/src/test/scala/zio/redis/ConnectionSpec.scala
+++ b/redis/src/test/scala/zio/redis/ConnectionSpec.scala
@@ -12,26 +12,22 @@ trait ConnectionSpec extends BaseSpec {
     suite("connection")(
       suite("clientCaching")(
         test("track keys") {
-          ZIO.serviceWithZIO[Redis] { redis =>
-            import redis._
-            for {
-              _            <- clientTrackingOff
-              _            <- clientTrackingOn(trackingMode = Some(ClientTrackingMode.OptIn))
-              _            <- clientCaching(true)
-              trackingInfo <- clientTrackingInfo
-            } yield assert(trackingInfo.flags.caching)(isSome(isTrue))
-          }
+          for {
+            redis        <- ZIO.service[Redis]
+            _            <- redis.clientTrackingOff
+            _            <- redis.clientTrackingOn(trackingMode = Some(ClientTrackingMode.OptIn))
+            _            <- redis.clientCaching(true)
+            trackingInfo <- redis.clientTrackingInfo
+          } yield assert(trackingInfo.flags.caching)(isSome(isTrue))
         },
         test("don't track keys") {
-          ZIO.serviceWithZIO[Redis] { redis =>
-            import redis._
-            for {
-              _            <- clientTrackingOff
-              _            <- clientTrackingOn(trackingMode = Some(ClientTrackingMode.OptOut))
-              _            <- clientCaching(false)
-              trackingInfo <- clientTrackingInfo
-            } yield assert(trackingInfo.flags.caching)(isSome(isFalse))
-          }
+          for {
+            redis        <- ZIO.service[Redis]
+            _            <- redis.clientTrackingOff
+            _            <- redis.clientTrackingOn(trackingMode = Some(ClientTrackingMode.OptOut))
+            _            <- redis.clientCaching(false)
+            trackingInfo <- redis.clientTrackingInfo
+          } yield assert(trackingInfo.flags.caching)(isSome(isFalse))
         }
       ),
       suite("clientId")(

--- a/redis/src/test/scala/zio/redis/ConnectionSpec.scala
+++ b/redis/src/test/scala/zio/redis/ConnectionSpec.scala
@@ -12,85 +12,97 @@ trait ConnectionSpec extends BaseSpec {
     suite("connection")(
       suite("clientCaching")(
         test("track keys") {
-          for {
-            _            <- clientTrackingOff
-            _            <- clientTrackingOn(trackingMode = Some(ClientTrackingMode.OptIn))
-            _            <- clientCaching(true)
-            trackingInfo <- clientTrackingInfo
-          } yield assert(trackingInfo.flags.caching)(isSome(isTrue))
+          ZIO.serviceWithZIO[Redis] { redis =>
+            import redis._
+            for {
+              _            <- clientTrackingOff
+              _            <- clientTrackingOn(trackingMode = Some(ClientTrackingMode.OptIn))
+              _            <- clientCaching(true)
+              trackingInfo <- clientTrackingInfo
+            } yield assert(trackingInfo.flags.caching)(isSome(isTrue))
+          }
         },
         test("don't track keys") {
-          for {
-            _            <- clientTrackingOff
-            _            <- clientTrackingOn(trackingMode = Some(ClientTrackingMode.OptOut))
-            _            <- clientCaching(false)
-            trackingInfo <- clientTrackingInfo
-          } yield assert(trackingInfo.flags.caching)(isSome(isFalse))
+          ZIO.serviceWithZIO[Redis] { redis =>
+            import redis._
+            for {
+              _            <- clientTrackingOff
+              _            <- clientTrackingOn(trackingMode = Some(ClientTrackingMode.OptOut))
+              _            <- clientCaching(false)
+              trackingInfo <- clientTrackingInfo
+            } yield assert(trackingInfo.flags.caching)(isSome(isFalse))
+          }
         }
       ),
       suite("clientId")(
         test("get client id") {
           for {
-            id <- clientId
+            id <- ZIO.serviceWithZIO[Redis](_.clientId)
           } yield assert(id)(isGreaterThan(0L))
         }
       ),
       suite("clientKill")(
         test("error when a connection with the specifed address doesn't exist") {
           for {
-            error <- clientKill(Address(InetAddress.getByName("0.0.0.0"), 0)).either
+            error <- ZIO.serviceWithZIO[Redis](_.clientKill(Address(InetAddress.getByName("0.0.0.0"), 0)).either)
           } yield assert(error)(isLeft)
         },
         test("specify filters that don't kill the connection") {
           for {
-            clientsKilled <- clientKill(ClientKillFilter.SkipMe(false), ClientKillFilter.Id(3341L))
+            clientsKilled <-
+              ZIO.serviceWithZIO[Redis](_.clientKill(ClientKillFilter.SkipMe(false), ClientKillFilter.Id(3341L)))
           } yield assert(clientsKilled)(equalTo(0L))
         },
         test("specify filters that kill the connection but skipme is enabled") {
           for {
-            id            <- clientId
-            clientsKilled <- clientKill(ClientKillFilter.SkipMe(true), ClientKillFilter.Id(id))
+            redis         <- ZIO.service[Redis]
+            id            <- redis.clientId
+            clientsKilled <- redis.clientKill(ClientKillFilter.SkipMe(true), ClientKillFilter.Id(id))
           } yield assert(clientsKilled)(equalTo(0L))
         }
       ),
       suite("clientGetRedir")(
         test("tracking disabled") {
           for {
-            _     <- clientTrackingOff
-            redir <- clientGetRedir
+            redis <- ZIO.service[Redis]
+            _     <- redis.clientTrackingOff
+            redir <- redis.clientGetRedir
           } yield assert(redir)(equalTo(ClientTrackingRedirect.NotEnabled))
         },
         test("tracking enabled but not redirecting") {
           for {
-            _     <- clientTrackingOn()
-            redir <- clientGetRedir
+            redis <- ZIO.service[Redis]
+            _     <- redis.clientTrackingOn()
+            redir <- redis.clientGetRedir
           } yield assert(redir)(equalTo(ClientTrackingRedirect.NotRedirected))
         }
       ),
       suite("client pause and unpause")(
         test("clientPause") {
           for {
-            unit <- clientPause(1.second, Some(ClientPauseMode.All))
+            unit <- ZIO.serviceWithZIO[Redis](_.clientPause(1.second, Some(ClientPauseMode.All)))
           } yield assert(unit)(isUnit)
         },
         test("clientUnpause") {
           for {
-            unit <- clientUnpause
+            unit <- ZIO.serviceWithZIO[Redis](_.clientUnpause)
           } yield assert(unit)(isUnit)
         }
       ),
       test("set and get name") {
         for {
-          _    <- clientSetName("foo")
-          name <- clientGetName
+          redis <- ZIO.service[Redis]
+          _     <- redis.clientSetName("foo")
+          name  <- redis.clientGetName
         } yield assert(name.getOrElse(""))(equalTo("foo"))
       } @@ clusterExecutorUnsupported,
       suite("clientTracking")(
         test("enable tracking in broadcast mode and with prefixes") {
           for {
-            _            <- clientTrackingOff
-            _            <- clientTrackingOn(None, Some(ClientTrackingMode.Broadcast), prefixes = Set("foo"))
-            trackingInfo <- clientTrackingInfo
+            redis        <- ZIO.service[Redis]
+            _            <- redis.clientTrackingOff
+            _            <- redis.clientTrackingOn(None, Some(ClientTrackingMode.Broadcast), prefixes = Set("foo"))
+            trackingInfo <- redis.clientTrackingInfo
           } yield assert(trackingInfo.redirect)(equalTo(ClientTrackingRedirect.NotRedirected)) &&
             assert(trackingInfo.flags)(
               equalTo(ClientTrackingFlags(clientSideCaching = true, trackingMode = Some(ClientTrackingMode.Broadcast)))
@@ -99,8 +111,9 @@ trait ConnectionSpec extends BaseSpec {
         },
         test("disable tracking") {
           for {
-            _            <- clientTrackingOff
-            trackingInfo <- clientTrackingInfo
+            redis        <- ZIO.service[Redis]
+            _            <- redis.clientTrackingOff
+            trackingInfo <- redis.clientTrackingInfo
           } yield assert(trackingInfo.redirect)(equalTo(ClientTrackingRedirect.NotEnabled)) &&
             assert(trackingInfo.flags)(
               equalTo(ClientTrackingFlags(clientSideCaching = false))
@@ -111,8 +124,9 @@ trait ConnectionSpec extends BaseSpec {
       suite("clientTrackingInfo")(
         test("get tracking info when tracking is disabled") {
           for {
-            _            <- clientTrackingOff
-            trackingInfo <- clientTrackingInfo
+            redis        <- ZIO.service[Redis]
+            _            <- redis.clientTrackingOff
+            trackingInfo <- redis.clientTrackingInfo
           } yield assert(trackingInfo)(
             equalTo(
               ClientTrackingInfo(
@@ -124,10 +138,11 @@ trait ConnectionSpec extends BaseSpec {
         },
         test("get tracking info when tracking is enabled in optin mode with noloop and caching on") {
           for {
-            _            <- clientTrackingOff
-            _            <- clientTrackingOn(trackingMode = Some(ClientTrackingMode.OptIn), noLoop = true)
-            _            <- clientCaching(true)
-            trackingInfo <- clientTrackingInfo
+            redis        <- ZIO.service[Redis]
+            _            <- redis.clientTrackingOff
+            _            <- redis.clientTrackingOn(trackingMode = Some(ClientTrackingMode.OptIn), noLoop = true)
+            _            <- redis.clientCaching(true)
+            trackingInfo <- redis.clientTrackingInfo
           } yield assert(trackingInfo)(
             equalTo(
               ClientTrackingInfo(
@@ -146,29 +161,34 @@ trait ConnectionSpec extends BaseSpec {
       suite("clientUnblock")(
         test("unblock client that isn't blocked") {
           for {
-            id   <- clientId
-            bool <- clientUnblock(id)
+            redis <- ZIO.service[Redis]
+            id    <- redis.clientId
+            bool  <- redis.clientUnblock(id)
           } yield assert(bool)(equalTo(false))
         }
       ),
       suite("ping")(
         test("PING with no input") {
-          ping(None).map(assert(_)(equalTo("PONG")))
+          ZIO.serviceWithZIO[Redis](_.ping(None).map(assert(_)(equalTo("PONG"))))
         } @@ clusterExecutorUnsupported,
         test("PING with input") {
-          ping(Some("Hello")).map(assert(_)(equalTo("Hello")))
+          ZIO.serviceWithZIO[Redis](_.ping(Some("Hello")).map(assert(_)(equalTo("Hello"))))
         },
         test("PING with a string argument will not lock executor") {
-          ping(Some("Hello with a newline\n")).map(assert(_)(equalTo("Hello with a newline\n")))
+          ZIO.serviceWithZIO[Redis](
+            _.ping(Some("Hello with a newline\n")).map(assert(_)(equalTo("Hello with a newline\n")))
+          )
         },
         test("PING with a multiline string argument will not lock executor") {
-          ping(Some("Hello with a newline\r\nAnd another line\n"))
-            .map(assert(_)(equalTo("Hello with a newline\r\nAnd another line\n")))
+          ZIO.serviceWithZIO[Redis](
+            _.ping(Some("Hello with a newline\r\nAnd another line\n"))
+              .map(assert(_)(equalTo("Hello with a newline\r\nAnd another line\n")))
+          )
         }
       ),
       test("reset") {
         for {
-          unit <- reset
+          unit <- ZIO.serviceWithZIO[Redis](_.reset)
         } yield assert(unit)(isUnit)
       } @@ clusterExecutorUnsupported
     ) @@ sequential

--- a/redis/src/test/scala/zio/redis/GeoSpec.scala
+++ b/redis/src/test/scala/zio/redis/GeoSpec.scala
@@ -1,8 +1,8 @@
 package zio.redis
 
-import zio.{Chunk, ZIO}
 import zio.test.Assertion._
 import zio.test._
+import zio.{Chunk, ZIO}
 
 trait GeoSpec extends BaseSpec {
   def geoSuite: Spec[Redis, RedisError] =

--- a/redis/src/test/scala/zio/redis/HashSpec.scala
+++ b/redis/src/test/scala/zio/redis/HashSpec.scala
@@ -1,6 +1,6 @@
 package zio.redis
 
-import zio.Chunk
+import zio.{Chunk, ZIO}
 import zio.test.Assertion._
 import zio.test._
 
@@ -10,106 +10,116 @@ trait HashSpec extends BaseSpec {
       suite("hSet, hGet, hGetAll and hDel")(
         test("set followed by get") {
           for {
+            redis         <- ZIO.service[Redis]
             hash   <- uuid
             field  <- uuid
             value  <- uuid
-            _      <- hSet(hash, field -> value)
-            result <- hGet(hash, field).returning[String]
+            _      <- redis.hSet(hash, field -> value)
+            result <- redis.hGet(hash, field).returning[String]
           } yield assert(result)(isSome(equalTo(value)))
         },
         test("set multiple fields for hash") {
           for {
+            redis         <- ZIO.service[Redis]
             hash   <- uuid
             field1 <- uuid
             field2 <- uuid
             value  <- uuid
-            result <- hSet(hash, field1 -> value, field2 -> value)
+            result <- redis.hSet(hash, field1 -> value, field2 -> value)
           } yield assert(result)(equalTo(2L))
         },
         test("get all fields for hash") {
           for {
+            redis         <- ZIO.service[Redis]
             hash   <- uuid
             field1 <- uuid
             field2 <- uuid
             value  <- uuid
-            _      <- hSet(hash, field1 -> value, field2 -> value)
-            result <- hGetAll(hash).returning[String, String]
+            _      <- redis.hSet(hash, field1 -> value, field2 -> value)
+            result <- redis.hGetAll(hash).returning[String, String]
           } yield assert(Chunk.fromIterable(result.values))(hasSameElements(Chunk(value, value)))
         },
         test("delete field for hash") {
           for {
+            redis         <- ZIO.service[Redis]
             hash    <- uuid
             field   <- uuid
             value   <- uuid
-            _       <- hSet(hash, field -> value)
-            deleted <- hDel(hash, field)
-            result  <- hGet(hash, field).returning[String]
+            _       <- redis.hSet(hash, field -> value)
+            deleted <- redis.hDel(hash, field)
+            result  <- redis.hGet(hash, field).returning[String]
           } yield assert(deleted)(equalTo(1L)) && assert(result)(isNone)
         },
         test("delete multiple fields for hash") {
           for {
+            redis         <- ZIO.service[Redis]
             hash    <- uuid
             field1  <- uuid
             field2  <- uuid
             value   <- uuid
-            _       <- hSet(hash, field1 -> value, field2 -> value)
-            deleted <- hDel(hash, field1, field2)
+            _       <- redis.hSet(hash, field1 -> value, field2 -> value)
+            deleted <- redis.hDel(hash, field1, field2)
           } yield assert(deleted)(equalTo(2L))
         }
       ),
       suite("hmSet and hmGet")(
         test("set followed by get") {
           for {
+            redis         <- ZIO.service[Redis]
             hash   <- uuid
             field  <- uuid
             value  <- uuid
-            _      <- hmSet(hash, field -> value)
-            result <- hmGet(hash, field).returning[String]
+            _      <- redis.hmSet(hash, field -> value)
+            result <- redis.hmGet(hash, field).returning[String]
           } yield assert(result)(hasSameElements(Chunk(Some(value))))
         },
         test("set multiple fields for hash") {
           for {
+            redis         <- ZIO.service[Redis]
             hash    <- uuid
             field1  <- uuid
             field2  <- uuid
             value   <- uuid
-            _       <- hmSet(hash, field1 -> value, field2 -> value)
-            result1 <- hmGet(hash, field1).returning[String]
-            result2 <- hmGet(hash, field2).returning[String]
+            _       <- redis.hmSet(hash, field1 -> value, field2 -> value)
+            result1 <- redis.hmGet(hash, field1).returning[String]
+            result2 <- redis.hmGet(hash, field2).returning[String]
           } yield assert(result1)(hasSameElements(Chunk(Some(value)))) &&
             assert(result2)(hasSameElements(Chunk(Some(value))))
         },
         test("get multiple fields for hash") {
           for {
+            redis         <- ZIO.service[Redis]
             hash   <- uuid
             field1 <- uuid
             field2 <- uuid
             value1 <- uuid
             value2 <- uuid
-            _      <- hmSet(hash, field1 -> value1, field2 -> value2)
-            result <- hmGet(hash, field1, field2).returning[String]
+            _      <- redis.hmSet(hash, field1 -> value1, field2 -> value2)
+            result <- redis.hmGet(hash, field1, field2).returning[String]
           } yield assert(result)(hasSameElements(Chunk(Some(value1), Some(value2))))
         },
         test("delete field for hash") {
           for {
+            redis         <- ZIO.service[Redis]
             hash    <- uuid
             field   <- uuid
             value   <- uuid
-            _       <- hmSet(hash, field -> value)
-            deleted <- hDel(hash, field)
-            result  <- hmGet(hash, field).returning[String]
+            _       <- redis.hmSet(hash, field -> value)
+            deleted <- redis.hDel(hash, field)
+            result  <- redis.hmGet(hash, field).returning[String]
           } yield assert(deleted)(equalTo(1L)) && assert(result)(hasSameElements(Chunk(None)))
         },
         test("delete multiple fields for hash") {
           for {
+            redis         <- ZIO.service[Redis]
             hash    <- uuid
             field1  <- uuid
             field2  <- uuid
             field3  <- uuid
             value   <- uuid
-            _       <- hmSet(hash, field1 -> value, field2 -> value, field3 -> value)
-            deleted <- hDel(hash, field1, field3)
-            result  <- hmGet(hash, field1, field2, field3).returning[String]
+            _       <- redis.hmSet(hash, field1 -> value, field2 -> value, field3 -> value)
+            deleted <- redis.hDel(hash, field1, field3)
+            result  <- redis.hmGet(hash, field1, field2, field3).returning[String]
           } yield assert(deleted)(equalTo(2L)) &&
             assert(result)(hasSameElements(Chunk(None, Some(value), None)))
         }
@@ -117,154 +127,172 @@ trait HashSpec extends BaseSpec {
       suite("hExists")(
         test("field should exist") {
           for {
+            redis         <- ZIO.service[Redis]
             hash   <- uuid
             field  <- uuid
             value  <- uuid
-            _      <- hSet(hash, field -> value)
-            result <- hExists(hash, field)
+            _      <- redis.hSet(hash, field -> value)
+            result <- redis.hExists(hash, field)
           } yield assert(result)(isTrue)
         },
         test("field shouldn't exist") {
           for {
+            redis         <- ZIO.service[Redis]
             hash   <- uuid
             field  <- uuid
-            result <- hExists(hash, field)
+            result <- redis.hExists(hash, field)
           } yield assert(result)(isFalse)
         }
       ),
       suite("hIncrBy and hIncrByFloat")(
         test("existing field should be incremented by 1") {
           for {
+            redis         <- ZIO.service[Redis]
             hash   <- uuid
             field  <- uuid
-            _      <- hSet(hash, field -> "1")
-            result <- hIncrBy(hash, field, 1L)
+            _      <- redis.hSet(hash, field -> "1")
+            result <- redis.hIncrBy(hash, field, 1L)
           } yield assert(result)(equalTo(2L))
         },
         test("incrementing value of non-existing hash and filed should create them") {
           for {
+            redis         <- ZIO.service[Redis]
             hash   <- uuid
             field  <- uuid
-            result <- hIncrBy(hash, field, 1L)
+            result <- redis.hIncrBy(hash, field, 1L)
           } yield assert(result)(equalTo(1L))
         },
         test("existing field should be incremented by 1.5") {
           for {
+            redis         <- ZIO.service[Redis]
             hash   <- uuid
             field  <- uuid
-            _      <- hSet(hash, field -> "1")
-            result <- hIncrByFloat(hash, field, 1.5)
+            _      <- redis.hSet(hash, field -> "1")
+            result <- redis.hIncrByFloat(hash, field, 1.5)
           } yield assert(result)(equalTo(2.5))
         },
         test("incrementing value of float for non-existing hash and field should create them") {
           for {
+            redis         <- ZIO.service[Redis]
             hash   <- uuid
             field  <- uuid
-            result <- hIncrByFloat(hash, field, 1.5)
+            result <- redis.hIncrByFloat(hash, field, 1.5)
           } yield assert(result)(equalTo(1.5))
         },
         test("incrementing value of float for non-existing hash and field with negative value") {
           for {
+            redis         <- ZIO.service[Redis]
             hash   <- uuid
             field  <- uuid
-            result <- hIncrByFloat(hash, field, -1.5)
+            result <- redis.hIncrByFloat(hash, field, -1.5)
           } yield assert(result)(equalTo(-1.5))
         }
       ),
       suite("hKeys and hLen")(
         test("get field names for existing hash") {
           for {
+            redis         <- ZIO.service[Redis]
             hash   <- uuid
             field  <- uuid
             value  <- uuid
-            _      <- hSet(hash, field -> value)
-            result <- hKeys(hash).returning[String]
+            _      <- redis.hSet(hash, field -> value)
+            result <- redis.hKeys(hash).returning[String]
           } yield assert(result)(hasSameElements(Chunk(field)))
         },
         test("get field names for non-existing hash") {
           for {
+            redis         <- ZIO.service[Redis]
             hash   <- uuid
-            result <- hKeys(hash).returning[String]
+            result <- redis.hKeys(hash).returning[String]
           } yield assert(result)(isEmpty)
         },
         test("get field count for existing hash") {
           for {
+            redis         <- ZIO.service[Redis]
             hash   <- uuid
             field  <- uuid
             value  <- uuid
-            _      <- hSet(hash, field -> value)
-            result <- hLen(hash)
+            _      <- redis.hSet(hash, field -> value)
+            result <- redis.hLen(hash)
           } yield assert(result)(equalTo(1L))
         },
         test("get field count for non-existing hash") {
           for {
+            redis         <- ZIO.service[Redis]
             hash   <- uuid
-            result <- hLen(hash)
+            result <- redis.hLen(hash)
           } yield assert(result)(equalTo(0L))
         }
       ),
       suite("hSetNx")(
         test("set value for non-existing field") {
           for {
+            redis         <- ZIO.service[Redis]
             hash   <- uuid
             field  <- uuid
             value  <- uuid
-            result <- hSetNx(hash, field, value)
+            result <- redis.hSetNx(hash, field, value)
           } yield assert(result)(isTrue)
         },
         test("set value for existing field") {
           for {
+            redis         <- ZIO.service[Redis]
             hash   <- uuid
             field  <- uuid
             value  <- uuid
-            _      <- hSet(hash, field -> value)
-            result <- hSetNx(hash, field, value)
+            _      <- redis.hSet(hash, field -> value)
+            result <- redis.hSetNx(hash, field, value)
           } yield assert(result)(isFalse)
         }
       ),
       suite("hStrLen")(
         test("get value length for existing field") {
           for {
+            redis         <- ZIO.service[Redis]
             hash   <- uuid
             field  <- uuid
             value  <- uuid
-            _      <- hSet(hash, field -> value)
-            result <- hStrLen(hash, field)
+            _      <- redis.hSet(hash, field -> value)
+            result <- redis.hStrLen(hash, field)
           } yield assert(result)(equalTo(value.length.toLong))
         },
         test("get value length for non-existing field") {
           for {
+            redis         <- ZIO.service[Redis]
             hash   <- uuid
             field  <- uuid
-            result <- hStrLen(hash, field)
+            result <- redis.hStrLen(hash, field)
           } yield assert(result)(equalTo(0L))
         }
       ),
       suite("hVals")(
         test("get all values from existing hash") {
           for {
+            redis         <- ZIO.service[Redis]
             hash   <- uuid
             field  <- uuid
             value  <- uuid
-            _      <- hSet(hash, field -> value)
-            result <- hVals(hash).returning[String]
+            _      <- redis.hSet(hash, field -> value)
+            result <- redis.hVals(hash).returning[String]
           } yield assert(result)(hasSameElements(Chunk(value)))
         },
         test("get all values from non-existing hash") {
           for {
+            redis         <- ZIO.service[Redis]
             hash   <- uuid
-            result <- hVals(hash).returning[String]
+            result <- redis.hVals(hash).returning[String]
           } yield assert(result)(isEmpty)
         }
       ),
       suite("hScan")(
         test("hScan entries with match and count options")(check(genPatternOption, genCountOption) { (pattern, count) =>
           for {
+            redis         <- ZIO.service[Redis]
             hash            <- uuid
             field           <- uuid
             value           <- uuid
-            _               <- hSet(hash, field -> value)
-            scan            <- hScan(hash, 0L, pattern, count).returning[String, String]
+            _               <- redis.hSet(hash, field -> value)
+            scan            <- redis.hScan(hash, 0L, pattern, count).returning[String, String]
             (next, elements) = scan
           } yield assert(next)(isGreaterThanEqualTo(0L)) && assert(elements)(isNonEmpty)
         })
@@ -272,65 +300,71 @@ trait HashSpec extends BaseSpec {
       suite("hRandField")(
         test("randomly select one field") {
           for {
+            redis         <- ZIO.service[Redis]
             hash   <- uuid
             field1 <- uuid
             value1 <- uuid
             field2 <- uuid
             value2 <- uuid
-            _      <- hSet(hash, field1 -> value1, field2 -> value2)
-            field  <- hRandField(hash).returning[String]
+            _      <- redis.hSet(hash, field1 -> value1, field2 -> value2)
+            field  <- redis.hRandField(hash).returning[String]
           } yield assert(Seq(field1, field2))(contains(field.get))
         },
         test("returns None if key does not exists") {
           for {
+            redis         <- ZIO.service[Redis]
             hash    <- uuid
             field   <- uuid
             value   <- uuid
             badHash <- uuid
-            _       <- hSet(hash, field -> value)
-            field   <- hRandField(badHash).returning[String]
+            _       <- redis.hSet(hash, field -> value)
+            field   <- redis.hRandField(badHash).returning[String]
           } yield assert(field)(isNone)
         },
         test("returns n different fields if count is provided") {
           for {
+            redis         <- ZIO.service[Redis]
             hash   <- uuid
             field1 <- uuid
             value1 <- uuid
             field2 <- uuid
             value2 <- uuid
-            _      <- hSet(hash, field1 -> value1, field2 -> value2)
-            fields <- hRandField(hash, 2).returning[String]
+            _      <- redis.hSet(hash, field1 -> value1, field2 -> value2)
+            fields <- redis.hRandField(hash, 2).returning[String]
           } yield assert(fields)(hasSize(equalTo(2)))
         },
         test("returns all hash fields if count is provided and is greater or equal than hash size") {
           for {
+            redis         <- ZIO.service[Redis]
             hash   <- uuid
             field1 <- uuid
             value1 <- uuid
             field2 <- uuid
             value2 <- uuid
-            _      <- hSet(hash, field1 -> value1, field2 -> value2)
-            fields <- hRandField(hash, 4).returning[String]
+            _      <- redis.hSet(hash, field1 -> value1, field2 -> value2)
+            fields <- redis.hRandField(hash, 4).returning[String]
           } yield assert(fields)(hasSize(equalTo(2)))
         },
         test("returns repeated fields if count is negative") {
           for {
+            redis         <- ZIO.service[Redis]
             hash   <- uuid
             field  <- uuid
             value  <- uuid
-            _      <- hSet(hash, field -> value)
-            fields <- hRandField(hash, -2).returning[String]
+            _      <- redis.hSet(hash, field -> value)
+            fields <- redis.hRandField(hash, -2).returning[String]
           } yield assert(fields)(hasSameElements(Chunk(field, field)))
         },
         test("returns n different fields and values with 'withvalues' option") {
           for {
+            redis         <- ZIO.service[Redis]
             hash   <- uuid
             field1 <- uuid
             value1 <- uuid
             field2 <- uuid
             value2 <- uuid
-            _      <- hSet(hash, field1 -> value1, field2 -> value2)
-            fields <- hRandField(hash, 4, withValues = true).returning[String]
+            _      <- redis.hSet(hash, field1 -> value1, field2 -> value2)
+            fields <- redis.hRandField(hash, 4, withValues = true).returning[String]
           } yield assert(fields)(hasSize(equalTo(4)))
         }
       )

--- a/redis/src/test/scala/zio/redis/HashSpec.scala
+++ b/redis/src/test/scala/zio/redis/HashSpec.scala
@@ -1,8 +1,8 @@
 package zio.redis
 
-import zio.{Chunk, ZIO}
 import zio.test.Assertion._
 import zio.test._
+import zio.{Chunk, ZIO}
 
 trait HashSpec extends BaseSpec {
   def hashSuite: Spec[Redis, RedisError] =
@@ -10,7 +10,7 @@ trait HashSpec extends BaseSpec {
       suite("hSet, hGet, hGetAll and hDel")(
         test("set followed by get") {
           for {
-            redis         <- ZIO.service[Redis]
+            redis  <- ZIO.service[Redis]
             hash   <- uuid
             field  <- uuid
             value  <- uuid
@@ -20,7 +20,7 @@ trait HashSpec extends BaseSpec {
         },
         test("set multiple fields for hash") {
           for {
-            redis         <- ZIO.service[Redis]
+            redis  <- ZIO.service[Redis]
             hash   <- uuid
             field1 <- uuid
             field2 <- uuid
@@ -30,7 +30,7 @@ trait HashSpec extends BaseSpec {
         },
         test("get all fields for hash") {
           for {
-            redis         <- ZIO.service[Redis]
+            redis  <- ZIO.service[Redis]
             hash   <- uuid
             field1 <- uuid
             field2 <- uuid
@@ -41,7 +41,7 @@ trait HashSpec extends BaseSpec {
         },
         test("delete field for hash") {
           for {
-            redis         <- ZIO.service[Redis]
+            redis   <- ZIO.service[Redis]
             hash    <- uuid
             field   <- uuid
             value   <- uuid
@@ -52,7 +52,7 @@ trait HashSpec extends BaseSpec {
         },
         test("delete multiple fields for hash") {
           for {
-            redis         <- ZIO.service[Redis]
+            redis   <- ZIO.service[Redis]
             hash    <- uuid
             field1  <- uuid
             field2  <- uuid
@@ -65,7 +65,7 @@ trait HashSpec extends BaseSpec {
       suite("hmSet and hmGet")(
         test("set followed by get") {
           for {
-            redis         <- ZIO.service[Redis]
+            redis  <- ZIO.service[Redis]
             hash   <- uuid
             field  <- uuid
             value  <- uuid
@@ -75,7 +75,7 @@ trait HashSpec extends BaseSpec {
         },
         test("set multiple fields for hash") {
           for {
-            redis         <- ZIO.service[Redis]
+            redis   <- ZIO.service[Redis]
             hash    <- uuid
             field1  <- uuid
             field2  <- uuid
@@ -88,7 +88,7 @@ trait HashSpec extends BaseSpec {
         },
         test("get multiple fields for hash") {
           for {
-            redis         <- ZIO.service[Redis]
+            redis  <- ZIO.service[Redis]
             hash   <- uuid
             field1 <- uuid
             field2 <- uuid
@@ -100,7 +100,7 @@ trait HashSpec extends BaseSpec {
         },
         test("delete field for hash") {
           for {
-            redis         <- ZIO.service[Redis]
+            redis   <- ZIO.service[Redis]
             hash    <- uuid
             field   <- uuid
             value   <- uuid
@@ -111,7 +111,7 @@ trait HashSpec extends BaseSpec {
         },
         test("delete multiple fields for hash") {
           for {
-            redis         <- ZIO.service[Redis]
+            redis   <- ZIO.service[Redis]
             hash    <- uuid
             field1  <- uuid
             field2  <- uuid
@@ -127,7 +127,7 @@ trait HashSpec extends BaseSpec {
       suite("hExists")(
         test("field should exist") {
           for {
-            redis         <- ZIO.service[Redis]
+            redis  <- ZIO.service[Redis]
             hash   <- uuid
             field  <- uuid
             value  <- uuid
@@ -137,7 +137,7 @@ trait HashSpec extends BaseSpec {
         },
         test("field shouldn't exist") {
           for {
-            redis         <- ZIO.service[Redis]
+            redis  <- ZIO.service[Redis]
             hash   <- uuid
             field  <- uuid
             result <- redis.hExists(hash, field)
@@ -147,7 +147,7 @@ trait HashSpec extends BaseSpec {
       suite("hIncrBy and hIncrByFloat")(
         test("existing field should be incremented by 1") {
           for {
-            redis         <- ZIO.service[Redis]
+            redis  <- ZIO.service[Redis]
             hash   <- uuid
             field  <- uuid
             _      <- redis.hSet(hash, field -> "1")
@@ -156,7 +156,7 @@ trait HashSpec extends BaseSpec {
         },
         test("incrementing value of non-existing hash and filed should create them") {
           for {
-            redis         <- ZIO.service[Redis]
+            redis  <- ZIO.service[Redis]
             hash   <- uuid
             field  <- uuid
             result <- redis.hIncrBy(hash, field, 1L)
@@ -164,7 +164,7 @@ trait HashSpec extends BaseSpec {
         },
         test("existing field should be incremented by 1.5") {
           for {
-            redis         <- ZIO.service[Redis]
+            redis  <- ZIO.service[Redis]
             hash   <- uuid
             field  <- uuid
             _      <- redis.hSet(hash, field -> "1")
@@ -173,7 +173,7 @@ trait HashSpec extends BaseSpec {
         },
         test("incrementing value of float for non-existing hash and field should create them") {
           for {
-            redis         <- ZIO.service[Redis]
+            redis  <- ZIO.service[Redis]
             hash   <- uuid
             field  <- uuid
             result <- redis.hIncrByFloat(hash, field, 1.5)
@@ -181,7 +181,7 @@ trait HashSpec extends BaseSpec {
         },
         test("incrementing value of float for non-existing hash and field with negative value") {
           for {
-            redis         <- ZIO.service[Redis]
+            redis  <- ZIO.service[Redis]
             hash   <- uuid
             field  <- uuid
             result <- redis.hIncrByFloat(hash, field, -1.5)
@@ -191,7 +191,7 @@ trait HashSpec extends BaseSpec {
       suite("hKeys and hLen")(
         test("get field names for existing hash") {
           for {
-            redis         <- ZIO.service[Redis]
+            redis  <- ZIO.service[Redis]
             hash   <- uuid
             field  <- uuid
             value  <- uuid
@@ -201,14 +201,14 @@ trait HashSpec extends BaseSpec {
         },
         test("get field names for non-existing hash") {
           for {
-            redis         <- ZIO.service[Redis]
+            redis  <- ZIO.service[Redis]
             hash   <- uuid
             result <- redis.hKeys(hash).returning[String]
           } yield assert(result)(isEmpty)
         },
         test("get field count for existing hash") {
           for {
-            redis         <- ZIO.service[Redis]
+            redis  <- ZIO.service[Redis]
             hash   <- uuid
             field  <- uuid
             value  <- uuid
@@ -218,7 +218,7 @@ trait HashSpec extends BaseSpec {
         },
         test("get field count for non-existing hash") {
           for {
-            redis         <- ZIO.service[Redis]
+            redis  <- ZIO.service[Redis]
             hash   <- uuid
             result <- redis.hLen(hash)
           } yield assert(result)(equalTo(0L))
@@ -227,7 +227,7 @@ trait HashSpec extends BaseSpec {
       suite("hSetNx")(
         test("set value for non-existing field") {
           for {
-            redis         <- ZIO.service[Redis]
+            redis  <- ZIO.service[Redis]
             hash   <- uuid
             field  <- uuid
             value  <- uuid
@@ -236,7 +236,7 @@ trait HashSpec extends BaseSpec {
         },
         test("set value for existing field") {
           for {
-            redis         <- ZIO.service[Redis]
+            redis  <- ZIO.service[Redis]
             hash   <- uuid
             field  <- uuid
             value  <- uuid
@@ -248,7 +248,7 @@ trait HashSpec extends BaseSpec {
       suite("hStrLen")(
         test("get value length for existing field") {
           for {
-            redis         <- ZIO.service[Redis]
+            redis  <- ZIO.service[Redis]
             hash   <- uuid
             field  <- uuid
             value  <- uuid
@@ -258,7 +258,7 @@ trait HashSpec extends BaseSpec {
         },
         test("get value length for non-existing field") {
           for {
-            redis         <- ZIO.service[Redis]
+            redis  <- ZIO.service[Redis]
             hash   <- uuid
             field  <- uuid
             result <- redis.hStrLen(hash, field)
@@ -268,7 +268,7 @@ trait HashSpec extends BaseSpec {
       suite("hVals")(
         test("get all values from existing hash") {
           for {
-            redis         <- ZIO.service[Redis]
+            redis  <- ZIO.service[Redis]
             hash   <- uuid
             field  <- uuid
             value  <- uuid
@@ -278,7 +278,7 @@ trait HashSpec extends BaseSpec {
         },
         test("get all values from non-existing hash") {
           for {
-            redis         <- ZIO.service[Redis]
+            redis  <- ZIO.service[Redis]
             hash   <- uuid
             result <- redis.hVals(hash).returning[String]
           } yield assert(result)(isEmpty)
@@ -287,7 +287,7 @@ trait HashSpec extends BaseSpec {
       suite("hScan")(
         test("hScan entries with match and count options")(check(genPatternOption, genCountOption) { (pattern, count) =>
           for {
-            redis         <- ZIO.service[Redis]
+            redis           <- ZIO.service[Redis]
             hash            <- uuid
             field           <- uuid
             value           <- uuid
@@ -300,7 +300,7 @@ trait HashSpec extends BaseSpec {
       suite("hRandField")(
         test("randomly select one field") {
           for {
-            redis         <- ZIO.service[Redis]
+            redis  <- ZIO.service[Redis]
             hash   <- uuid
             field1 <- uuid
             value1 <- uuid
@@ -312,7 +312,7 @@ trait HashSpec extends BaseSpec {
         },
         test("returns None if key does not exists") {
           for {
-            redis         <- ZIO.service[Redis]
+            redis   <- ZIO.service[Redis]
             hash    <- uuid
             field   <- uuid
             value   <- uuid
@@ -323,7 +323,7 @@ trait HashSpec extends BaseSpec {
         },
         test("returns n different fields if count is provided") {
           for {
-            redis         <- ZIO.service[Redis]
+            redis  <- ZIO.service[Redis]
             hash   <- uuid
             field1 <- uuid
             value1 <- uuid
@@ -335,7 +335,7 @@ trait HashSpec extends BaseSpec {
         },
         test("returns all hash fields if count is provided and is greater or equal than hash size") {
           for {
-            redis         <- ZIO.service[Redis]
+            redis  <- ZIO.service[Redis]
             hash   <- uuid
             field1 <- uuid
             value1 <- uuid
@@ -347,7 +347,7 @@ trait HashSpec extends BaseSpec {
         },
         test("returns repeated fields if count is negative") {
           for {
-            redis         <- ZIO.service[Redis]
+            redis  <- ZIO.service[Redis]
             hash   <- uuid
             field  <- uuid
             value  <- uuid
@@ -357,7 +357,7 @@ trait HashSpec extends BaseSpec {
         },
         test("returns n different fields and values with 'withvalues' option") {
           for {
-            redis         <- ZIO.service[Redis]
+            redis  <- ZIO.service[Redis]
             hash   <- uuid
             field1 <- uuid
             value1 <- uuid

--- a/redis/src/test/scala/zio/redis/HyperLogLogSpec.scala
+++ b/redis/src/test/scala/zio/redis/HyperLogLogSpec.scala
@@ -10,22 +10,22 @@ trait HyperLogLogSpec extends BaseSpec {
       suite("add elements")(
         test("pfAdd elements to key") {
           for {
-            redis         <- ZIO.service[Redis]
-            key <- uuid
-            add <- redis.pfAdd(key, "one", "two", "three")
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            add   <- redis.pfAdd(key, "one", "two", "three")
           } yield assert(add)(equalTo(true))
         },
         test("pfAdd nothing to key when new elements not unique") {
           for {
-            redis         <- ZIO.service[Redis]
-            key  <- uuid
-            add1 <- redis.pfAdd(key, "one", "two", "three")
-            add2 <- redis.pfAdd(key, "one", "two", "three")
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            add1  <- redis.pfAdd(key, "one", "two", "three")
+            add2  <- redis.pfAdd(key, "one", "two", "three")
           } yield assert(add1)(equalTo(true)) && assert(add2)(equalTo(false))
         },
         test("pfAdd error when not hyperloglog") {
           for {
-            redis         <- ZIO.service[Redis]
+            redis <- ZIO.service[Redis]
             key   <- uuid
             value <- uuid
             _     <- redis.set(key, value, None, None, None)
@@ -36,13 +36,13 @@ trait HyperLogLogSpec extends BaseSpec {
       suite("count elements")(
         test("pfCount zero at undefined key") {
           for {
-            redis         <- ZIO.service[Redis]
+            redis <- ZIO.service[Redis]
             count <- redis.pfCount("noKey")
           } yield assert(count)(equalTo(0L))
         },
         test("pfCount values at key") {
           for {
-            redis         <- ZIO.service[Redis]
+            redis <- ZIO.service[Redis]
             key   <- uuid
             add   <- redis.pfAdd(key, "one", "two", "three")
             count <- redis.pfCount(key)
@@ -50,7 +50,7 @@ trait HyperLogLogSpec extends BaseSpec {
         },
         test("pfCount union key with key2") {
           for {
-            redis         <- ZIO.service[Redis]
+            redis <- ZIO.service[Redis]
             key   <- uuid
             key2  <- uuid
             add   <- redis.pfAdd(key, "one", "two", "three")
@@ -60,7 +60,7 @@ trait HyperLogLogSpec extends BaseSpec {
         } @@ clusterExecutorUnsupported,
         test("error when not hyperloglog") {
           for {
-            redis         <- ZIO.service[Redis]
+            redis <- ZIO.service[Redis]
             key   <- uuid
             value <- uuid
             _     <- redis.set(key, value, None, None, None)
@@ -71,7 +71,7 @@ trait HyperLogLogSpec extends BaseSpec {
       suite("merge")(
         test("pfMerge two hyperloglogs and create destination") {
           for {
-            redis         <- ZIO.service[Redis]
+            redis <- ZIO.service[Redis]
             key   <- uuid
             key2  <- uuid
             key3  <- uuid
@@ -83,7 +83,7 @@ trait HyperLogLogSpec extends BaseSpec {
         },
         test("pfMerge two hyperloglogs with already existing destination values") {
           for {
-            redis         <- ZIO.service[Redis]
+            redis <- ZIO.service[Redis]
             key   <- uuid
             key2  <- uuid
             key3  <- uuid
@@ -96,7 +96,7 @@ trait HyperLogLogSpec extends BaseSpec {
         },
         test("pfMerge error when source not hyperloglog") {
           for {
-            redis         <- ZIO.service[Redis]
+            redis <- ZIO.service[Redis]
             key   <- uuid
             value <- uuid
             key2  <- uuid

--- a/redis/src/test/scala/zio/redis/HyperLogLogSpec.scala
+++ b/redis/src/test/scala/zio/redis/HyperLogLogSpec.scala
@@ -1,5 +1,6 @@
 package zio.redis
 
+import zio.ZIO
 import zio.test.Assertion._
 import zio.test._
 
@@ -9,90 +10,100 @@ trait HyperLogLogSpec extends BaseSpec {
       suite("add elements")(
         test("pfAdd elements to key") {
           for {
+            redis         <- ZIO.service[Redis]
             key <- uuid
-            add <- pfAdd(key, "one", "two", "three")
+            add <- redis.pfAdd(key, "one", "two", "three")
           } yield assert(add)(equalTo(true))
         },
         test("pfAdd nothing to key when new elements not unique") {
           for {
+            redis         <- ZIO.service[Redis]
             key  <- uuid
-            add1 <- pfAdd(key, "one", "two", "three")
-            add2 <- pfAdd(key, "one", "two", "three")
+            add1 <- redis.pfAdd(key, "one", "two", "three")
+            add2 <- redis.pfAdd(key, "one", "two", "three")
           } yield assert(add1)(equalTo(true)) && assert(add2)(equalTo(false))
         },
         test("pfAdd error when not hyperloglog") {
           for {
+            redis         <- ZIO.service[Redis]
             key   <- uuid
             value <- uuid
-            _     <- set(key, value, None, None, None)
-            add   <- pfAdd(key, "one", "two", "three").either
+            _     <- redis.set(key, value, None, None, None)
+            add   <- redis.pfAdd(key, "one", "two", "three").either
           } yield assert(add)(isLeft(isSubtype[RedisError.WrongType](anything)))
         }
       ),
       suite("count elements")(
         test("pfCount zero at undefined key") {
           for {
-            count <- pfCount("noKey")
+            redis         <- ZIO.service[Redis]
+            count <- redis.pfCount("noKey")
           } yield assert(count)(equalTo(0L))
         },
         test("pfCount values at key") {
           for {
+            redis         <- ZIO.service[Redis]
             key   <- uuid
-            add   <- pfAdd(key, "one", "two", "three")
-            count <- pfCount(key)
+            add   <- redis.pfAdd(key, "one", "two", "three")
+            count <- redis.pfCount(key)
           } yield assert(add)(equalTo(true)) && assert(count)(equalTo(3L))
         },
         test("pfCount union key with key2") {
           for {
+            redis         <- ZIO.service[Redis]
             key   <- uuid
             key2  <- uuid
-            add   <- pfAdd(key, "one", "two", "three")
-            add2  <- pfAdd(key2, "four", "five", "six")
-            count <- pfCount(key, key2)
+            add   <- redis.pfAdd(key, "one", "two", "three")
+            add2  <- redis.pfAdd(key2, "four", "five", "six")
+            count <- redis.pfCount(key, key2)
           } yield assert(add)(equalTo(true)) && assert(add2)(equalTo(true)) && assert(count)(equalTo(6L))
         } @@ clusterExecutorUnsupported,
         test("error when not hyperloglog") {
           for {
+            redis         <- ZIO.service[Redis]
             key   <- uuid
             value <- uuid
-            _     <- set(key, value, None, None, None)
-            count <- pfCount(key).either
+            _     <- redis.set(key, value, None, None, None)
+            count <- redis.pfCount(key).either
           } yield assert(count)(isLeft)
         }
       ),
       suite("merge")(
         test("pfMerge two hyperloglogs and create destination") {
           for {
+            redis         <- ZIO.service[Redis]
             key   <- uuid
             key2  <- uuid
             key3  <- uuid
-            _     <- pfAdd(key, "one", "two", "three", "four")
-            _     <- pfAdd(key2, "five", "six", "seven")
-            _     <- pfMerge(key3, key2, key)
-            count <- pfCount(key3)
+            _     <- redis.pfAdd(key, "one", "two", "three", "four")
+            _     <- redis.pfAdd(key2, "five", "six", "seven")
+            _     <- redis.pfMerge(key3, key2, key)
+            count <- redis.pfCount(key3)
           } yield assert(count)(equalTo(7L))
         },
         test("pfMerge two hyperloglogs with already existing destination values") {
           for {
+            redis         <- ZIO.service[Redis]
             key   <- uuid
             key2  <- uuid
             key3  <- uuid
-            _     <- pfAdd(key, "one", "two", "three", "four")
-            _     <- pfAdd(key2, "five", "six", "seven")
-            _     <- pfAdd(key3, "eight", "nine", "ten")
-            _     <- pfMerge(key3, key2, key)
-            count <- pfCount(key3)
+            _     <- redis.pfAdd(key, "one", "two", "three", "four")
+            _     <- redis.pfAdd(key2, "five", "six", "seven")
+            _     <- redis.pfAdd(key3, "eight", "nine", "ten")
+            _     <- redis.pfMerge(key3, key2, key)
+            count <- redis.pfCount(key3)
           } yield assert(count)(equalTo(10L))
         },
         test("pfMerge error when source not hyperloglog") {
           for {
+            redis         <- ZIO.service[Redis]
             key   <- uuid
             value <- uuid
             key2  <- uuid
             key3  <- uuid
-            _     <- set(key, value, None, None, None)
-            _     <- pfAdd(key2, "five", "six", "seven")
-            merge <- pfMerge(key3, key2, key).either
+            _     <- redis.set(key, value, None, None, None)
+            _     <- redis.pfAdd(key2, "five", "six", "seven")
+            merge <- redis.pfMerge(key3, key2, key).either
           } yield assert(merge)(isLeft)
         }
       ) @@ clusterExecutorUnsupported

--- a/redis/src/test/scala/zio/redis/KeysSpec.scala
+++ b/redis/src/test/scala/zio/redis/KeysSpec.scala
@@ -12,109 +12,121 @@ trait KeysSpec extends BaseSpec {
     suite("keys")(
       test("set followed by get") {
         for {
+          redis <- ZIO.service[Redis]
           key   <- uuid
           value <- uuid
-          _     <- set(key, value)
-          v     <- get(key).returning[String]
+          _     <- redis.set(key, value)
+          v     <- redis.get(key).returning[String]
         } yield assert(v)(isSome(equalTo(value)))
       },
       test("get non-existing key") {
         for {
-          key <- uuid
-          v   <- get(key).returning[String]
+          redis <- ZIO.service[Redis]
+          key   <- uuid
+          v     <- redis.get(key).returning[String]
         } yield assert(v)(isNone)
       },
       test("handles wrong types") {
         for {
-          key <- uuid
-          _   <- sAdd(key, "1", "2", "3")
-          v   <- get(key).returning[String].either
+          redis <- ZIO.service[Redis]
+          key   <- uuid
+          _     <- redis.sAdd(key, "1", "2", "3")
+          v     <- redis.get(key).returning[String].either
         } yield assert(v)(isLeft)
       },
       test("check whether or not key exists") {
         for {
+          redis <- ZIO.service[Redis]
           key   <- uuid
           value <- uuid
-          _     <- set(key, value)
-          e1    <- exists(key)
-          e2    <- exists("unknown")
+          _     <- redis.set(key, value)
+          e1    <- redis.exists(key)
+          e2    <- redis.exists("unknown")
         } yield assert(e1)(equalTo(1L)) && assert(e2)(equalTo(0L))
       },
       test("delete existing key") {
         for {
+          redis   <- ZIO.service[Redis]
           key     <- uuid
           value   <- uuid
-          _       <- set(key, value)
-          deleted <- del(key)
+          _       <- redis.set(key, value)
+          deleted <- redis.del(key)
         } yield assert(deleted)(equalTo(1L))
       },
       test("find all keys matching pattern") {
         for {
+          redis    <- ZIO.service[Redis]
           value    <- uuid
           key1      = "custom_key_1"
           key2      = "custom_key_2"
-          _        <- set(key1, value)
-          _        <- set(key2, value)
-          response <- keys("*custom*").returning[String]
+          _        <- redis.set(key1, value)
+          _        <- redis.set(key2, value)
+          response <- redis.keys("*custom*").returning[String]
         } yield assert(response)(hasSameElements(Chunk(key1, key2)))
       } @@ clusterExecutorUnsupported,
       test("unlink existing key") {
         for {
+          redis   <- ZIO.service[Redis]
           key     <- uuid
           value   <- uuid
-          _       <- set(key, value)
-          removed <- unlink(key)
+          _       <- redis.set(key, value)
+          removed <- redis.unlink(key)
         } yield assert(removed)(equalTo(1L))
       },
       test("touch two existing keys") {
         for {
+          redis   <- ZIO.service[Redis]
           key1    <- uuid
           value1  <- uuid
-          _       <- set(key1, value1)
+          _       <- redis.set(key1, value1)
           key2    <- uuid
           value2  <- uuid
-          _       <- set(key2, value2)
-          touched <- touch(key1, key2)
+          _       <- redis.set(key2, value2)
+          touched <- redis.touch(key1, key2)
         } yield assert(touched)(equalTo(2L))
       } @@ clusterExecutorUnsupported,
       test("scan entries with match, count and type options")(
         check(genPatternOption, genCountOption, genStringRedisTypeOption) { (pattern, count, redisType) =>
           for {
+            redis           <- ZIO.service[Redis]
             key             <- uuid
             value           <- uuid
-            _               <- set(key, value)
-            scan            <- scan(0L, pattern, count, redisType).returning[String]
+            _               <- redis.set(key, value)
+            scan            <- redis.scan(0L, pattern, count, redisType).returning[String]
             (next, elements) = scan
           } yield assert(next)(isGreaterThanEqualTo(0L)) && assert(elements)(isNonEmpty)
         }
       ) @@ flaky,
       test("fetch random key") {
         for {
+          redis     <- ZIO.service[Redis]
           key       <- uuid
           value     <- uuid
-          _         <- set(key, value)
-          allKeys   <- keys("*").returning[String]
-          randomKey <- randomKey.returning[String]
+          _         <- redis.set(key, value)
+          allKeys   <- redis.keys("*").returning[String]
+          randomKey <- redis.randomKey.returning[String]
         } yield assert(allKeys)(contains(randomKey.get))
       } @@ ignore,
       test("dump followed by restore") {
         for {
+          redis    <- ZIO.service[Redis]
           key      <- uuid
           value    <- uuid
-          _        <- set(key, value)
-          dumped   <- dump(key)
-          _        <- del(key)
-          restore  <- restore(key, 0L, dumped).either
-          restored <- get(key).returning[String]
+          _        <- redis.set(key, value)
+          dumped   <- redis.dump(key)
+          _        <- redis.del(key)
+          restore  <- redis.restore(key, 0L, dumped).either
+          restored <- redis.get(key).returning[String]
         } yield assert(restore)(isRight) && assert(restored)(isSome(equalTo(value)))
       } @@ ignore,
       suite("migrate")(
         test("migrate key to another redis server (copy and replace)") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
             value <- uuid
-            _     <- set(key, value)
-            response <- migrate(
+            _     <- redis.set(key, value)
+            response <- redis.migrate(
                           "redis2",
                           6379,
                           key,
@@ -124,8 +136,8 @@ trait KeysSpec extends BaseSpec {
                           replace = Option(Replace),
                           keys = None
                         )
-            originGet <- get(key).returning[String]
-            destGet   <- get(key).returning[String].provideLayer(KeysSpec.SecondExecutor)
+            originGet <- redis.get(key).returning[String]
+            destGet   <- redis.get(key).returning[String].provideLayer(KeysSpec.SecondExecutor)
           } yield assert(response)(equalTo("OK")) &&
             assert(originGet)(isSome(equalTo(value))) &&
             assert(destGet)(isSome(equalTo(value)))
@@ -134,276 +146,308 @@ trait KeysSpec extends BaseSpec {
           for {
             key   <- uuid
             value <- uuid
-            _     <- set(key, value)
-            response <-
-              migrate(
-                "redis2",
-                6379,
-                key,
-                0L,
-                KeysSpec.MigrateTimeout,
-                copy = None,
-                replace = Option(Replace),
-                keys = None
-              )
-            originGet <- get(key).returning[String]
-            destGet   <- get(key).returning[String].provideLayer(KeysSpec.SecondExecutor)
+            redis <- ZIO.service[Redis]
+            _     <- redis.set(key, value)
+            response <- redis.migrate(
+                          "redis2",
+                          6379,
+                          key,
+                          0L,
+                          KeysSpec.MigrateTimeout,
+                          copy = None,
+                          replace = Option(Replace),
+                          keys = None
+                        )
+            originGet <- redis.get(key).returning[String]
+            destGet   <- ZIO.serviceWithZIO[Redis](_.get(key).returning[String]).provideLayer(KeysSpec.SecondExecutor)
           } yield assert(response)(equalTo("OK")) &&
             assert(originGet)(isNone) &&
             assert(destGet)(isSome(equalTo(value)))
         },
         test("migrate key to another redis server (move and no replace, should fail when key exists)") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
             value <- uuid
-            _     <- set(key, value)
-            _     <- set(key, value).provideLayer(KeysSpec.SecondExecutor) // also add to second Redis
+            _     <- redis.set(key, value)
+            _ <- ZIO
+                   .serviceWithZIO[Redis](_.set(key, value))
+                   .provideLayer(KeysSpec.SecondExecutor) // also add to second Redis
             response <-
-              migrate("redis2", 6379, key, 0L, KeysSpec.MigrateTimeout, copy = None, replace = None, keys = None).either
+              redis
+                .migrate("redis2", 6379, key, 0L, KeysSpec.MigrateTimeout, copy = None, replace = None, keys = None)
+                .either
           } yield assert(response)(isLeft(isSubtype[ProtocolError](anything)))
         }
       ) @@ testExecutorUnsupported @@ clusterExecutorUnsupported,
       suite("ttl")(
         test("check ttl for existing key") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
             value <- uuid
-            _     <- pSetEx(key, 1000.millis, value)
-            ttl   <- ttl(key).either
+            _     <- redis.pSetEx(key, 1000.millis, value)
+            ttl   <- redis.ttl(key).either
           } yield assert(ttl)(isRight)
         } @@ eventually,
         test("check ttl for non-existing key") {
           for {
-            key <- uuid
-            ttl <- ttl(key).either
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            ttl   <- redis.ttl(key).either
           } yield assert(ttl)(isLeft)
         },
         test("check pTtl for existing key") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
             value <- uuid
-            _     <- pSetEx(key, 1000.millis, value)
-            pTtl  <- pTtl(key).either
+            _     <- redis.pSetEx(key, 1000.millis, value)
+            pTtl  <- redis.pTtl(key).either
           } yield assert(pTtl)(isRight)
         } @@ eventually,
         test("check pTtl for non-existing key") {
           for {
-            key  <- uuid
-            pTtl <- pTtl(key).either
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            pTtl  <- redis.pTtl(key).either
           } yield assert(pTtl)(isLeft)
         }
       ),
       suite("expiration")(
         test("set key expiration with pExpire command") {
           for {
+            redis     <- ZIO.service[Redis]
             key       <- uuid
             value     <- uuid
-            _         <- set(key, value)
-            exp       <- pExpire(key, 2000.millis)
-            response1 <- exists(key)
+            _         <- redis.set(key, value)
+            exp       <- redis.pExpire(key, 2000.millis)
+            response1 <- redis.exists(key)
             fiber     <- ZIO.sleep(2050.millis).fork <* TestClock.adjust(2050.millis)
             _         <- fiber.join
-            response2 <- exists(key)
+            response2 <- redis.exists(key)
           } yield assert(exp)(isTrue) && assert(response1)(equalTo(1L)) && assert(response2)(equalTo(0L))
         },
         test("set key expiration with pExpireAt command") {
           for {
+            redis     <- ZIO.service[Redis]
             key       <- uuid
             value     <- uuid
             expiresAt <- Clock.instant.map(_.plusMillis(2000.millis.toMillis))
-            _         <- set(key, value)
-            exp       <- pExpireAt(key, expiresAt)
-            response1 <- exists(key)
+            _         <- redis.set(key, value)
+            exp       <- redis.pExpireAt(key, expiresAt)
+            response1 <- redis.exists(key)
             fiber     <- ZIO.sleep(2050.millis).fork <* TestClock.adjust(2050.millis)
             _         <- fiber.join
-            response2 <- exists(key)
+            response2 <- redis.exists(key)
           } yield assert(exp)(isTrue) && assert(response1)(equalTo(1L)) && assert(response2)(equalTo(0L))
         },
         test("expire followed by persist") {
           for {
+            redis     <- ZIO.service[Redis]
             key       <- uuid
             value     <- uuid
-            _         <- set(key, value)
-            exp       <- expire(key, 10000.millis)
-            persisted <- persist(key)
+            _         <- redis.set(key, value)
+            exp       <- redis.expire(key, 10000.millis)
+            persisted <- redis.persist(key)
           } yield assert(exp)(isTrue) && assert(persisted)(isTrue)
         },
         test("set key expiration with expireAt command") {
           for {
+            redis     <- ZIO.service[Redis]
             key       <- uuid
             value     <- uuid
             expiresAt <- Clock.instant.map(_.plusMillis(2000.millis.toMillis))
-            _         <- set(key, value)
-            exp       <- expireAt(key, expiresAt)
-            response1 <- exists(key)
+            _         <- redis.set(key, value)
+            exp       <- redis.expireAt(key, expiresAt)
+            response1 <- redis.exists(key)
             fiber     <- ZIO.sleep(2050.millis).fork <* TestClock.adjust(2050.millis)
             _         <- fiber.join
-            response2 <- exists(key)
+            response2 <- redis.exists(key)
           } yield assert(exp)(isTrue) && assert(response1)(equalTo(1L)) && assert(response2)(equalTo(0L))
         }
       ),
       suite("renaming")(
         test("rename existing key") {
           for {
+            redis   <- ZIO.service[Redis]
             key     <- uuid
             newKey  <- uuid
             value   <- uuid
-            _       <- set(key, value)
-            renamed <- rename(key, newKey).either
-            v       <- get(newKey).returning[String]
+            _       <- redis.set(key, value)
+            renamed <- redis.rename(key, newKey).either
+            v       <- redis.get(newKey).returning[String]
           } yield assert(renamed)(isRight) && assert(v)(isSome(equalTo(value)))
         },
         test("try to rename non-existing key") {
           for {
+            redis   <- ZIO.service[Redis]
             key     <- uuid
             newKey  <- uuid
-            renamed <- rename(key, newKey).either
+            renamed <- redis.rename(key, newKey).either
           } yield assert(renamed)(isLeft)
         },
         test("rename key to newkey if newkey does not yet exist") {
           for {
+            redis   <- ZIO.service[Redis]
             key     <- uuid
             newKey  <- uuid
             value   <- uuid
-            _       <- set(key, value)
-            renamed <- renameNx(key, newKey)
-            v       <- get(newKey).returning[String]
+            _       <- redis.set(key, value)
+            renamed <- redis.renameNx(key, newKey)
+            v       <- redis.get(newKey).returning[String]
           } yield assert(renamed)(isTrue) && assert(v)(isSome(equalTo(value)))
         },
         test("try to rename non-existing key with renameNx command") {
           for {
+            redis   <- ZIO.service[Redis]
             key     <- uuid
             newKey  <- uuid
-            renamed <- renameNx(key, newKey).either
+            renamed <- redis.renameNx(key, newKey).either
           } yield assert(renamed)(isLeft)
         }
       ) @@ clusterExecutorUnsupported,
       suite("types")(
         test("string type") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
             value  <- uuid
-            _      <- set(key, value)
-            string <- typeOf(key)
+            _      <- redis.set(key, value)
+            string <- redis.typeOf(key)
           } yield assert(string)(equalTo(RedisType.String))
         },
         test("list type") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
             value <- uuid
-            _     <- lPush(key, value)
-            list  <- typeOf(key)
+            _     <- redis.lPush(key, value)
+            list  <- redis.typeOf(key)
           } yield assert(list)(equalTo(RedisType.List))
         },
         test("set type") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
             value <- uuid
-            _     <- sAdd(key, value)
-            set   <- typeOf(key)
+            _     <- redis.sAdd(key, value)
+            set   <- redis.typeOf(key)
           } yield assert(set)(equalTo(RedisType.Set))
         },
         test("sorted set type") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
             value <- uuid
-            _     <- zAdd(key)(MemberScore(1d, value))
-            zset  <- typeOf(key)
+            _     <- redis.zAdd(key)(MemberScore(1d, value))
+            zset  <- redis.typeOf(key)
           } yield assert(zset)(equalTo(RedisType.SortedSet))
         },
         test("hash type") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
             field <- uuid
             value <- uuid
-            _     <- hSet(key, (field, value))
-            hash  <- typeOf(key)
+            _     <- redis.hSet(key, (field, value))
+            hash  <- redis.typeOf(key)
           } yield assert(hash)(equalTo(RedisType.Hash))
         },
         test("stream type") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
             field  <- uuid
             value  <- uuid
-            _      <- xAdd(key, "*", (field, value)).returning[String]
-            stream <- typeOf(key)
+            _      <- redis.xAdd(key, "*", (field, value)).returning[String]
+            stream <- redis.typeOf(key)
           } yield assert(stream)(equalTo(RedisType.Stream))
         } @@ testExecutorUnsupported
       ),
       suite("sort")(
         test("list of numbers") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- lPush(key, "1", "0", "2")
-            sorted <- sort(key).returning[String]
+            _      <- redis.lPush(key, "1", "0", "2")
+            sorted <- redis.sort(key).returning[String]
           } yield assert(sorted)(equalTo(Chunk("0", "1", "2")))
         },
         test("list of strings") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- lPush(key, "z", "a", "c")
-            sorted <- sort(key, alpha = Some(Alpha)).returning[String]
+            _      <- redis.lPush(key, "z", "a", "c")
+            sorted <- redis.sort(key, alpha = Some(Alpha)).returning[String]
           } yield assert(sorted)(equalTo(Chunk("a", "c", "z")))
         },
         test("list of numbers, limited") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- lPush(key, "1", "0", "2")
-            sorted <- sort(key, limit = Some(Limit(1, 1))).returning[String]
+            _      <- redis.lPush(key, "1", "0", "2")
+            sorted <- redis.sort(key, limit = Some(Limit(1, 1))).returning[String]
           } yield assert(sorted)(equalTo(Chunk("1")))
         },
         test("descending sort") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- lPush(key, "1", "0", "2")
-            sorted <- sort(key, order = Order.Descending).returning[String]
+            _      <- redis.lPush(key, "1", "0", "2")
+            sorted <- redis.sort(key, order = Order.Descending).returning[String]
           } yield assert(sorted)(equalTo(Chunk("2", "1", "0")))
         },
         test("by the value referenced by a key-value pair") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
             a      <- uuid
             b      <- uuid
-            _      <- lPush(key, b, a)
+            _      <- redis.lPush(key, b, a)
             prefix <- uuid
-            _      <- set(s"${prefix}_$a", "A")
-            _      <- set(s"${prefix}_$b", "B")
-            sorted <- sort(key, by = Some(s"${prefix}_*"), alpha = Some(Alpha)).returning[String]
+            _      <- redis.set(s"${prefix}_$a", "A")
+            _      <- redis.set(s"${prefix}_$b", "B")
+            sorted <- redis.sort(key, by = Some(s"${prefix}_*"), alpha = Some(Alpha)).returning[String]
           } yield assert(sorted)(equalTo(Chunk(a, b)))
         } @@ clusterExecutorUnsupported,
         test("getting the value referenced by a key-value pair") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
             value  <- uuid
-            _      <- lPush(key, value)
+            _      <- redis.lPush(key, value)
             prefix <- uuid
-            _      <- set(s"${prefix}_$value", "A")
-            sorted <- sort(key, get = Some(s"${prefix}_*" -> List.empty), alpha = Some(Alpha)).returning[String]
+            _      <- redis.set(s"${prefix}_$value", "A")
+            sorted <- redis.sort(key, get = Some(s"${prefix}_*" -> List.empty), alpha = Some(Alpha)).returning[String]
           } yield assert(sorted)(equalTo(Chunk("A")))
         } @@ clusterExecutorUnsupported,
         test("getting multiple values referenced by a key-value pair") {
           for {
+            redis   <- ZIO.service[Redis]
             key     <- uuid
             value1  <- uuid
             value2  <- uuid
-            _       <- lPush(key, value1, value2)
+            _       <- redis.lPush(key, value1, value2)
             prefix  <- uuid
-            _       <- set(s"${prefix}_$value1", "A1")
-            _       <- set(s"${prefix}_$value2", "A2")
+            _       <- redis.set(s"${prefix}_$value1", "A1")
+            _       <- redis.set(s"${prefix}_$value2", "A2")
             prefix2 <- uuid
-            _       <- set(s"${prefix2}_$value1", "B1")
-            _       <- set(s"${prefix2}_$value2", "B2")
-            sorted <- sort(key, get = Some((s"${prefix}_*", List(s"${prefix2}_*"))), alpha = Some(Alpha))
+            _       <- redis.set(s"${prefix2}_$value1", "B1")
+            _       <- redis.set(s"${prefix2}_$value2", "B2")
+            sorted <- redis
+                        .sort(key, get = Some((s"${prefix}_*", List(s"${prefix2}_*"))), alpha = Some(Alpha))
                         .returning[String]
           } yield assert(sorted)(equalTo(Chunk("A1", "B1", "A2", "B2")))
         } @@ flaky @@ clusterExecutorUnsupported,
         test("sort and store result") {
           for {
+            redis     <- ZIO.service[Redis]
             key       <- uuid
             resultKey <- uuid
-            _         <- lPush(key, "1", "0", "2")
-            count     <- sortStore(key, Store(resultKey))
-            sorted    <- lRange(resultKey, 0 to 2).returning[String]
+            _         <- redis.lPush(key, "1", "0", "2")
+            count     <- redis.sortStore(key, Store(resultKey))
+            sorted    <- redis.lRange(resultKey, 0 to 2).returning[String]
           } yield assert(sorted)(equalTo(Chunk("0", "1", "2"))) && assert(count)(equalTo(3L))
         } @@ clusterExecutorUnsupported
       )

--- a/redis/src/test/scala/zio/redis/ListSpec.scala
+++ b/redis/src/test/scala/zio/redis/ListSpec.scala
@@ -14,187 +14,210 @@ trait ListSpec extends BaseSpec {
       suite("pop")(
         test("lPop non-empty list") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- lPush(key, "world", "hello")
-            popped <- lPop(key).returning[String]
+            _      <- redis.lPush(key, "world", "hello")
+            popped <- redis.lPop(key).returning[String]
           } yield assert(popped)(isSome(equalTo("hello")))
         },
         test("lPop empty list") {
           for {
-            popped <- lPop("unknown").returning[String]
+            redis  <- ZIO.service[Redis]
+            popped <- redis.lPop("unknown").returning[String]
           } yield assert(popped)(isNone)
         },
         test("lPop error not list") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
             value <- uuid
-            _     <- set(key, value)
-            pop   <- lPop(key).returning[String].either
+            _     <- redis.set(key, value)
+            pop   <- redis.lPop(key).returning[String].either
           } yield assert(pop)(isLeft)
         },
         test("rPop non-empty list") {
           for {
-            key <- uuid
-            _   <- rPush(key, "world", "hello")
-            pop <- rPop(key).returning[String]
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.rPush(key, "world", "hello")
+            pop   <- redis.rPop(key).returning[String]
           } yield assert(pop)(isSome(equalTo("hello")))
         },
         test("rPop empty list") {
           for {
-            pop <- rPop("unknown").returning[String]
+            redis <- ZIO.service[Redis]
+            pop   <- redis.rPop("unknown").returning[String]
           } yield assert(pop)(isNone)
         },
         test("rPop error not list") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
             value <- uuid
-            _     <- set(key, value)
-            pop   <- rPop(key).returning[String].either
+            _     <- redis.set(key, value)
+            pop   <- redis.rPop(key).returning[String].either
           } yield assert(pop)(isLeft)
         }
       ),
       suite("push")(
         test("lPush onto empty list") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
-            push  <- lPush(key, "hello")
-            range <- lRange(key, 0 to -1).returning[String]
+            push  <- redis.lPush(key, "hello")
+            range <- redis.lRange(key, 0 to -1).returning[String]
           } yield assert(push)(equalTo(1L)) && assert(range)(equalTo(Chunk("hello")))
         },
         test("lPush multiple elements onto empty list") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
-            push  <- lPush(key, "hello", "world")
-            range <- lRange(key, 0 to -1).returning[String]
+            push  <- redis.lPush(key, "hello", "world")
+            range <- redis.lRange(key, 0 to -1).returning[String]
           } yield assert(push)(equalTo(2L)) && assert(range)(equalTo(Chunk("world", "hello")))
         },
         test("lPush error when not list") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
             value <- uuid
-            _     <- set(key, value)
-            push  <- lPush(key, "hello").either
+            _     <- redis.set(key, value)
+            push  <- redis.lPush(key, "hello").either
           } yield assert(push)(isLeft)
         },
         test("lPushX onto non-empty list") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
-            _     <- lPush(key, "world")
-            px    <- lPushX(key, "hello")
-            range <- lRange(key, 0 to -1).returning[String]
+            _     <- redis.lPush(key, "world")
+            px    <- redis.lPushX(key, "hello")
+            range <- redis.lRange(key, 0 to -1).returning[String]
           } yield assert(px)(equalTo(2L)) && assert(range)(equalTo(Chunk("hello", "world")))
         },
         test("lPushX nothing when key doesn't exist") {
           for {
-            key <- uuid
-            px  <- lPushX(key, "world")
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            px    <- redis.lPushX(key, "world")
           } yield assert(px)(equalTo(0L))
         },
         test("lPushX error when not list") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
             value <- uuid
-            _     <- set(key, value)
-            push  <- lPushX(key, "hello").either
+            _     <- redis.set(key, value)
+            push  <- redis.lPushX(key, "hello").either
           } yield assert(push)(isLeft(isSubtype[RedisError.WrongType](anything)))
         },
         test("rPush onto empty list") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
-            push  <- rPush(key, "hello")
-            range <- lRange(key, 0 to -1).returning[String]
+            push  <- redis.rPush(key, "hello")
+            range <- redis.lRange(key, 0 to -1).returning[String]
           } yield assert(push)(equalTo(1L)) && assert(range)(equalTo(Chunk("hello")))
         },
         test("rPush multiple elements onto empty list") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
-            push  <- rPush(key, "hello", "world")
-            range <- lRange(key, 0 to -1).returning[String]
+            push  <- redis.rPush(key, "hello", "world")
+            range <- redis.lRange(key, 0 to -1).returning[String]
           } yield assert(push)(equalTo(2L)) && assert(range)(equalTo(Chunk("hello", "world")))
         },
         test("rPush error when not list") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
             value <- uuid
-            _     <- set(key, value)
-            push  <- rPush(key, "hello").either
+            _     <- redis.set(key, value)
+            push  <- redis.rPush(key, "hello").either
           } yield assert(push)(isLeft)
         },
         test("rPushX onto non-empty list") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
-            _     <- rPush(key, "world")
-            px    <- rPushX(key, "hello")
-            range <- lRange(key, 0 to -1).returning[String]
+            _     <- redis.rPush(key, "world")
+            px    <- redis.rPushX(key, "hello")
+            range <- redis.lRange(key, 0 to -1).returning[String]
           } yield assert(px)(equalTo(2L)) && assert(range)(equalTo(Chunk("world", "hello")))
         },
         test("rPushX nothing when key doesn't exist") {
           for {
-            key <- uuid
-            px  <- rPushX(key, "world")
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            px    <- redis.rPushX(key, "world")
           } yield assert(px)(equalTo(0L))
         },
         test("rPushX error when not list") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
             value <- uuid
-            _     <- set(key, value)
-            push  <- rPushX(key, "hello").either
+            _     <- redis.set(key, value)
+            push  <- redis.rPushX(key, "hello").either
           } yield assert(push)(isLeft(isSubtype[RedisError.WrongType](anything)))
         }
       ),
       suite("poppush")(
         test("rPopLPush") {
           for {
-            key  <- uuid
-            dest <- uuid
-            _    <- rPush(key, "one", "two", "three")
-            _    <- rPush(dest, "four")
-            _    <- rPopLPush(key, dest).returning[String]
-            r    <- lRange(key, 0 to -1).returning[String]
-            l    <- lRange(dest, 0 to -1).returning[String]
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            dest  <- uuid
+            _     <- redis.rPush(key, "one", "two", "three")
+            _     <- redis.rPush(dest, "four")
+            _     <- redis.rPopLPush(key, dest).returning[String]
+            r     <- redis.lRange(key, 0 to -1).returning[String]
+            l     <- redis.lRange(dest, 0 to -1).returning[String]
           } yield assert(r)(equalTo(Chunk("one", "two"))) && assert(l)(equalTo(Chunk("three", "four")))
         },
         test("rPopLPush nothing when source does not exist") {
           for {
-            key  <- uuid
-            dest <- uuid
-            _    <- rPush(dest, "four")
-            _    <- rPopLPush(key, dest).returning[String]
-            l    <- lRange(dest, 0 to -1).returning[String]
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            dest  <- uuid
+            _     <- redis.rPush(dest, "four")
+            _     <- redis.rPopLPush(key, dest).returning[String]
+            l     <- redis.lRange(dest, 0 to -1).returning[String]
           } yield assert(l)(equalTo(Chunk("four")))
         },
         test("rPopLPush error when not list") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
             dest  <- uuid
             value <- uuid
-            _     <- set(key, value)
-            rpp   <- rPopLPush(key, dest).returning[String].either
+            _     <- redis.set(key, value)
+            rpp   <- redis.rPopLPush(key, dest).returning[String].either
           } yield assert(rpp)(isLeft)
         }
       ) @@ clusterExecutorUnsupported,
       suite("blocking poppush")(
         test("brPopLPush") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
             dest  <- uuid
-            _     <- rPush(key, "one", "two", "three")
-            _     <- rPush(dest, "four")
-            fiber <- brPopLPush(key, dest, 1.seconds).returning[String].fork
+            _     <- redis.rPush(key, "one", "two", "three")
+            _     <- redis.rPush(dest, "four")
+            fiber <- redis.brPopLPush(key, dest, 1.seconds).returning[String].fork
             _     <- TestClock.adjust(1.second)
             _     <- fiber.join
-            r     <- lRange(key, 0 to -1).returning[String]
-            l     <- lRange(dest, 0 to -1).returning[String]
+            r     <- redis.lRange(key, 0 to -1).returning[String]
+            l     <- redis.lRange(dest, 0 to -1).returning[String]
           } yield assert(r)(equalTo(Chunk("one", "two"))) && assert(l)(equalTo(Chunk("three", "four")))
         },
         test("brPopLPush block for 1 second when source does not exist") {
           for {
+            redis     <- ZIO.service[Redis]
             key       <- uuid
             dest      <- uuid
-            _         <- rPush(dest, "four")
+            _         <- redis.rPush(dest, "four")
             startTime <- currentTime(TimeUnit.SECONDS)
-            fiber     <- brPopLPush(key, dest, 1.seconds).returning[String].fork
+            fiber     <- redis.brPopLPush(key, dest, 1.seconds).returning[String].fork
             _         <- TestClock.adjust(1.second)
             s         <- fiber.join
             endTime   <- currentTime(TimeUnit.SECONDS)
@@ -202,208 +225,234 @@ trait ListSpec extends BaseSpec {
         },
         test("brPopLPush error when not list") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
             dest  <- uuid
             value <- uuid
-            _     <- set(key, value)
-            bpp   <- brPopLPush(key, dest, 1.seconds).returning[String].either
+            _     <- redis.set(key, value)
+            bpp   <- redis.brPopLPush(key, dest, 1.seconds).returning[String].either
           } yield assert(bpp)(isLeft)
         }
       ) @@ clusterExecutorUnsupported,
       suite("remove")(
         test("lRem 2 elements moving from head") {
           for {
+            redis   <- ZIO.service[Redis]
             key     <- uuid
-            _       <- lPush(key, "world", "hello", "hello", "hello")
-            removed <- lRem(key, 2, "hello")
-            range   <- lRange(key, 0 to 1).returning[String]
+            _       <- redis.lPush(key, "world", "hello", "hello", "hello")
+            removed <- redis.lRem(key, 2, "hello")
+            range   <- redis.lRange(key, 0 to 1).returning[String]
           } yield assert(removed)(equalTo(2L)) && assert(range)(equalTo(Chunk("hello", "world")))
         },
         test("lRem 2 elements moving from tail") {
           for {
+            redis   <- ZIO.service[Redis]
             key     <- uuid
-            _       <- lPush(key, "hello", "hello", "world", "hello")
-            removed <- lRem(key, -2, "hello")
-            range   <- lRange(key, 0 to 1).returning[String]
+            _       <- redis.lPush(key, "hello", "hello", "world", "hello")
+            removed <- redis.lRem(key, -2, "hello")
+            range   <- redis.lRange(key, 0 to 1).returning[String]
           } yield assert(removed)(equalTo(2L)) && assert(range)(equalTo(Chunk("hello", "world")))
         },
         test("lRem all 3 'hello' elements") {
           for {
+            redis   <- ZIO.service[Redis]
             key     <- uuid
-            _       <- lPush(key, "hello", "hello", "world", "hello")
-            removed <- lRem(key, 0, "hello")
-            range   <- lRange(key, 0 to 1).returning[String]
+            _       <- redis.lPush(key, "hello", "hello", "world", "hello")
+            removed <- redis.lRem(key, 0, "hello")
+            range   <- redis.lRange(key, 0 to 1).returning[String]
           } yield assert(removed)(equalTo(3L)) && assert(range)(equalTo(Chunk("world")))
         },
         test("lRem nothing when key does not exist") {
           for {
+            redis   <- ZIO.service[Redis]
             key     <- uuid
-            _       <- lPush(key, "world", "hello")
-            removed <- lRem(key, 0, "goodbye")
-            range   <- lRange(key, 0 to 1).returning[String]
+            _       <- redis.lPush(key, "world", "hello")
+            removed <- redis.lRem(key, 0, "goodbye")
+            range   <- redis.lRange(key, 0 to 1).returning[String]
           } yield assert(removed)(equalTo(0L)) && assert(range)(equalTo(Chunk("hello", "world")))
         },
         test("lRem error when not list") {
           for {
+            redis   <- ZIO.service[Redis]
             key     <- uuid
-            _       <- set(key, "hello")
-            removed <- lRem(key, 0, "hello").either
+            _       <- redis.set(key, "hello")
+            removed <- redis.lRem(key, 0, "hello").either
           } yield assert(removed)(isLeft)
         }
       ),
       suite("set")(
         test("lSet element") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
-            _     <- lPush(key, "world", "hello")
-            _     <- lSet(key, 1, "goodbye")
-            range <- lRange(key, 0 to 1).returning[String]
+            _     <- redis.lPush(key, "world", "hello")
+            _     <- redis.lSet(key, 1, "goodbye")
+            range <- redis.lRange(key, 0 to 1).returning[String]
           } yield assert(range)(equalTo(Chunk("hello", "goodbye")))
         },
         test("lSet error when index out of bounds") {
           for {
-            key <- uuid
-            _   <- lPush(key, "world", "hello")
-            set <- lSet(key, 2, "goodbye").either
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.lPush(key, "world", "hello")
+            set   <- redis.lSet(key, 2, "goodbye").either
           } yield assert(set)(isLeft)
         },
         test("lSet error when not list") {
           for {
-            key <- uuid
-            _   <- set(key, "hello")
-            set <- lSet(key, 0, "goodbye").either
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.set(key, "hello")
+            set   <- redis.lSet(key, 0, "goodbye").either
           } yield assert(set)(isLeft)
         }
       ),
       suite("length")(
         test("lLen non-empty list") {
           for {
-            key <- uuid
-            _   <- lPush(key, "world", "hello")
-            len <- lLen(key)
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.lPush(key, "world", "hello")
+            len   <- redis.lLen(key)
           } yield assert(len)(equalTo(2L))
         },
         test("lLen 0 when no key") {
           for {
-            len <- lLen("unknown")
+            redis <- ZIO.service[Redis]
+            len   <- redis.lLen("unknown")
           } yield assert(len)(equalTo(0L))
         },
         test("lLen error when not list") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
             value <- uuid
-            _     <- set(key, value)
-            index <- lLen(key).either
+            _     <- redis.set(key, value)
+            index <- redis.lLen(key).either
           } yield assert(index)(isLeft)
         }
       ),
       suite("range")(
         test("lRange two elements") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
-            _     <- lPush(key, "world", "hello")
-            range <- lRange(key, 0 to 1).returning[String]
+            _     <- redis.lPush(key, "world", "hello")
+            range <- redis.lRange(key, 0 to 1).returning[String]
           } yield assert(range)(equalTo(Chunk("hello", "world")))
         },
         test("lRange two elements negative indices") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
-            _     <- lPush(key, "world", "hello")
-            range <- lRange(key, -2 to -1).returning[String]
+            _     <- redis.lPush(key, "world", "hello")
+            range <- redis.lRange(key, -2 to -1).returning[String]
           } yield assert(range)(equalTo(Chunk("hello", "world")))
         },
         test("lRange start out of bounds") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
-            _     <- lPush(key, "world", "hello")
-            range <- lRange(key, 2 to 3).returning[String]
+            _     <- redis.lPush(key, "world", "hello")
+            range <- redis.lRange(key, 2 to 3).returning[String]
           } yield assert(range)(equalTo(Chunk()))
         },
         test("lRange end out of bounds") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
-            _     <- lPush(key, "world", "hello")
-            range <- lRange(key, 1 to 2).returning[String]
+            _     <- redis.lPush(key, "world", "hello")
+            range <- redis.lRange(key, 1 to 2).returning[String]
           } yield assert(range)(equalTo(Chunk("world")))
         },
         test("lRange error when not list") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
-            _     <- set(key, "hello")
-            range <- lRange(key, 1 to 2).returning[String].either
+            _     <- redis.set(key, "hello")
+            range <- redis.lRange(key, 1 to 2).returning[String].either
           } yield assert(range)(isLeft)
         }
       ),
       suite("index element")(
         test("lIndex first element") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
-            _     <- lPush(key, "world", "hello")
-            index <- lIndex(key, 0L).returning[String]
+            _     <- redis.lPush(key, "world", "hello")
+            index <- redis.lIndex(key, 0L).returning[String]
           } yield assert(index)(isSome(equalTo("hello")))
         },
         test("lIndex last element") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
-            _     <- lPush(key, "world", "hello")
-            index <- lIndex(key, -1L).returning[String]
+            _     <- redis.lPush(key, "world", "hello")
+            index <- redis.lIndex(key, -1L).returning[String]
           } yield assert(index)(isSome(equalTo("world")))
         },
         test("lIndex no existing element") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
-            _     <- lPush(key, "world", "hello")
-            index <- lIndex(key, 3).returning[String]
+            _     <- redis.lPush(key, "world", "hello")
+            index <- redis.lIndex(key, 3).returning[String]
           } yield assert(index)(isNone)
         },
         test("lIndex error when not list") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
             value <- uuid
-            _     <- set(key, value)
-            index <- lIndex(key, -1L).returning[String].either
+            _     <- redis.set(key, value)
+            index <- redis.lIndex(key, -1L).returning[String].either
           } yield assert(index)(isLeft)
         }
       ),
       suite("trim element")(
         test("lTrim element") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
-            _     <- lPush(key, "world", "hello")
-            _     <- lTrim(key, 0 to 0)
-            range <- lRange(key, 0 to -1).returning[String]
+            _     <- redis.lPush(key, "world", "hello")
+            _     <- redis.lTrim(key, 0 to 0)
+            range <- redis.lRange(key, 0 to -1).returning[String]
           } yield assert(range)(equalTo(Chunk("hello")))
         },
         test("lTrim start index out of bounds") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
-            _     <- lPush(key, "world", "hello")
-            _     <- lTrim(key, 2 to 5)
-            range <- lRange(key, 0 to 1).returning[String]
+            _     <- redis.lPush(key, "world", "hello")
+            _     <- redis.lTrim(key, 2 to 5)
+            range <- redis.lRange(key, 0 to 1).returning[String]
           } yield assert(range)(equalTo(Chunk()))
         },
         test("lTrim end index out of bounds") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
-            _     <- lPush(key, "world", "hello")
-            _     <- lTrim(key, 0 to 3)
-            range <- lRange(key, 0 to 1).returning[String]
+            _     <- redis.lPush(key, "world", "hello")
+            _     <- redis.lTrim(key, 0 to 3)
+            range <- redis.lRange(key, 0 to 1).returning[String]
           } yield assert(range)(equalTo(Chunk("hello", "world")))
         },
         test("lTrim error when not list") {
           for {
-            key  <- uuid
-            _    <- set(key, "hello")
-            trim <- lTrim(key, 0 to 3).either
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.set(key, "hello")
+            trim  <- redis.lTrim(key, 0 to 3).either
           } yield assert(trim)(isLeft)
         }
       ),
       suite("blPop")(
         test("from single list") {
           for {
+            redis      <- ZIO.service[Redis]
             key        <- uuid
-            _          <- lPush(key, "a", "b", "c")
-            fiber      <- blPop(key)(1.second).returning[String].fork
+            _          <- redis.lPush(key, "a", "b", "c")
+            fiber      <- redis.blPop(key)(1.second).returning[String].fork
             _          <- TestClock.adjust(1.second)
             popped     <- fiber.join.some
             (src, elem) = popped
@@ -411,10 +460,11 @@ trait ListSpec extends BaseSpec {
         },
         test("from one empty and one non-empty list") {
           for {
+            redis      <- ZIO.service[Redis]
             empty      <- uuid
             nonEmpty   <- uuid
-            _          <- lPush(nonEmpty, "a", "b", "c")
-            fiber      <- blPop(empty, nonEmpty)(1.second).returning[String].fork
+            _          <- redis.lPush(nonEmpty, "a", "b", "c")
+            fiber      <- redis.blPop(empty, nonEmpty)(1.second).returning[String].fork
             _          <- TestClock.adjust(1.second)
             popped     <- fiber.join.some
             (src, elem) = popped
@@ -422,44 +472,49 @@ trait ListSpec extends BaseSpec {
         },
         test("from one empty list") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            fiber  <- blPop(key)(1.second).returning[String].fork
+            fiber  <- redis.blPop(key)(1.second).returning[String].fork
             _      <- TestClock.adjust(1.second)
             popped <- fiber.join
           } yield assert(popped)(isNone)
         },
         test("from multiple empty lists") {
           for {
+            redis  <- ZIO.service[Redis]
             first  <- uuid
             second <- uuid
-            fiber  <- blPop(first, second)(1.second).returning[String].fork
+            fiber  <- redis.blPop(first, second)(1.second).returning[String].fork
             _      <- TestClock.adjust(1.second)
             popped <- fiber.join
           } yield assert(popped)(isNone)
         },
         test("from non-empty list with timeout 0s") {
           for {
+            redis      <- ZIO.service[Redis]
             key        <- uuid
-            _          <- lPush(key, "a", "b", "c")
-            popped     <- blPop(key)(0.seconds).returning[String].some
+            _          <- redis.lPush(key, "a", "b", "c")
+            popped     <- redis.blPop(key)(0.seconds).returning[String].some
             (src, elem) = popped
           } yield assert(src)(equalTo(key)) && assert(elem)(equalTo("c"))
         },
         test("from not list") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
             value  <- uuid
-            _      <- set(key, value)
-            popped <- blPop(key)(1.second).returning[String].either
+            _      <- redis.set(key, value)
+            popped <- redis.blPop(key)(1.second).returning[String].either
           } yield assert(popped)(isLeft(isSubtype[WrongType](anything)))
         }
       ) @@ clusterExecutorUnsupported,
       suite("brPop")(
         test("from single list") {
           for {
+            redis      <- ZIO.service[Redis]
             key        <- uuid
-            _          <- lPush(key, "a", "b", "c")
-            fiber      <- brPop(key)(1.second).returning[String].fork
+            _          <- redis.lPush(key, "a", "b", "c")
+            fiber      <- redis.brPop(key)(1.second).returning[String].fork
             _          <- TestClock.adjust(1.second)
             popped     <- fiber.join.some
             (src, elem) = popped
@@ -467,292 +522,323 @@ trait ListSpec extends BaseSpec {
         },
         test("from one empty and one non-empty list") {
           for {
+            redis      <- ZIO.service[Redis]
             empty      <- uuid
             nonEmpty   <- uuid
-            _          <- lPush(nonEmpty, "a", "b", "c")
-            popped     <- brPop(empty, nonEmpty)(1.second).returning[String].some
+            _          <- redis.lPush(nonEmpty, "a", "b", "c")
+            popped     <- redis.brPop(empty, nonEmpty)(1.second).returning[String].some
             (src, elem) = popped
           } yield assert(src)(equalTo(nonEmpty)) && assert(elem)(equalTo("a"))
         },
         test("from one empty list") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            fiber  <- brPop(key)(1.second).returning[String].fork
+            fiber  <- redis.brPop(key)(1.second).returning[String].fork
             _      <- TestClock.adjust(1.second)
             popped <- fiber.join
           } yield assert(popped)(isNone)
         },
         test("from multiple empty lists") {
           for {
+            redis  <- ZIO.service[Redis]
             first  <- uuid
             second <- uuid
-            fiber  <- brPop(first, second)(1.second).returning[String].fork
+            fiber  <- redis.brPop(first, second)(1.second).returning[String].fork
             _      <- TestClock.adjust(1.second)
             popped <- fiber.join
           } yield assert(popped)(isNone)
         },
         test("from non-empty list with timeout 0s") {
           for {
+            redis      <- ZIO.service[Redis]
             key        <- uuid
-            _          <- lPush(key, "a", "b", "c")
-            popped     <- brPop(key)(0.seconds).returning[String].some
+            _          <- redis.lPush(key, "a", "b", "c")
+            popped     <- redis.brPop(key)(0.seconds).returning[String].some
             (src, elem) = popped
           } yield assert(src)(equalTo(key)) && assert(elem)(equalTo("a"))
         },
         test("from not list") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
             value  <- uuid
-            _      <- set(key, value)
-            popped <- brPop(key)(1.second).returning[String].either
+            _      <- redis.set(key, value)
+            popped <- redis.brPop(key)(1.second).returning[String].either
           } yield assert(popped)(isLeft(isSubtype[WrongType](anything)))
         }
       ) @@ clusterExecutorUnsupported,
       suite("lInsert")(
         test("before pivot into non-empty list") {
           for {
-            key <- uuid
-            _   <- lPush(key, "a", "b", "c")
-            len <- lInsert(key, Position.Before, "b", "d")
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.lPush(key, "a", "b", "c")
+            len   <- redis.lInsert(key, Position.Before, "b", "d")
           } yield assert(len)(equalTo(4L))
         },
         test("after pivot into non-empty list") {
           for {
-            key <- uuid
-            _   <- lPush(key, "a", "b", "c")
-            len <- lInsert(key, Position.After, "b", "d")
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.lPush(key, "a", "b", "c")
+            len   <- redis.lInsert(key, Position.After, "b", "d")
           } yield assert(len)(equalTo(4L))
         },
         test("before pivot into empty list") {
           for {
-            key <- uuid
-            len <- lInsert(key, Position.Before, "a", "b")
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            len   <- redis.lInsert(key, Position.Before, "a", "b")
           } yield assert(len)(equalTo(0L))
         },
         test("after pivot into empty list") {
           for {
-            key <- uuid
-            len <- lInsert(key, Position.After, "a", "b")
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            len   <- redis.lInsert(key, Position.After, "a", "b")
           } yield assert(len)(equalTo(0L))
         },
         test("before pivot that doesn't exist") {
           for {
-            key <- uuid
-            _   <- lPush(key, "a", "b", "c")
-            len <- lInsert(key, Position.Before, "unknown", "d")
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.lPush(key, "a", "b", "c")
+            len   <- redis.lInsert(key, Position.Before, "unknown", "d")
           } yield assert(len)(equalTo(-1L))
         },
         test("after pivot that doesn't exist") {
           for {
-            key <- uuid
-            _   <- lPush(key, "a", "b", "c")
-            len <- lInsert(key, Position.After, "unknown", "d")
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.lPush(key, "a", "b", "c")
+            len   <- redis.lInsert(key, Position.After, "unknown", "d")
           } yield assert(len)(equalTo(-1L))
         },
         test("error before pivot into not list") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
             value <- uuid
-            _     <- set(key, value)
-            len   <- lInsert(key, Position.Before, "a", "b").either
+            _     <- redis.set(key, value)
+            len   <- redis.lInsert(key, Position.Before, "a", "b").either
           } yield assert(len)(isLeft(isSubtype[WrongType](anything)))
         },
         test("error after pivot into not list") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
             value <- uuid
-            _     <- set(key, value)
-            len   <- lInsert(key, Position.After, "a", "b").either
+            _     <- redis.set(key, value)
+            len   <- redis.lInsert(key, Position.After, "a", "b").either
           } yield assert(len)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
       suite("lMove")(
         test("move from source to destination left right") {
           for {
+            redis            <- ZIO.service[Redis]
             source           <- uuid
             destination      <- uuid
-            _                <- rPush(source, "a", "b", "c")
-            _                <- rPush(destination, "d")
-            moved            <- lMove(source, destination, Side.Left, Side.Right).returning[String]
-            sourceRange      <- lRange(source, 0 to -1).returning[String]
-            destinationRange <- lRange(destination, 0 to -1).returning[String]
+            _                <- redis.rPush(source, "a", "b", "c")
+            _                <- redis.rPush(destination, "d")
+            moved            <- redis.lMove(source, destination, Side.Left, Side.Right).returning[String]
+            sourceRange      <- redis.lRange(source, 0 to -1).returning[String]
+            destinationRange <- redis.lRange(destination, 0 to -1).returning[String]
           } yield assert(moved)(isSome(equalTo("a"))) &&
             assert(sourceRange)(equalTo(Chunk("b", "c"))) && assert(destinationRange)(equalTo(Chunk("d", "a")))
         },
         test("move from source to destination right left") {
           for {
+            redis            <- ZIO.service[Redis]
             source           <- uuid
             destination      <- uuid
-            _                <- rPush(source, "a", "b", "c")
-            _                <- rPush(destination, "d")
-            moved            <- lMove(source, destination, Side.Right, Side.Left).returning[String]
-            sourceRange      <- lRange(source, 0 to -1).returning[String]
-            destinationRange <- lRange(destination, 0 to -1).returning[String]
+            _                <- redis.rPush(source, "a", "b", "c")
+            _                <- redis.rPush(destination, "d")
+            moved            <- redis.lMove(source, destination, Side.Right, Side.Left).returning[String]
+            sourceRange      <- redis.lRange(source, 0 to -1).returning[String]
+            destinationRange <- redis.lRange(destination, 0 to -1).returning[String]
           } yield assert(moved)(isSome(equalTo("c"))) &&
             assert(sourceRange)(equalTo(Chunk("a", "b"))) &&
             assert(destinationRange)(equalTo(Chunk("c", "d")))
         },
         test("move from source to destination left left") {
           for {
+            redis            <- ZIO.service[Redis]
             source           <- uuid
             destination      <- uuid
-            _                <- rPush(source, "a", "b", "c")
-            _                <- rPush(destination, "d")
-            moved            <- lMove(source, destination, Side.Left, Side.Left).returning[String]
-            sourceRange      <- lRange(source, 0 to -1).returning[String]
-            destinationRange <- lRange(destination, 0 to -1).returning[String]
+            _                <- redis.rPush(source, "a", "b", "c")
+            _                <- redis.rPush(destination, "d")
+            moved            <- redis.lMove(source, destination, Side.Left, Side.Left).returning[String]
+            sourceRange      <- redis.lRange(source, 0 to -1).returning[String]
+            destinationRange <- redis.lRange(destination, 0 to -1).returning[String]
           } yield assert(moved)(isSome(equalTo("a"))) &&
             assert(sourceRange)(equalTo(Chunk("b", "c"))) &&
             assert(destinationRange)(equalTo(Chunk("a", "d")))
         },
         test("move from source to destination right right") {
           for {
+            redis            <- ZIO.service[Redis]
             source           <- uuid
             destination      <- uuid
-            _                <- rPush(source, "a", "b", "c")
-            _                <- rPush(destination, "d")
-            moved            <- lMove(source, destination, Side.Right, Side.Right).returning[String]
-            sourceRange      <- lRange(source, 0 to -1).returning[String]
-            destinationRange <- lRange(destination, 0 to -1).returning[String]
+            _                <- redis.rPush(source, "a", "b", "c")
+            _                <- redis.rPush(destination, "d")
+            moved            <- redis.lMove(source, destination, Side.Right, Side.Right).returning[String]
+            sourceRange      <- redis.lRange(source, 0 to -1).returning[String]
+            destinationRange <- redis.lRange(destination, 0 to -1).returning[String]
           } yield assert(moved)(isSome(equalTo("c"))) &&
             assert(sourceRange)(equalTo(Chunk("a", "b"))) &&
             assert(destinationRange)(equalTo(Chunk("d", "c")))
         },
         test("move from source to source left right") {
           for {
+            redis       <- ZIO.service[Redis]
             source      <- uuid
-            _           <- rPush(source, "a", "b", "c")
-            moved       <- lMove(source, source, Side.Left, Side.Right).returning[String]
-            sourceRange <- lRange(source, 0 to -1).returning[String]
+            _           <- redis.rPush(source, "a", "b", "c")
+            moved       <- redis.lMove(source, source, Side.Left, Side.Right).returning[String]
+            sourceRange <- redis.lRange(source, 0 to -1).returning[String]
           } yield assert(moved)(isSome(equalTo("a"))) && assert(sourceRange)(equalTo(Chunk("b", "c", "a")))
         },
         test("move from source to source right left") {
           for {
+            redis       <- ZIO.service[Redis]
             source      <- uuid
-            _           <- rPush(source, "a", "b", "c")
-            moved       <- lMove(source, source, Side.Right, Side.Left).returning[String]
-            sourceRange <- lRange(source, 0 to -1).returning[String]
+            _           <- redis.rPush(source, "a", "b", "c")
+            moved       <- redis.lMove(source, source, Side.Right, Side.Left).returning[String]
+            sourceRange <- redis.lRange(source, 0 to -1).returning[String]
           } yield assert(moved)(isSome(equalTo("c"))) &&
             assert(sourceRange)(equalTo(Chunk("c", "a", "b")))
         },
         test("move from source to source left left") {
           for {
+            redis       <- ZIO.service[Redis]
             source      <- uuid
-            _           <- rPush(source, "a", "b", "c")
-            moved       <- lMove(source, source, Side.Left, Side.Left).returning[String]
-            sourceRange <- lRange(source, 0 to -1).returning[String]
+            _           <- redis.rPush(source, "a", "b", "c")
+            moved       <- redis.lMove(source, source, Side.Left, Side.Left).returning[String]
+            sourceRange <- redis.lRange(source, 0 to -1).returning[String]
           } yield assert(moved)(isSome(equalTo("a"))) &&
             assert(sourceRange)(equalTo(Chunk("a", "b", "c")))
         },
         test("move from source to source right right") {
           for {
+            redis       <- ZIO.service[Redis]
             source      <- uuid
-            _           <- rPush(source, "a", "b", "c")
-            moved       <- lMove(source, source, Side.Right, Side.Right).returning[String]
-            sourceRange <- lRange(source, 0 to -1).returning[String]
+            _           <- redis.rPush(source, "a", "b", "c")
+            moved       <- redis.lMove(source, source, Side.Right, Side.Right).returning[String]
+            sourceRange <- redis.lRange(source, 0 to -1).returning[String]
           } yield assert(moved)(isSome(equalTo("c"))) && assert(sourceRange)(equalTo(Chunk("a", "b", "c")))
         },
         test("return nil when source dose not exist") {
           for {
+            redis       <- ZIO.service[Redis]
             source      <- uuid
             destination <- uuid
-            _           <- rPush(destination, "d")
-            moved       <- lMove(source, destination, Side.Left, Side.Right).returning[String]
+            _           <- redis.rPush(destination, "d")
+            moved       <- redis.lMove(source, destination, Side.Left, Side.Right).returning[String]
           } yield assert(moved)(isNone)
         }
       ) @@ clusterExecutorUnsupported,
       suite("blMove")(
         test("move from source to destination left right") {
           for {
+            redis            <- ZIO.service[Redis]
             source           <- uuid
             destination      <- uuid
-            _                <- rPush(source, "a", "b", "c")
-            _                <- rPush(destination, "d")
-            moved            <- blMove(source, destination, Side.Left, Side.Right, 1.second).returning[String]
-            sourceRange      <- lRange(source, 0 to -1).returning[String]
-            destinationRange <- lRange(destination, 0 to -1).returning[String]
+            _                <- redis.rPush(source, "a", "b", "c")
+            _                <- redis.rPush(destination, "d")
+            moved            <- redis.blMove(source, destination, Side.Left, Side.Right, 1.second).returning[String]
+            sourceRange      <- redis.lRange(source, 0 to -1).returning[String]
+            destinationRange <- redis.lRange(destination, 0 to -1).returning[String]
           } yield assert(moved)(isSome(equalTo("a"))) &&
             assert(sourceRange)(equalTo(Chunk("b", "c"))) &&
             assert(destinationRange)(equalTo(Chunk("d", "a")))
         },
         test("move from source to destination right left") {
           for {
+            redis            <- ZIO.service[Redis]
             source           <- uuid
             destination      <- uuid
-            _                <- rPush(source, "a", "b", "c")
-            _                <- rPush(destination, "d")
-            moved            <- blMove(source, destination, Side.Right, Side.Left, 1.second).returning[String]
-            sourceRange      <- lRange(source, 0 to -1).returning[String]
-            destinationRange <- lRange(destination, 0 to -1).returning[String]
+            _                <- redis.rPush(source, "a", "b", "c")
+            _                <- redis.rPush(destination, "d")
+            moved            <- redis.blMove(source, destination, Side.Right, Side.Left, 1.second).returning[String]
+            sourceRange      <- redis.lRange(source, 0 to -1).returning[String]
+            destinationRange <- redis.lRange(destination, 0 to -1).returning[String]
           } yield assert(moved)(isSome(equalTo("c"))) &&
             assert(sourceRange)(equalTo(Chunk("a", "b"))) &&
             assert(destinationRange)(equalTo(Chunk("c", "d")))
         },
         test("move from source to destination left left") {
           for {
+            redis            <- ZIO.service[Redis]
             source           <- uuid
             destination      <- uuid
-            _                <- rPush(source, "a", "b", "c")
-            _                <- rPush(destination, "d")
-            moved            <- blMove(source, destination, Side.Left, Side.Left, 1.second).returning[String]
-            sourceRange      <- lRange(source, 0 to -1).returning[String]
-            destinationRange <- lRange(destination, 0 to -1).returning[String]
+            _                <- redis.rPush(source, "a", "b", "c")
+            _                <- redis.rPush(destination, "d")
+            moved            <- redis.blMove(source, destination, Side.Left, Side.Left, 1.second).returning[String]
+            sourceRange      <- redis.lRange(source, 0 to -1).returning[String]
+            destinationRange <- redis.lRange(destination, 0 to -1).returning[String]
           } yield assert(moved)(isSome(equalTo("a"))) &&
             assert(sourceRange)(equalTo(Chunk("b", "c"))) &&
             assert(destinationRange)(equalTo(Chunk("a", "d")))
         },
         test("move from source to destination right right") {
           for {
+            redis            <- ZIO.service[Redis]
             source           <- uuid
             destination      <- uuid
-            _                <- rPush(source, "a", "b", "c")
-            _                <- rPush(destination, "d")
-            moved            <- blMove(source, destination, Side.Right, Side.Right, 1.second).returning[String]
-            sourceRange      <- lRange(source, 0 to -1).returning[String]
-            destinationRange <- lRange(destination, 0 to -1).returning[String]
+            _                <- redis.rPush(source, "a", "b", "c")
+            _                <- redis.rPush(destination, "d")
+            moved            <- redis.blMove(source, destination, Side.Right, Side.Right, 1.second).returning[String]
+            sourceRange      <- redis.lRange(source, 0 to -1).returning[String]
+            destinationRange <- redis.lRange(destination, 0 to -1).returning[String]
           } yield assert(moved)(isSome(equalTo("c"))) &&
             assert(sourceRange)(equalTo(Chunk("a", "b"))) &&
             assert(destinationRange)(equalTo(Chunk("d", "c")))
         },
         test("move from source to source left right") {
           for {
+            redis       <- ZIO.service[Redis]
             source      <- uuid
-            _           <- rPush(source, "a", "b", "c")
-            moved       <- blMove(source, source, Side.Left, Side.Right, 1.second).returning[String]
-            sourceRange <- lRange(source, 0 to -1).returning[String]
+            _           <- redis.rPush(source, "a", "b", "c")
+            moved       <- redis.blMove(source, source, Side.Left, Side.Right, 1.second).returning[String]
+            sourceRange <- redis.lRange(source, 0 to -1).returning[String]
           } yield assert(moved)(isSome(equalTo("a"))) && assert(sourceRange)(equalTo(Chunk("b", "c", "a")))
         },
         test("move from source to source right left") {
           for {
+            redis       <- ZIO.service[Redis]
             source      <- uuid
-            _           <- rPush(source, "a", "b", "c")
-            moved       <- blMove(source, source, Side.Right, Side.Left, 1.second).returning[String]
-            sourceRange <- lRange(source, 0 to -1).returning[String]
+            _           <- redis.rPush(source, "a", "b", "c")
+            moved       <- redis.blMove(source, source, Side.Right, Side.Left, 1.second).returning[String]
+            sourceRange <- redis.lRange(source, 0 to -1).returning[String]
           } yield assert(moved)(isSome(equalTo("c"))) && assert(sourceRange)(equalTo(Chunk("c", "a", "b")))
         },
         test("move from source to source left left") {
           for {
+            redis       <- ZIO.service[Redis]
             source      <- uuid
-            _           <- rPush(source, "a", "b", "c")
-            moved       <- blMove(source, source, Side.Left, Side.Left, 1.second).returning[String]
-            sourceRange <- lRange(source, 0 to -1).returning[String]
+            _           <- redis.rPush(source, "a", "b", "c")
+            moved       <- redis.blMove(source, source, Side.Left, Side.Left, 1.second).returning[String]
+            sourceRange <- redis.lRange(source, 0 to -1).returning[String]
           } yield assert(moved)(isSome(equalTo("a"))) && assert(sourceRange)(equalTo(Chunk("a", "b", "c")))
         },
         test("move from source to source right right") {
           for {
+            redis       <- ZIO.service[Redis]
             source      <- uuid
-            _           <- rPush(source, "a", "b", "c")
-            moved       <- blMove(source, source, Side.Right, Side.Right, 1.second).returning[String]
-            sourceRange <- lRange(source, 0 to -1).returning[String]
+            _           <- redis.rPush(source, "a", "b", "c")
+            moved       <- redis.blMove(source, source, Side.Right, Side.Right, 1.second).returning[String]
+            sourceRange <- redis.lRange(source, 0 to -1).returning[String]
           } yield assert(moved)(isSome(equalTo("c"))) && assert(sourceRange)(equalTo(Chunk("a", "b", "c")))
         },
         test("block until timeout reached and return nil") {
           for {
+            redis       <- ZIO.service[Redis]
             source      <- uuid
             destination <- uuid
-            _           <- rPush(destination, "d")
+            _           <- redis.rPush(destination, "d")
             startTime   <- currentTime(TimeUnit.SECONDS)
-            fiber       <- blMove(source, destination, Side.Left, Side.Right, 1.second).returning[String].fork
+            fiber       <- redis.blMove(source, destination, Side.Left, Side.Right, 1.second).returning[String].fork
             _           <- TestClock.adjust(1.second)
             moved       <- fiber.join
             endTime     <- currentTime(TimeUnit.SECONDS)
@@ -762,60 +848,68 @@ trait ListSpec extends BaseSpec {
       suite("lPos")(
         test("find index of element") {
           for {
-            key <- uuid
-            _   <- rPush(key, "a", "b", "c", "d", "1", "2", "3", "4", "3", "3", "3")
-            idx <- lPos(key, "3")
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.rPush(key, "a", "b", "c", "d", "1", "2", "3", "4", "3", "3", "3")
+            idx   <- redis.lPos(key, "3")
           } yield assert(idx)(isSome(equalTo(6L)))
         },
         test("don't find index of element") {
           for {
-            key <- uuid
-            _   <- rPush(key, "a", "b", "c", "d", "1", "2", "3", "4", "3", "3", "3")
-            idx <- lPos(key, "unknown")
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.rPush(key, "a", "b", "c", "d", "1", "2", "3", "4", "3", "3", "3")
+            idx   <- redis.lPos(key, "unknown")
           } yield assert(idx)(isNone)
         },
         test("find index of element with positive rank") {
           for {
-            key <- uuid
-            _   <- rPush(key, "a", "b", "c", "d", "1", "2", "3", "4", "3", "3", "3")
-            idx <- lPos(key, "3", rank = Some(Rank(2)))
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.rPush(key, "a", "b", "c", "d", "1", "2", "3", "4", "3", "3", "3")
+            idx   <- redis.lPos(key, "3", rank = Some(Rank(2)))
           } yield assert(idx)(isSome(equalTo(8L)))
         },
         test("find index of element with negative rank") {
           for {
-            key <- uuid
-            _   <- rPush(key, "a", "b", "c", "d", "1", "2", "3", "4", "3", "3", "3")
-            idx <- lPos(key, "3", rank = Some(Rank(-1)))
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.rPush(key, "a", "b", "c", "d", "1", "2", "3", "4", "3", "3", "3")
+            idx   <- redis.lPos(key, "3", rank = Some(Rank(-1)))
           } yield assert(idx)(isSome(equalTo(10L)))
         },
         test("find index of element with maxLen") {
           for {
-            key <- uuid
-            _   <- rPush(key, "a", "b", "c", "d", "1", "2", "3", "4", "3", "3", "3")
-            idx <- lPos(key, "3", maxLen = Some(ListMaxLen(8)))
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.rPush(key, "a", "b", "c", "d", "1", "2", "3", "4", "3", "3", "3")
+            idx   <- redis.lPos(key, "3", maxLen = Some(ListMaxLen(8)))
           } yield assert(idx)(isSome(equalTo(6L)))
         },
         test("don't find index of element with maxLen") {
           for {
-            key <- uuid
-            _   <- rPush(key, "a", "b", "c", "d", "1", "2", "3", "4", "3", "3", "3")
-            idx <- lPos(key, "3", maxLen = Some(ListMaxLen(5)))
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.rPush(key, "a", "b", "c", "d", "1", "2", "3", "4", "3", "3", "3")
+            idx   <- redis.lPos(key, "3", maxLen = Some(ListMaxLen(5)))
           } yield assert(idx)(isNone)
         }
       ),
       suite("lPosCount")(
         test("find index of element with rank and count") {
           for {
-            key <- uuid
-            _   <- rPush(key, "a", "b", "c", "d", "1", "2", "3", "4", "3", "3", "3")
-            idx <- lPosCount(key, "3", Count(2), rank = Some(Rank(2)))
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.rPush(key, "a", "b", "c", "d", "1", "2", "3", "4", "3", "3", "3")
+            idx   <- redis.lPosCount(key, "3", Count(2), rank = Some(Rank(2)))
           } yield assert(idx)(equalTo(Chunk(8L, 9L)))
         },
         test("find index of element with negative rank and count") {
           for {
-            key <- uuid
-            _   <- rPush(key, "a", "b", "c", "d", "1", "2", "3", "4", "3", "3", "3")
-            idx <- lPosCount(key, "3", Count(2), rank = Some(Rank(-3)))
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.rPush(key, "a", "b", "c", "d", "1", "2", "3", "4", "3", "3", "3")
+            idx   <- redis.lPosCount(key, "3", Count(2), rank = Some(Rank(-3)))
           } yield assert(idx)(equalTo(Chunk(8L, 6L)))
         }
       )

--- a/redis/src/test/scala/zio/redis/ScriptingSpec.scala
+++ b/redis/src/test/scala/zio/redis/ScriptingSpec.scala
@@ -29,7 +29,7 @@ trait ScriptingSpec extends BaseSpec {
         },
         test("take strings return strings") {
           for {
-            redis <- ZIO.service[Redis]
+            redis   <- ZIO.service[Redis]
             keyHash <- uuid
             key1    <- uuid.map(_ + s"{$keyHash}")
             key2    <- uuid.map(_ + s"{$keyHash}")
@@ -41,7 +41,7 @@ trait ScriptingSpec extends BaseSpec {
         },
         test("put custom input value return custom input value") {
           for {
-            redis <- ZIO.service[Redis]
+            redis   <- ZIO.service[Redis]
             keyHash <- uuid
             key1    <- uuid.map(_ + s"{$keyHash}")
             key2    <- uuid.map(_ + s"{$keyHash}")
@@ -58,17 +58,17 @@ trait ScriptingSpec extends BaseSpec {
           val emptyInput: Chunk[Long] = Chunk.empty
           for {
             redis <- ZIO.service[Redis]
-            res <- redis.eval(lua, emptyInput, emptyInput).returning[CustomData]
+            res   <- redis.eval(lua, emptyInput, emptyInput).returning[CustomData]
           } yield assertTrue(res == expected)
         },
         test("throw an error when incorrect script's sent") {
           for {
             redis <- ZIO.service[Redis]
-            key  <- uuid
-            arg  <- uuid
-            lua   = ";"
-            error = "Error compiling script (new function): user_script:1: unexpected symbol near ';'"
-            res  <- redis.eval(lua, Chunk(key), Chunk(arg)).returning[String].either
+            key   <- uuid
+            arg   <- uuid
+            lua    = ";"
+            error  = "Error compiling script (new function): user_script:1: unexpected symbol near ';'"
+            res   <- redis.eval(lua, Chunk(key), Chunk(arg)).returning[String].either
           } yield assert(res)(isLeft(isSubtype[ProtocolError](hasField("message", _.message, equalTo(error)))))
         },
         test("throw an error if couldn't decode resp value") {
@@ -76,15 +76,15 @@ trait ScriptingSpec extends BaseSpec {
           implicit val decoder: Output[String] = errorOutput(customError)
           for {
             redis <- ZIO.service[Redis]
-            key <- uuid
-            arg <- uuid
-            lua  = ""
-            res <- redis.eval(lua, Chunk(key), Chunk(arg)).returning[String](decoder).either
+            key   <- uuid
+            arg   <- uuid
+            lua    = ""
+            res   <- redis.eval(lua, Chunk(key), Chunk(arg)).returning[String](decoder).either
           } yield assert(res)(isLeft(isSubtype[ProtocolError](hasField("message", _.message, equalTo(customError)))))
         },
         test("throw custom error from script") {
           for {
-            redis <- ZIO.service[Redis]
+            redis  <- ZIO.service[Redis]
             key    <- uuid
             arg    <- uuid
             myError = "My Error"
@@ -97,8 +97,8 @@ trait ScriptingSpec extends BaseSpec {
         test("put boolean and return existence of key") {
           for {
             redis <- ZIO.service[Redis]
-            key <- uuid
-            arg  = true
+            key   <- uuid
+            arg    = true
             lua =
               """
                 |redis.call('set',KEYS[1],ARGV[1])
@@ -110,7 +110,7 @@ trait ScriptingSpec extends BaseSpec {
         },
         test("take strings return strings") {
           for {
-            redis <- ZIO.service[Redis]
+            redis   <- ZIO.service[Redis]
             keyHash <- uuid
             key1    <- uuid.map(_ + s"{$keyHash}")
             key2    <- uuid.map(_ + s"{$keyHash}")
@@ -127,7 +127,7 @@ trait ScriptingSpec extends BaseSpec {
           val emptyInput: Chunk[String] = Chunk.empty
           for {
             redis <- ZIO.service[Redis]
-            res <- redis.eval(lua, emptyInput, emptyInput).returning[CustomData]
+            res   <- redis.eval(lua, emptyInput, emptyInput).returning[CustomData]
           } yield assertTrue(res == expected)
         },
         test("throw an error if couldn't decode resp value") {
@@ -135,16 +135,16 @@ trait ScriptingSpec extends BaseSpec {
           implicit val decoder: Output[String] = errorOutput(customError)
           for {
             redis <- ZIO.service[Redis]
-            key <- uuid
-            arg <- uuid
-            lua  = ""
-            sha <- redis.scriptLoad(lua)
-            res <- redis.evalSha(sha, Chunk(key), Chunk(arg)).returning[String](decoder).either
+            key   <- uuid
+            arg   <- uuid
+            lua    = ""
+            sha   <- redis.scriptLoad(lua)
+            res   <- redis.evalSha(sha, Chunk(key), Chunk(arg)).returning[String](decoder).either
           } yield assert(res)(isLeft(isSubtype[ProtocolError](hasField("message", _.message, equalTo(customError)))))
         },
         test("throw custom error from script") {
           for {
-            redis <- ZIO.service[Redis]
+            redis  <- ZIO.service[Redis]
             key    <- uuid
             arg    <- uuid
             myError = "My Error"
@@ -159,7 +159,7 @@ trait ScriptingSpec extends BaseSpec {
           val emptyInput: Chunk[String] = Chunk.empty
           for {
             redis <- ZIO.service[Redis]
-            res <- redis.evalSha(lua, emptyInput, emptyInput).returning[String].either
+            res   <- redis.evalSha(lua, emptyInput, emptyInput).returning[String].either
           } yield assert(res)(isLeft(isSubtype[NoScript](hasField("message", _.message, equalTo(error)))))
         }
       ),
@@ -169,9 +169,9 @@ trait ScriptingSpec extends BaseSpec {
           val lua2 = """return "2""""
           for {
             redis <- ZIO.service[Redis]
-            sha1 <- redis.scriptLoad(lua1)
-            sha2 <- redis.scriptLoad(lua2)
-            res  <- redis.scriptExists(sha1, sha2)
+            sha1  <- redis.scriptLoad(lua1)
+            sha2  <- redis.scriptLoad(lua2)
+            res   <- redis.scriptExists(sha1, sha2)
           } yield assertTrue(res == Chunk(true, true))
         },
         test("return false if scripts aren't found in the cache") {
@@ -179,7 +179,7 @@ trait ScriptingSpec extends BaseSpec {
           val lua2 = """return "2""""
           for {
             redis <- ZIO.service[Redis]
-            res <- redis.scriptExists(lua1, lua2)
+            res   <- redis.scriptExists(lua1, lua2)
           } yield assertTrue(res == Chunk(false, false))
         }
       ),
@@ -188,7 +188,7 @@ trait ScriptingSpec extends BaseSpec {
           val lua = """return "1""""
           for {
             redis <- ZIO.service[Redis]
-            sha <- redis.scriptLoad(lua)
+            sha   <- redis.scriptLoad(lua)
           } yield assert(sha)(isSubtype[String](anything))
         },
         test("throw an error when incorrect script was sent") {
@@ -196,7 +196,7 @@ trait ScriptingSpec extends BaseSpec {
           val error = "Error compiling script (new function): user_script:1: unexpected symbol near ';'"
           for {
             redis <- ZIO.service[Redis]
-            sha <- redis.scriptLoad(lua).either
+            sha   <- redis.scriptLoad(lua).either
           } yield assert(sha)(isLeft(isSubtype[ProtocolError](hasField("message", _.message, equalTo(error)))))
         }
       )

--- a/redis/src/test/scala/zio/redis/SetsSpec.scala
+++ b/redis/src/test/scala/zio/redis/SetsSpec.scala
@@ -12,726 +12,810 @@ trait SetsSpec extends BaseSpec {
       suite("sAdd")(
         test("to empty set") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
-            added <- sAdd(key, "hello")
+            added <- redis.sAdd(key, "hello")
           } yield assert(added)(equalTo(1L))
         },
         test("to the non-empty set") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
-            _     <- sAdd(key, "hello")
-            added <- sAdd(key, "world")
+            _     <- redis.sAdd(key, "hello")
+            added <- redis.sAdd(key, "world")
           } yield assert(added)(equalTo(1L))
         },
         test("existing element to set") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
-            _     <- sAdd(key, "hello")
-            added <- sAdd(key, "hello")
+            _     <- redis.sAdd(key, "hello")
+            added <- redis.sAdd(key, "hello")
           } yield assert(added)(equalTo(0L))
         },
         test("multiple elements to set") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
-            added <- sAdd(key, "a", "b", "c")
+            added <- redis.sAdd(key, "a", "b", "c")
           } yield assert(added)(equalTo(3L))
         },
         test("error when not set") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
             value <- uuid
-            _     <- set(key, value)
-            added <- sAdd(key, "hello").either
+            _     <- redis.set(key, value)
+            added <- redis.sAdd(key, "hello").either
           } yield assert(added)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
       suite("sCard")(
         test("non-empty set") {
           for {
-            key  <- uuid
-            _    <- sAdd(key, "hello")
-            card <- sCard(key)
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.sAdd(key, "hello")
+            card  <- redis.sCard(key)
           } yield assert(card)(equalTo(1L))
         },
         test("0 when key doesn't exist") {
           for {
+            redis   <- ZIO.service[Redis]
             unknown <- uuid
-            card    <- sCard(unknown)
+            card    <- redis.sCard(unknown)
           } yield assert(card)(equalTo(0L))
         },
         test("error when not set") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
             value <- uuid
-            _     <- set(key, value)
-            card  <- sCard(key).either
+            _     <- redis.set(key, value)
+            card  <- redis.sCard(key).either
           } yield assert(card)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
       suite("sDiff")(
         test("two non-empty sets") {
           for {
+            redis  <- ZIO.service[Redis]
             first  <- uuid
             second <- uuid
-            _      <- sAdd(first, "a", "b", "c", "d")
-            _      <- sAdd(second, "a", "c")
-            diff   <- sDiff(first, second).returning[String]
+            _      <- redis.sAdd(first, "a", "b", "c", "d")
+            _      <- redis.sAdd(second, "a", "c")
+            diff   <- redis.sDiff(first, second).returning[String]
           } yield assert(diff)(hasSameElements(Chunk("b", "d")))
         },
         test("non-empty set and empty set") {
           for {
+            redis    <- ZIO.service[Redis]
             nonEmpty <- uuid
             empty    <- uuid
-            _        <- sAdd(nonEmpty, "a", "b")
-            diff     <- sDiff(nonEmpty, empty).returning[String]
+            _        <- redis.sAdd(nonEmpty, "a", "b")
+            diff     <- redis.sDiff(nonEmpty, empty).returning[String]
           } yield assert(diff)(hasSameElements(Chunk("a", "b")))
         },
         test("empty set and non-empty set") {
           for {
+            redis    <- ZIO.service[Redis]
             empty    <- uuid
             nonEmpty <- uuid
-            _        <- sAdd(nonEmpty, "a", "b")
-            diff     <- sDiff(empty, nonEmpty).returning[String]
+            _        <- redis.sAdd(nonEmpty, "a", "b")
+            diff     <- redis.sDiff(empty, nonEmpty).returning[String]
           } yield assert(diff)(isEmpty)
         },
         test("empty when both sets are empty") {
           for {
+            redis  <- ZIO.service[Redis]
             first  <- uuid
             second <- uuid
-            diff   <- sDiff(first, second).returning[String]
+            diff   <- redis.sDiff(first, second).returning[String]
           } yield assert(diff)(isEmpty)
         },
         test("non-empty set with multiple non-empty sets") {
           for {
+            redis  <- ZIO.service[Redis]
             first  <- uuid
             second <- uuid
             third  <- uuid
-            _      <- sAdd(first, "a", "b", "c", "d")
-            _      <- sAdd(second, "b", "d")
-            _      <- sAdd(third, "b", "c")
-            diff   <- sDiff(first, second, third).returning[String]
+            _      <- redis.sAdd(first, "a", "b", "c", "d")
+            _      <- redis.sAdd(second, "b", "d")
+            _      <- redis.sAdd(third, "b", "c")
+            diff   <- redis.sDiff(first, second, third).returning[String]
           } yield assert(diff)(hasSameElements(Chunk("a")))
         },
         test("error when first parameter is not set") {
           for {
+            redis  <- ZIO.service[Redis]
             first  <- uuid
             second <- uuid
             value  <- uuid
-            _      <- set(first, value)
-            diff   <- sDiff(first, second).returning[String].either
+            _      <- redis.set(first, value)
+            diff   <- redis.sDiff(first, second).returning[String].either
           } yield assert(diff)(isLeft(isSubtype[WrongType](anything)))
         },
         test("error when second parameter is not set") {
           for {
+            redis  <- ZIO.service[Redis]
             first  <- uuid
             second <- uuid
             value  <- uuid
-            _      <- set(second, value)
-            diff   <- sDiff(first, second).returning[String].either
+            _      <- redis.set(second, value)
+            diff   <- redis.sDiff(first, second).returning[String].either
           } yield assert(diff)(isLeft(isSubtype[WrongType](anything)))
         }
       ) @@ clusterExecutorUnsupported,
       suite("sDiffStore")(
         test("two non-empty sets") {
           for {
+            redis  <- ZIO.service[Redis]
             dest   <- uuid
             first  <- uuid
             second <- uuid
-            _      <- sAdd(first, "a", "b", "c", "d")
-            _      <- sAdd(second, "a", "c")
-            card   <- sDiffStore(dest, first, second)
+            _      <- redis.sAdd(first, "a", "b", "c", "d")
+            _      <- redis.sAdd(second, "a", "c")
+            card   <- redis.sDiffStore(dest, first, second)
           } yield assert(card)(equalTo(2L))
         },
         test("non-empty set and empty set") {
           for {
+            redis    <- ZIO.service[Redis]
             dest     <- uuid
             nonEmpty <- uuid
             empty    <- uuid
-            _        <- sAdd(nonEmpty, "a", "b")
-            card     <- sDiffStore(dest, nonEmpty, empty)
+            _        <- redis.sAdd(nonEmpty, "a", "b")
+            card     <- redis.sDiffStore(dest, nonEmpty, empty)
           } yield assert(card)(equalTo(2L))
         },
         test("empty set and non-empty set") {
           for {
+            redis    <- ZIO.service[Redis]
             dest     <- uuid
             empty    <- uuid
             nonEmpty <- uuid
-            _        <- sAdd(nonEmpty, "a", "b")
-            card     <- sDiffStore(dest, empty, nonEmpty)
+            _        <- redis.sAdd(nonEmpty, "a", "b")
+            card     <- redis.sDiffStore(dest, empty, nonEmpty)
           } yield assert(card)(equalTo(0L))
         },
         test("empty when both sets are empty") {
           for {
+            redis  <- ZIO.service[Redis]
             dest   <- uuid
             first  <- uuid
             second <- uuid
-            card   <- sDiffStore(dest, first, second)
+            card   <- redis.sDiffStore(dest, first, second)
           } yield assert(card)(equalTo(0L))
         },
         test("non-empty set with multiple non-empty sets") {
           for {
+            redis  <- ZIO.service[Redis]
             dest   <- uuid
             first  <- uuid
             second <- uuid
             third  <- uuid
-            _      <- sAdd(first, "a", "b", "c", "d")
-            _      <- sAdd(second, "b", "d")
-            _      <- sAdd(third, "b", "c")
-            card   <- sDiffStore(dest, first, second, third)
+            _      <- redis.sAdd(first, "a", "b", "c", "d")
+            _      <- redis.sAdd(second, "b", "d")
+            _      <- redis.sAdd(third, "b", "c")
+            card   <- redis.sDiffStore(dest, first, second, third)
           } yield assert(card)(equalTo(1L))
         },
         test("error when first parameter is not set") {
           for {
+            redis  <- ZIO.service[Redis]
             dest   <- uuid
             first  <- uuid
             second <- uuid
             value  <- uuid
-            _      <- set(first, value)
-            card   <- sDiffStore(dest, first, second).either
+            _      <- redis.set(first, value)
+            card   <- redis.sDiffStore(dest, first, second).either
           } yield assert(card)(isLeft(isSubtype[WrongType](anything)))
         },
         test("error when second parameter is not set") {
           for {
+            redis  <- ZIO.service[Redis]
             dest   <- uuid
             first  <- uuid
             second <- uuid
             value  <- uuid
-            _      <- set(second, value)
-            card   <- sDiffStore(dest, first, second).either
+            _      <- redis.set(second, value)
+            card   <- redis.sDiffStore(dest, first, second).either
           } yield assert(card)(isLeft(isSubtype[WrongType](anything)))
         }
       ) @@ clusterExecutorUnsupported,
       suite("sInter")(
         test("two non-empty sets") {
           for {
+            redis  <- ZIO.service[Redis]
             first  <- uuid
             second <- uuid
-            _      <- sAdd(first, "a", "b", "c", "d")
-            _      <- sAdd(second, "a", "c", "e")
-            inter  <- sInter(first, second).returning[String]
+            _      <- redis.sAdd(first, "a", "b", "c", "d")
+            _      <- redis.sAdd(second, "a", "c", "e")
+            inter  <- redis.sInter(first, second).returning[String]
           } yield assert(inter)(hasSameElements(Chunk("a", "c")))
         },
         test("empty when one of the sets is empty") {
           for {
+            redis    <- ZIO.service[Redis]
             nonEmpty <- uuid
             empty    <- uuid
-            _        <- sAdd(nonEmpty, "a", "b")
-            inter    <- sInter(nonEmpty, empty).returning[String]
+            _        <- redis.sAdd(nonEmpty, "a", "b")
+            inter    <- redis.sInter(nonEmpty, empty).returning[String]
           } yield assert(inter)(isEmpty)
         },
         test("empty when both sets are empty") {
           for {
+            redis  <- ZIO.service[Redis]
             first  <- uuid
             second <- uuid
-            inter  <- sInter(first, second).returning[String]
+            inter  <- redis.sInter(first, second).returning[String]
           } yield assert(inter)(isEmpty)
         },
         test("non-empty set with multiple non-empty sets") {
           for {
+            redis  <- ZIO.service[Redis]
             first  <- uuid
             second <- uuid
             third  <- uuid
-            _      <- sAdd(first, "a", "b", "c", "d")
-            _      <- sAdd(second, "b", "d")
-            _      <- sAdd(third, "b", "c")
-            inter  <- sInter(first, second, third).returning[String]
+            _      <- redis.sAdd(first, "a", "b", "c", "d")
+            _      <- redis.sAdd(second, "b", "d")
+            _      <- redis.sAdd(third, "b", "c")
+            inter  <- redis.sInter(first, second, third).returning[String]
           } yield assert(inter)(hasSameElements(Chunk("b")))
         },
         test("error when first parameter is not set") {
           for {
+            redis  <- ZIO.service[Redis]
             first  <- uuid
             second <- uuid
             value  <- uuid
-            _      <- set(first, value)
-            inter  <- sInter(first, second).returning[String].either
+            _      <- redis.set(first, value)
+            inter  <- redis.sInter(first, second).returning[String].either
           } yield assert(inter)(isLeft(isSubtype[WrongType](anything)))
         },
         test("error when empty first set and second parameter is not set") {
           for {
+            redis  <- ZIO.service[Redis]
             first  <- uuid
             second <- uuid
             value  <- uuid
-            _      <- set(second, value)
-            inter  <- sInter(first, second).returning[String].either
+            _      <- redis.set(second, value)
+            inter  <- redis.sInter(first, second).returning[String].either
           } yield assert(inter)(isLeft(isSubtype[WrongType](anything)))
         },
         test("error with non-empty first set and second parameter is not set") {
           for {
+            redis  <- ZIO.service[Redis]
             first  <- uuid
             second <- uuid
             value  <- uuid
-            _      <- sAdd(first, "a")
-            _      <- set(second, value)
-            inter  <- sInter(first, second).returning[String].either
+            _      <- redis.sAdd(first, "a")
+            _      <- redis.set(second, value)
+            inter  <- redis.sInter(first, second).returning[String].either
           } yield assert(inter)(isLeft(isSubtype[WrongType](anything)))
         }
       ) @@ clusterExecutorUnsupported,
       suite("sInterStore")(
         test("two non-empty sets") {
           for {
+            redis  <- ZIO.service[Redis]
             dest   <- uuid
             first  <- uuid
             second <- uuid
-            _      <- sAdd(first, "a", "b", "c", "d")
-            _      <- sAdd(second, "a", "c", "e")
-            card   <- sInterStore(dest, first, second)
+            _      <- redis.sAdd(first, "a", "b", "c", "d")
+            _      <- redis.sAdd(second, "a", "c", "e")
+            card   <- redis.sInterStore(dest, first, second)
           } yield assert(card)(equalTo(2L))
         },
         test("empty when one of the sets is empty") {
           for {
+            redis    <- ZIO.service[Redis]
             dest     <- uuid
             nonEmpty <- uuid
             empty    <- uuid
-            _        <- sAdd(nonEmpty, "a", "b")
-            card     <- sInterStore(dest, nonEmpty, empty)
+            _        <- redis.sAdd(nonEmpty, "a", "b")
+            card     <- redis.sInterStore(dest, nonEmpty, empty)
           } yield assert(card)(equalTo(0L))
         },
         test("empty when both sets are empty") {
           for {
+            redis  <- ZIO.service[Redis]
             dest   <- uuid
             first  <- uuid
             second <- uuid
-            card   <- sInterStore(dest, first, second)
+            card   <- redis.sInterStore(dest, first, second)
           } yield assert(card)(equalTo(0L))
         },
         test("non-empty set with multiple non-empty sets") {
           for {
+            redis  <- ZIO.service[Redis]
             dest   <- uuid
             first  <- uuid
             second <- uuid
             third  <- uuid
-            _      <- sAdd(first, "a", "b", "c", "d")
-            _      <- sAdd(second, "b", "d")
-            _      <- sAdd(third, "b", "c")
-            card   <- sInterStore(dest, first, second, third)
+            _      <- redis.sAdd(first, "a", "b", "c", "d")
+            _      <- redis.sAdd(second, "b", "d")
+            _      <- redis.sAdd(third, "b", "c")
+            card   <- redis.sInterStore(dest, first, second, third)
           } yield assert(card)(equalTo(1L))
         },
         test("error when first parameter is not set") {
           for {
+            redis  <- ZIO.service[Redis]
             dest   <- uuid
             first  <- uuid
             second <- uuid
             value  <- uuid
-            _      <- set(first, value)
-            card   <- sInterStore(dest, first, second).either
+            _      <- redis.set(first, value)
+            card   <- redis.sInterStore(dest, first, second).either
           } yield assert(card)(isLeft(isSubtype[WrongType](anything)))
         },
         test("error when empty first set and second parameter is not set") {
           for {
+            redis  <- ZIO.service[Redis]
             dest   <- uuid
             first  <- uuid
             second <- uuid
             value  <- uuid
-            _      <- set(second, value)
-            card   <- sInterStore(dest, first, second).either
+            _      <- redis.set(second, value)
+            card   <- redis.sInterStore(dest, first, second).either
           } yield assert(card)(isLeft(isSubtype[WrongType](anything)))
         },
         test("error with non-empty first set and second parameter is not set") {
           for {
+            redis  <- ZIO.service[Redis]
             dest   <- uuid
             first  <- uuid
             second <- uuid
             value  <- uuid
-            _      <- sAdd(first, "a")
-            _      <- set(second, value)
-            card   <- sInterStore(dest, first, second).either
+            _      <- redis.sAdd(first, "a")
+            _      <- redis.set(second, value)
+            card   <- redis.sInterStore(dest, first, second).either
           } yield assert(card)(isLeft(isSubtype[WrongType](anything)))
         }
       ) @@ clusterExecutorUnsupported,
       suite("sIsMember")(
         test("actual element of the non-empty set") {
           for {
+            redis    <- ZIO.service[Redis]
             key      <- uuid
-            _        <- sAdd(key, "a", "b", "c")
-            isMember <- sIsMember(key, "b")
+            _        <- redis.sAdd(key, "a", "b", "c")
+            isMember <- redis.sIsMember(key, "b")
           } yield assert(isMember)(isTrue)
         },
         test("element that is not present in the set") {
           for {
+            redis    <- ZIO.service[Redis]
             key      <- uuid
-            _        <- sAdd(key, "a", "b", "c")
-            isMember <- sIsMember(key, "unknown")
+            _        <- redis.sAdd(key, "a", "b", "c")
+            isMember <- redis.sIsMember(key, "unknown")
           } yield assert(isMember)(isFalse)
         },
         test("of an empty set") {
           for {
+            redis    <- ZIO.service[Redis]
             key      <- uuid
-            isMember <- sIsMember(key, "a")
+            isMember <- redis.sIsMember(key, "a")
           } yield assert(isMember)(isFalse)
         },
         test("when not set") {
           for {
+            redis    <- ZIO.service[Redis]
             key      <- uuid
             value    <- uuid
-            _        <- set(key, value)
-            isMember <- sIsMember(key, "a").either
+            _        <- redis.set(key, value)
+            isMember <- redis.sIsMember(key, "a").either
           } yield assert(isMember)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
       suite("sMembers")(
         test("non-empty set") {
           for {
+            redis   <- ZIO.service[Redis]
             key     <- uuid
-            _       <- sAdd(key, "a", "b", "c")
-            members <- sMembers(key).returning[String]
+            _       <- redis.sAdd(key, "a", "b", "c")
+            members <- redis.sMembers(key).returning[String]
           } yield assert(members)(hasSameElements(Chunk("a", "b", "c")))
         },
         test("empty set") {
           for {
+            redis   <- ZIO.service[Redis]
             key     <- uuid
-            members <- sMembers(key).returning[String]
+            members <- redis.sMembers(key).returning[String]
           } yield assert(members)(isEmpty)
         },
         test("when not set") {
           for {
+            redis   <- ZIO.service[Redis]
             key     <- uuid
             value   <- uuid
-            _       <- set(key, value)
-            members <- sMembers(key).returning[String].either
+            _       <- redis.set(key, value)
+            members <- redis.sMembers(key).returning[String].either
           } yield assert(members)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
       suite("sMove")(
         test("from non-empty source to non-empty destination") {
           for {
+            redis <- ZIO.service[Redis]
             src   <- uuid
             dest  <- uuid
-            _     <- sAdd(src, "a", "b", "c")
-            _     <- sAdd(dest, "d", "e", "f")
-            moved <- sMove(src, dest, "a")
+            _     <- redis.sAdd(src, "a", "b", "c")
+            _     <- redis.sAdd(dest, "d", "e", "f")
+            moved <- redis.sMove(src, dest, "a")
           } yield assert(moved)(isTrue)
         },
         test("from non-empty source to empty destination") {
           for {
+            redis <- ZIO.service[Redis]
             src   <- uuid
             dest  <- uuid
-            _     <- sAdd(src, "a", "b", "c")
-            moved <- sMove(src, dest, "a")
+            _     <- redis.sAdd(src, "a", "b", "c")
+            moved <- redis.sMove(src, dest, "a")
           } yield assert(moved)(isTrue)
         },
         test("element already present in the destination") {
           for {
+            redis <- ZIO.service[Redis]
             src   <- uuid
             dest  <- uuid
-            _     <- sAdd(src, "a", "b", "c")
-            _     <- sAdd(dest, "a", "d", "e")
-            moved <- sMove(src, dest, "a")
+            _     <- redis.sAdd(src, "a", "b", "c")
+            _     <- redis.sAdd(dest, "a", "d", "e")
+            moved <- redis.sMove(src, dest, "a")
           } yield assert(moved)(isTrue)
         },
         test("from empty source to non-empty destination") {
           for {
+            redis <- ZIO.service[Redis]
             src   <- uuid
             dest  <- uuid
-            _     <- sAdd(dest, "b", "c")
-            moved <- sMove(src, dest, "a")
+            _     <- redis.sAdd(dest, "b", "c")
+            moved <- redis.sMove(src, dest, "a")
           } yield assert(moved)(isFalse)
         },
         test("non-existent element") {
           for {
+            redis <- ZIO.service[Redis]
             src   <- uuid
             dest  <- uuid
-            _     <- sAdd(src, "a", "b")
-            _     <- sAdd(dest, "c", "d")
-            moved <- sMove(src, dest, "unknown")
+            _     <- redis.sAdd(src, "a", "b")
+            _     <- redis.sAdd(dest, "c", "d")
+            moved <- redis.sMove(src, dest, "unknown")
           } yield assert(moved)(isFalse)
         },
         test("from empty source to not set destination") {
           for {
+            redis <- ZIO.service[Redis]
             src   <- uuid
             dest  <- uuid
             value <- uuid
-            _     <- set(dest, value)
-            moved <- sMove(src, dest, "unknown")
+            _     <- redis.set(dest, value)
+            moved <- redis.sMove(src, dest, "unknown")
           } yield assert(moved)(isFalse)
         },
         test("error when non-empty source and not set destination") {
           for {
+            redis <- ZIO.service[Redis]
             src   <- uuid
             dest  <- uuid
             value <- uuid
-            _     <- sAdd(src, "a", "b", "c")
-            _     <- set(dest, value)
-            moved <- sMove(src, dest, "a").either
+            _     <- redis.sAdd(src, "a", "b", "c")
+            _     <- redis.set(dest, value)
+            moved <- redis.sMove(src, dest, "a").either
           } yield assert(moved)(isLeft(isSubtype[WrongType](anything)))
         },
         test("error when not set source to non-empty destination") {
           for {
+            redis <- ZIO.service[Redis]
             src   <- uuid
             dest  <- uuid
             value <- uuid
-            _     <- set(src, value)
-            _     <- sAdd(dest, "a", "b", "c")
-            moved <- sMove(src, dest, "a").either
+            _     <- redis.set(src, value)
+            _     <- redis.sAdd(dest, "a", "b", "c")
+            moved <- redis.sMove(src, dest, "a").either
           } yield assert(moved)(isLeft(isSubtype[WrongType](anything)))
         }
       ) @@ clusterExecutorUnsupported,
       suite("sPop")(
         test("one element from non-empty set") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- sAdd(key, "a", "b", "c")
-            popped <- sPop(key).returning[String]
+            _      <- redis.sAdd(key, "a", "b", "c")
+            popped <- redis.sPop(key).returning[String]
           } yield assert(popped)(isNonEmpty)
         },
         test("one element from an empty set") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            popped <- sPop(key).returning[String]
+            popped <- redis.sPop(key).returning[String]
           } yield assert(popped)(isEmpty)
         },
         test("error when poping one element from not set") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
             value  <- uuid
-            _      <- set(key, value)
-            popped <- sPop(key).returning[String].either
+            _      <- redis.set(key, value)
+            popped <- redis.sPop(key).returning[String].either
           } yield assert(popped)(isLeft(isSubtype[WrongType](anything)))
         },
         test("multiple elements from non-empty set") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- sAdd(key, "a", "b", "c")
-            popped <- sPop(key, Some(2L)).returning[String]
+            _      <- redis.sAdd(key, "a", "b", "c")
+            popped <- redis.sPop(key, Some(2L)).returning[String]
           } yield assert(popped)(hasSize(equalTo(2)))
         },
         test("more elements then there is in non-empty set") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- sAdd(key, "a", "b", "c")
-            popped <- sPop(key, Some(5L)).returning[String]
+            _      <- redis.sAdd(key, "a", "b", "c")
+            popped <- redis.sPop(key, Some(5L)).returning[String]
           } yield assert(popped)(hasSize(equalTo(3)))
         },
         test("multiple elements from empty set") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            popped <- sPop(key, Some(3)).returning[String]
+            popped <- redis.sPop(key, Some(3)).returning[String]
           } yield assert(popped)(isEmpty)
         },
         test("error when poping multiple elements from not set") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
             value  <- uuid
-            _      <- set(key, value)
-            popped <- sPop(key, Some(3)).returning[String].either
+            _      <- redis.set(key, value)
+            popped <- redis.sPop(key, Some(3)).returning[String].either
           } yield assert(popped)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
       suite("sRandMember")(
         test("one element from non-empty set") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- sAdd(key, "a", "b", "c")
-            member <- sRandMember(key).returning[String]
+            _      <- redis.sAdd(key, "a", "b", "c")
+            member <- redis.sRandMember(key).returning[String]
           } yield assert(member)(hasSize(equalTo(1)))
         },
         test("one element from an empty set") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            member <- sRandMember(key).returning[String]
+            member <- redis.sRandMember(key).returning[String]
           } yield assert(member)(isEmpty)
         },
         test("error when one element from not set") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
             value  <- uuid
-            _      <- set(key, value)
-            member <- sRandMember(key).returning[String].either
+            _      <- redis.set(key, value)
+            member <- redis.sRandMember(key).returning[String].either
           } yield assert(member)(isLeft(isSubtype[WrongType](anything)))
         },
         test("multiple elements from non-empty set") {
           for {
+            redis   <- ZIO.service[Redis]
             key     <- uuid
-            _       <- sAdd(key, "a", "b", "c")
-            members <- sRandMember(key, Some(2L)).returning[String]
+            _       <- redis.sAdd(key, "a", "b", "c")
+            members <- redis.sRandMember(key, Some(2L)).returning[String]
           } yield assert(members)(hasSize(equalTo(2)))
         },
         test("more elements than there is present in the non-empty set") {
           for {
+            redis   <- ZIO.service[Redis]
             key     <- uuid
-            _       <- sAdd(key, "a", "b", "c")
-            members <- sRandMember(key, Some(5L)).returning[String]
+            _       <- redis.sAdd(key, "a", "b", "c")
+            members <- redis.sRandMember(key, Some(5L)).returning[String]
           } yield assert(members)(hasSize(equalTo(3)))
         },
         test("multiple elements from an empty set") {
           for {
+            redis   <- ZIO.service[Redis]
             key     <- uuid
-            members <- sRandMember(key, Some(3L)).returning[String]
+            members <- redis.sRandMember(key, Some(3L)).returning[String]
           } yield assert(members)(isEmpty)
         },
         test("repeated elements from non-empty set") {
           for {
+            redis   <- ZIO.service[Redis]
             key     <- uuid
-            _       <- sAdd(key, "a", "b", "c")
-            members <- sRandMember(key, Some(-5L)).returning[String]
+            _       <- redis.sAdd(key, "a", "b", "c")
+            members <- redis.sRandMember(key, Some(-5L)).returning[String]
           } yield assert(members)(hasSize(equalTo(5)))
         },
         test("repeated elements from an empty set") {
           for {
+            redis   <- ZIO.service[Redis]
             key     <- uuid
-            members <- sRandMember(key, Some(-3L)).returning[String]
+            members <- redis.sRandMember(key, Some(-3L)).returning[String]
           } yield assert(members)(isEmpty)
         },
         test("error multiple elements from not set") {
           for {
+            redis   <- ZIO.service[Redis]
             key     <- uuid
             value   <- uuid
-            _       <- set(key, value)
-            members <- sRandMember(key, Some(3L)).returning[String].either
+            _       <- redis.set(key, value)
+            members <- redis.sRandMember(key, Some(3L)).returning[String].either
           } yield assert(members)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
       suite("sRem")(
         test("existing elements from non-empty set") {
           for {
+            redis   <- ZIO.service[Redis]
             key     <- uuid
-            _       <- sAdd(key, "a", "b", "c")
-            removed <- sRem(key, "b", "c")
+            _       <- redis.sAdd(key, "a", "b", "c")
+            removed <- redis.sRem(key, "b", "c")
           } yield assert(removed)(equalTo(2L))
         },
         test("when just part of elements are present in the non-empty set") {
           for {
+            redis   <- ZIO.service[Redis]
             key     <- uuid
-            _       <- sAdd(key, "a", "b", "c")
-            removed <- sRem(key, "b", "d")
+            _       <- redis.sAdd(key, "a", "b", "c")
+            removed <- redis.sRem(key, "b", "d")
           } yield assert(removed)(equalTo(1L))
         },
         test("when none of the elements are present in the non-empty set") {
           for {
+            redis   <- ZIO.service[Redis]
             key     <- uuid
-            _       <- sAdd(key, "a", "b", "c")
-            removed <- sRem(key, "d", "e")
+            _       <- redis.sAdd(key, "a", "b", "c")
+            removed <- redis.sRem(key, "d", "e")
           } yield assert(removed)(equalTo(0L))
         },
         test("elements from an empty set") {
           for {
+            redis   <- ZIO.service[Redis]
             key     <- uuid
-            removed <- sRem(key, "a", "b")
+            removed <- redis.sRem(key, "a", "b")
           } yield assert(removed)(equalTo(0L))
         },
         test("elements from not set") {
           for {
+            redis   <- ZIO.service[Redis]
             key     <- uuid
             value   <- uuid
-            _       <- set(key, value)
-            removed <- sRem(key, "a", "b").either
+            _       <- redis.set(key, value)
+            removed <- redis.sRem(key, "a", "b").either
           } yield assert(removed)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
       suite("sUnion")(
         test("two non-empty sets") {
           for {
+            redis  <- ZIO.service[Redis]
             first  <- uuid
             second <- uuid
-            _      <- sAdd(first, "a", "b", "c", "d")
-            _      <- sAdd(second, "a", "c", "e")
-            union  <- sUnion(first, second).returning[String]
+            _      <- redis.sAdd(first, "a", "b", "c", "d")
+            _      <- redis.sAdd(second, "a", "c", "e")
+            union  <- redis.sUnion(first, second).returning[String]
           } yield assert(union)(hasSameElements(Chunk("a", "b", "c", "d", "e")))
         },
         test("equal to the non-empty set when the other one is empty") {
           for {
+            redis    <- ZIO.service[Redis]
             nonEmpty <- uuid
             empty    <- uuid
-            _        <- sAdd(nonEmpty, "a", "b")
-            union    <- sUnion(nonEmpty, empty).returning[String]
+            _        <- redis.sAdd(nonEmpty, "a", "b")
+            union    <- redis.sUnion(nonEmpty, empty).returning[String]
           } yield assert(union)(hasSameElements(Chunk("a", "b")))
         },
         test("empty when both sets are empty") {
           for {
+            redis  <- ZIO.service[Redis]
             first  <- uuid
             second <- uuid
-            union  <- sUnion(first, second).returning[String]
+            union  <- redis.sUnion(first, second).returning[String]
           } yield assert(union)(isEmpty)
         },
         test("non-empty set with multiple non-empty sets") {
           for {
+            redis  <- ZIO.service[Redis]
             first  <- uuid
             second <- uuid
             third  <- uuid
-            _      <- sAdd(first, "a", "b", "c", "d")
-            _      <- sAdd(second, "b", "d")
-            _      <- sAdd(third, "b", "c", "e")
-            union  <- sUnion(first, second, third).returning[String]
+            _      <- redis.sAdd(first, "a", "b", "c", "d")
+            _      <- redis.sAdd(second, "b", "d")
+            _      <- redis.sAdd(third, "b", "c", "e")
+            union  <- redis.sUnion(first, second, third).returning[String]
           } yield assert(union)(hasSameElements(Chunk("a", "b", "c", "d", "e")))
         },
         test("error when first parameter is not set") {
           for {
+            redis  <- ZIO.service[Redis]
             first  <- uuid
             second <- uuid
             value  <- uuid
-            _      <- set(first, value)
-            union  <- sUnion(first, second).returning[String].either
+            _      <- redis.set(first, value)
+            union  <- redis.sUnion(first, second).returning[String].either
           } yield assert(union)(isLeft(isSubtype[WrongType](anything)))
         },
         test("error when the first parameter is set and the second parameter is not set") {
           for {
+            redis  <- ZIO.service[Redis]
             first  <- uuid
             second <- uuid
             value  <- uuid
-            _      <- sAdd(first, "a")
-            _      <- set(second, value)
-            union  <- sUnion(first, second).returning[String].either
+            _      <- redis.sAdd(first, "a")
+            _      <- redis.set(second, value)
+            union  <- redis.sUnion(first, second).returning[String].either
           } yield assert(union)(isLeft(isSubtype[WrongType](anything)))
         }
       ) @@ clusterExecutorUnsupported,
       suite("sUnionStore")(
         test("two non-empty sets") {
           for {
+            redis  <- ZIO.service[Redis]
             first  <- uuid
             second <- uuid
             dest   <- uuid
-            _      <- sAdd(first, "a", "b", "c", "d")
-            _      <- sAdd(second, "a", "c", "e")
-            card   <- sUnionStore(dest, first, second)
+            _      <- redis.sAdd(first, "a", "b", "c", "d")
+            _      <- redis.sAdd(second, "a", "c", "e")
+            card   <- redis.sUnionStore(dest, first, second)
           } yield assert(card)(equalTo(5L))
         },
         test("equal to the non-empty set when the other one is empty") {
           for {
+            redis    <- ZIO.service[Redis]
             nonEmpty <- uuid
             empty    <- uuid
             dest     <- uuid
-            _        <- sAdd(nonEmpty, "a", "b")
-            card     <- sUnionStore(dest, nonEmpty, empty)
+            _        <- redis.sAdd(nonEmpty, "a", "b")
+            card     <- redis.sUnionStore(dest, nonEmpty, empty)
           } yield assert(card)(equalTo(2L))
         },
         test("empty when both sets are empty") {
           for {
+            redis  <- ZIO.service[Redis]
             first  <- uuid
             second <- uuid
             dest   <- uuid
-            card   <- sUnionStore(dest, first, second)
+            card   <- redis.sUnionStore(dest, first, second)
           } yield assert(card)(equalTo(0L))
         },
         test("non-empty set with multiple non-empty sets") {
           for {
+            redis  <- ZIO.service[Redis]
             first  <- uuid
             second <- uuid
             third  <- uuid
             dest   <- uuid
-            _      <- sAdd(first, "a", "b", "c", "d")
-            _      <- sAdd(second, "b", "d")
-            _      <- sAdd(third, "b", "c", "e")
-            card   <- sUnionStore(dest, first, second, third)
+            _      <- redis.sAdd(first, "a", "b", "c", "d")
+            _      <- redis.sAdd(second, "b", "d")
+            _      <- redis.sAdd(third, "b", "c", "e")
+            card   <- redis.sUnionStore(dest, first, second, third)
           } yield assert(card)(equalTo(5L))
         },
         test("error when the first parameter is not set") {
           for {
+            redis  <- ZIO.service[Redis]
             first  <- uuid
             second <- uuid
             dest   <- uuid
             value  <- uuid
-            _      <- set(first, value)
-            card   <- sUnionStore(dest, first, second).either
+            _      <- redis.set(first, value)
+            card   <- redis.sUnionStore(dest, first, second).either
           } yield assert(card)(isLeft(isSubtype[WrongType](anything)))
         },
         test("error when the first parameter is set and the second parameter is not set") {
           for {
+            redis  <- ZIO.service[Redis]
             first  <- uuid
             second <- uuid
             dest   <- uuid
             value  <- uuid
-            _      <- sAdd(first, "a")
-            _      <- set(second, value)
-            card   <- sUnionStore(dest, first, second).either
+            _      <- redis.sAdd(first, "a")
+            _      <- redis.set(second, value)
+            card   <- redis.sUnionStore(dest, first, second).either
           } yield assert(card)(isLeft(isSubtype[WrongType](anything)))
         }
       ) @@ clusterExecutorUnsupported,
@@ -739,15 +823,17 @@ trait SetsSpec extends BaseSpec {
         test("non-empty set") {
           val testData = NonEmptyChunk("a", "b", "c")
           for {
+            redis   <- ZIO.service[Redis]
             key     <- uuid
-            _       <- sAdd(key, testData.head, testData.tail: _*)
+            _       <- redis.sAdd(key, testData.head, testData.tail: _*)
             members <- scanAll(key)
           } yield assert(members.toSet)(equalTo(testData.toSet))
         },
         test("empty set") {
           for {
+            redis            <- ZIO.service[Redis]
             key              <- uuid
-            scan             <- sScan(key, 0L).returning[String]
+            scan             <- redis.sScan(key, 0L).returning[String]
             (cursor, members) = scan
           } yield assert(cursor)(isZero) &&
             assert(members)(isEmpty)
@@ -755,25 +841,28 @@ trait SetsSpec extends BaseSpec {
         test("with match over non-empty set") {
           val testData = NonEmptyChunk("one", "two", "three")
           for {
+            redis   <- ZIO.service[Redis]
             key     <- uuid
-            _       <- sAdd(key, testData.head, testData.tail: _*)
+            _       <- redis.sAdd(key, testData.head, testData.tail: _*)
             members <- scanAll(key, Some("t[a-z]*"))
           } yield assert(members.toSet)(equalTo(Set("two", "three")))
         },
         test("with count over non-empty set") {
           val testData = NonEmptyChunk("a", "b", "c", "d", "e")
           for {
+            redis   <- ZIO.service[Redis]
             key     <- uuid
-            _       <- sAdd(key, testData.head, testData.tail: _*)
+            _       <- redis.sAdd(key, testData.head, testData.tail: _*)
             members <- scanAll(key, None, Some(Count(3L)))
           } yield assert(members.toSet)(equalTo(testData.toSet))
         },
         test("error when not set") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
             value <- uuid
-            _     <- set(key, value)
-            scan  <- sScan(key, 0L).returning[String].either
+            _     <- redis.set(key, value)
+            scan  <- redis.sScan(key, 0L).returning[String].either
           } yield assert(scan)(isLeft(isSubtype[WrongType](anything)))
         }
       )
@@ -786,7 +875,7 @@ trait SetsSpec extends BaseSpec {
   ): ZIO[Redis, RedisError, Chunk[String]] =
     ZStream
       .paginateChunkZIO(0L) { cursor =>
-        sScan(key, cursor, pattern, count).returning[String].map {
+        ZIO.serviceWithZIO[Redis](_.sScan(key, cursor, pattern, count).returning[String]).map {
           case (nc, nm) if nc == 0 => (nm, None)
           case (nc, nm)            => (nm, Some(nc))
         }

--- a/redis/src/test/scala/zio/redis/SortedSetsSpec.scala
+++ b/redis/src/test/scala/zio/redis/SortedSetsSpec.scala
@@ -353,10 +353,11 @@ trait SortedSetsSpec extends BaseSpec {
       suite("zInter")(
         test("two non-empty sets") {
           for {
-            redis   <- ZIO.service[Redis]
-            first   <- uuid
-            second  <- uuid
-            _       <- redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
+            redis  <- ZIO.service[Redis]
+            first  <- uuid
+            second <- uuid
+            _ <-
+              redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
             _       <- redis.zAdd(second)(MemberScore(1d, "a"), MemberScore(3d, "c"), MemberScore(5d, "e"))
             members <- redis.zInter(2, first, second)().returning[String]
           } yield assert(members)(equalTo(Chunk("a", "c")))
@@ -380,11 +381,12 @@ trait SortedSetsSpec extends BaseSpec {
         },
         test("non-empty set with multiple non-empty sets") {
           for {
-            redis   <- ZIO.service[Redis]
-            first   <- uuid
-            second  <- uuid
-            third   <- uuid
-            _       <- redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
+            redis  <- ZIO.service[Redis]
+            first  <- uuid
+            second <- uuid
+            third  <- uuid
+            _ <-
+              redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
             _       <- redis.zAdd(second)(MemberScore(2d, "b"), MemberScore(2d, "b"), MemberScore(4d, "d"))
             _       <- redis.zAdd(third)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"))
             members <- redis.zInter(3, first, second, third)().returning[String]
@@ -477,10 +479,11 @@ trait SortedSetsSpec extends BaseSpec {
       suite("zInterWithScores")(
         test("two non-empty sets") {
           for {
-            redis   <- ZIO.service[Redis]
-            first   <- uuid
-            second  <- uuid
-            _       <- redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
+            redis  <- ZIO.service[Redis]
+            first  <- uuid
+            second <- uuid
+            _ <-
+              redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
             _       <- redis.zAdd(second)(MemberScore(1d, "a"), MemberScore(3d, "c"), MemberScore(5d, "e"))
             members <- redis.zInterWithScores(2, first, second)().returning[String]
           } yield assert(members)(equalTo(Chunk(MemberScore(2d, "a"), MemberScore(6d, "c"))))
@@ -504,11 +507,12 @@ trait SortedSetsSpec extends BaseSpec {
         },
         test("non-empty set with multiple non-empty sets") {
           for {
-            redis   <- ZIO.service[Redis]
-            first   <- uuid
-            second  <- uuid
-            third   <- uuid
-            _       <- redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
+            redis  <- ZIO.service[Redis]
+            first  <- uuid
+            second <- uuid
+            third  <- uuid
+            _ <-
+              redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
             _       <- redis.zAdd(second)(MemberScore(2d, "b"), MemberScore(2d, "b"), MemberScore(4d, "d"))
             _       <- redis.zAdd(third)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"))
             members <- redis.zInterWithScores(3, first, second, third)().returning[String]
@@ -574,7 +578,8 @@ trait SortedSetsSpec extends BaseSpec {
             second <- uuid
             _      <- redis.zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
             _      <- redis.zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
-            members <- redis.zInterWithScores(2, first, second)(weights = Some(::(2.0, List(3.0, 5.0))))
+            members <- redis
+                         .zInterWithScores(2, first, second)(weights = Some(::(2.0, List(3.0, 5.0))))
                          .returning[String]
                          .either
           } yield assert(members)(isLeft(isSubtype[ProtocolError](anything)))
@@ -607,9 +612,10 @@ trait SortedSetsSpec extends BaseSpec {
             dest   <- uuid
             first  <- uuid
             second <- uuid
-            _      <- redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
-            _      <- redis.zAdd(second)(MemberScore(1d, "a"), MemberScore(3d, "c"), MemberScore(5d, "e"))
-            card   <- redis.zInterStore(s"out_$dest", 2, first, second)()
+            _ <-
+              redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
+            _    <- redis.zAdd(second)(MemberScore(1d, "a"), MemberScore(3d, "c"), MemberScore(5d, "e"))
+            card <- redis.zInterStore(s"out_$dest", 2, first, second)()
           } yield assert(card)(equalTo(2L))
         },
         test("empty when one of the sets is empty") {
@@ -638,10 +644,11 @@ trait SortedSetsSpec extends BaseSpec {
             first  <- uuid
             second <- uuid
             third  <- uuid
-            _      <- redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
-            _      <- redis.zAdd(second)(MemberScore(2d, "b"), MemberScore(2d, "b"), MemberScore(4d, "d"))
-            _      <- redis.zAdd(third)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"))
-            card   <- redis.zInterStore(dest, 3, first, second, third)()
+            _ <-
+              redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
+            _    <- redis.zAdd(second)(MemberScore(2d, "b"), MemberScore(2d, "b"), MemberScore(4d, "d"))
+            _    <- redis.zAdd(third)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"))
+            card <- redis.zInterStore(dest, 3, first, second, third)()
           } yield assert(card)(equalTo(1L))
         },
         test("error when first parameter is not set") {
@@ -882,10 +889,12 @@ trait SortedSetsSpec extends BaseSpec {
                    MemberScore(5d, "NewYork"),
                    MemberScore(6d, "Seoul")
                  )
-            result <- redis.zRangeByLex(
-                        key,
-                        LexRange(min = LexMinimum.Open("London"), max = LexMaximum.Closed("Seoul"))
-                      ).returning[String]
+            result <- redis
+                        .zRangeByLex(
+                          key,
+                          LexRange(min = LexMinimum.Open("London"), max = LexMaximum.Closed("Seoul"))
+                        )
+                        .returning[String]
           } yield assert(result.toList)(equalTo(List("Paris")))
         },
         test("non-empty set with limit") {
@@ -900,18 +909,21 @@ trait SortedSetsSpec extends BaseSpec {
                    MemberScore(5d, "NewYork"),
                    MemberScore(6d, "Seoul")
                  )
-            result <- redis.zRangeByLex(
-                        key,
-                        LexRange(min = LexMinimum.Unbounded, max = LexMaximum.Unbounded),
-                        Some(Limit(2, 3))
-                      ).returning[String]
+            result <- redis
+                        .zRangeByLex(
+                          key,
+                          LexRange(min = LexMinimum.Unbounded, max = LexMaximum.Unbounded),
+                          Some(Limit(2, 3))
+                        )
+                        .returning[String]
           } yield assert(result.toList)(equalTo(List("Paris", "Tokyo", "NewYork")))
         },
         test("empty set") {
           for {
             redis <- ZIO.service[Redis]
             key   <- uuid
-            result <- redis.zRangeByLex(key, LexRange(min = LexMinimum.Open("A"), max = LexMaximum.Closed("Z")))
+            result <- redis
+                        .zRangeByLex(key, LexRange(min = LexMinimum.Open("A"), max = LexMaximum.Closed("Z")))
                         .returning[String]
           } yield assert(result.toList)(isEmpty)
         }
@@ -929,7 +941,8 @@ trait SortedSetsSpec extends BaseSpec {
                    MemberScore(1800d, "MicroSoft"),
                    MemberScore(2500d, "LG")
                  )
-            result <- redis.zRangeByScore(key, ScoreRange(ScoreMinimum.Open(1500), ScoreMaximum.Closed(1900)))
+            result <- redis
+                        .zRangeByScore(key, ScoreRange(ScoreMinimum.Open(1500), ScoreMaximum.Closed(1900)))
                         .returning[String]
           } yield assert(result.toList)(equalTo(List("Samsung", "MicroSoft", "Micromax")))
         },
@@ -953,7 +966,8 @@ trait SortedSetsSpec extends BaseSpec {
           for {
             redis <- ZIO.service[Redis]
             key   <- uuid
-            result <- redis.zRangeByScore(key, ScoreRange(ScoreMinimum.Open(1500), ScoreMaximum.Closed(1900)))
+            result <- redis
+                        .zRangeByScore(key, ScoreRange(ScoreMinimum.Open(1500), ScoreMaximum.Closed(1900)))
                         .returning[String]
           } yield assert(result.toList)(isEmpty)
         }
@@ -986,7 +1000,8 @@ trait SortedSetsSpec extends BaseSpec {
             lg         = MemberScore(2500d, "LG")
             _         <- redis.zAdd(key)(samsung, nokia, micromax, sunsui, microSoft, lg)
             scoreRange = ScoreRange(ScoreMinimum.Open(1500), ScoreMaximum.Closed(2500))
-            result    <- redis.zRangeByScoreWithScores(key, scoreRange, Some(Limit(offset = 1, count = 3))).returning[String]
+            result <-
+              redis.zRangeByScoreWithScores(key, scoreRange, Some(Limit(offset = 1, count = 3))).returning[String]
           } yield assert(result.toList)(equalTo(List(microSoft, micromax, nokia)))
         },
         test("empty set") {
@@ -1069,8 +1084,10 @@ trait SortedSetsSpec extends BaseSpec {
                    MemberScore(0d, "Kolkata"),
                    MemberScore(0d, "Chennai")
                  )
-            remResult <- redis.zRemRangeByLex(key, LexRange(min = LexMinimum.Open("Hyderabad"), max = LexMaximum.Closed("Mumbai")))
-            rangeResult <- redis.zRangeByLex(key, LexRange(min = LexMinimum.Unbounded, max = LexMaximum.Unbounded))
+            remResult <-
+              redis.zRemRangeByLex(key, LexRange(min = LexMinimum.Open("Hyderabad"), max = LexMaximum.Closed("Mumbai")))
+            rangeResult <- redis
+                             .zRangeByLex(key, LexRange(min = LexMinimum.Unbounded, max = LexMaximum.Unbounded))
                              .returning[String]
           } yield assert(rangeResult.toList)(equalTo(List("Chennai", "Delhi", "Hyderabad"))) &&
             assert(remResult)(equalTo(2L))
@@ -1079,7 +1096,8 @@ trait SortedSetsSpec extends BaseSpec {
           for {
             redis <- ZIO.service[Redis]
             key   <- uuid
-            remResult <- redis.zRemRangeByLex(key, LexRange(min = LexMinimum.Open("Hyderabad"), max = LexMaximum.Closed("Mumbai")))
+            remResult <-
+              redis.zRemRangeByLex(key, LexRange(min = LexMinimum.Open("Hyderabad"), max = LexMaximum.Closed("Mumbai")))
           } yield assert(remResult)(equalTo(0L))
         }
       ),
@@ -1120,16 +1138,19 @@ trait SortedSetsSpec extends BaseSpec {
                    MemberScore(50d, "Kolkata"),
                    MemberScore(65d, "Chennai")
                  )
-            remResult <- redis.zRemRangeByScore(key, ScoreRange(min = ScoreMinimum.Infinity, max = ScoreMaximum.Open(70)))
-            rangeResult <- redis.zRangeByScore(key, ScoreRange(min = ScoreMinimum.Infinity, max = ScoreMaximum.Infinity))
+            remResult <-
+              redis.zRemRangeByScore(key, ScoreRange(min = ScoreMinimum.Infinity, max = ScoreMaximum.Open(70)))
+            rangeResult <- redis
+                             .zRangeByScore(key, ScoreRange(min = ScoreMinimum.Infinity, max = ScoreMaximum.Infinity))
                              .returning[String]
           } yield assert(rangeResult.toList)(equalTo(List("Hyderabad", "Delhi"))) && assert(remResult)(equalTo(3L))
         },
         test("empty set") {
           for {
-            redis     <- ZIO.service[Redis]
-            key       <- uuid
-            remResult <- redis.zRemRangeByScore(key, ScoreRange(min = ScoreMinimum.Infinity, max = ScoreMaximum.Open(70)))
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            remResult <-
+              redis.zRemRangeByScore(key, ScoreRange(min = ScoreMinimum.Infinity, max = ScoreMaximum.Open(70)))
           } yield assert(remResult)(equalTo(0L))
         }
       ),
@@ -1443,10 +1464,11 @@ trait SortedSetsSpec extends BaseSpec {
       suite("zUnion")(
         test("two non-empty sets") {
           for {
-            redis   <- ZIO.service[Redis]
-            first   <- uuid
-            second  <- uuid
-            _       <- redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
+            redis  <- ZIO.service[Redis]
+            first  <- uuid
+            second <- uuid
+            _ <-
+              redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
             _       <- redis.zAdd(second)(MemberScore(1d, "a"), MemberScore(3d, "c"), MemberScore(5d, "e"))
             members <- redis.zUnion(2, first, second)().returning[String]
           } yield assert(members)(equalTo(Chunk("a", "b", "d", "e", "c")))
@@ -1470,11 +1492,12 @@ trait SortedSetsSpec extends BaseSpec {
         },
         test("non-empty set with multiple non-empty sets") {
           for {
-            redis   <- ZIO.service[Redis]
-            first   <- uuid
-            second  <- uuid
-            third   <- uuid
-            _       <- redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
+            redis  <- ZIO.service[Redis]
+            first  <- uuid
+            second <- uuid
+            third  <- uuid
+            _ <-
+              redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
             _       <- redis.zAdd(second)(MemberScore(2, "b"), MemberScore(4d, "d"))
             _       <- redis.zAdd(third)(MemberScore(2, "b"), MemberScore(3d, "c"), MemberScore(5d, "e"))
             members <- redis.zUnion(3, first, second, third)().returning[String]
@@ -1565,10 +1588,11 @@ trait SortedSetsSpec extends BaseSpec {
       suite("zUnionWithScores")(
         test("two non-empty sets") {
           for {
-            redis   <- ZIO.service[Redis]
-            first   <- uuid
-            second  <- uuid
-            _       <- redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
+            redis  <- ZIO.service[Redis]
+            first  <- uuid
+            second <- uuid
+            _ <-
+              redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
             _       <- redis.zAdd(second)(MemberScore(1d, "a"), MemberScore(3d, "c"), MemberScore(5d, "e"))
             members <- redis.zUnionWithScores(2, first, second)().returning[String]
           } yield assert(members)(
@@ -1602,11 +1626,12 @@ trait SortedSetsSpec extends BaseSpec {
         },
         test("non-empty set with multiple non-empty sets") {
           for {
-            redis   <- ZIO.service[Redis]
-            first   <- uuid
-            second  <- uuid
-            third   <- uuid
-            _       <- redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
+            redis  <- ZIO.service[Redis]
+            first  <- uuid
+            second <- uuid
+            third  <- uuid
+            _ <-
+              redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
             _       <- redis.zAdd(second)(MemberScore(2, "b"), MemberScore(4d, "d"))
             _       <- redis.zAdd(third)(MemberScore(2, "b"), MemberScore(3d, "c"), MemberScore(5d, "e"))
             members <- redis.zUnionWithScores(3, first, second, third)().returning[String]
@@ -1722,12 +1747,13 @@ trait SortedSetsSpec extends BaseSpec {
         },
         test("parameter weights provided along with aggregate") {
           for {
-            redis   <- ZIO.service[Redis]
-            first   <- uuid
-            second  <- uuid
-            _       <- redis.zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
-            _       <- redis.zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
-            members <- redis.zUnionWithScores(2, first, second)(Some(::(2, List(3))), Some(Aggregate.Max)).returning[String]
+            redis  <- ZIO.service[Redis]
+            first  <- uuid
+            second <- uuid
+            _      <- redis.zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
+            _      <- redis.zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
+            members <-
+              redis.zUnionWithScores(2, first, second)(Some(::(2, List(3))), Some(Aggregate.Max)).returning[String]
           } yield assert(members)(
             equalTo(
               Chunk(
@@ -1747,9 +1773,10 @@ trait SortedSetsSpec extends BaseSpec {
             first  <- uuid
             second <- uuid
             dest   <- uuid
-            _      <- redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
-            _      <- redis.zAdd(second)(MemberScore(1d, "a"), MemberScore(3d, "c"), MemberScore(5d, "e"))
-            card   <- redis.zUnionStore(dest, 2, first, second)()
+            _ <-
+              redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
+            _    <- redis.zAdd(second)(MemberScore(1d, "a"), MemberScore(3d, "c"), MemberScore(5d, "e"))
+            card <- redis.zUnionStore(dest, 2, first, second)()
           } yield assert(card)(equalTo(5L))
         },
         test("equal to the non-empty set when the other one is empty") {
@@ -1778,10 +1805,11 @@ trait SortedSetsSpec extends BaseSpec {
             second <- uuid
             third  <- uuid
             dest   <- uuid
-            _      <- redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
-            _      <- redis.zAdd(second)(MemberScore(2, "b"), MemberScore(4d, "d"))
-            _      <- redis.zAdd(third)(MemberScore(2, "b"), MemberScore(3d, "c"), MemberScore(5d, "e"))
-            card   <- redis.zUnionStore(dest, 3, first, second, third)()
+            _ <-
+              redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
+            _    <- redis.zAdd(second)(MemberScore(2, "b"), MemberScore(4d, "d"))
+            _    <- redis.zAdd(third)(MemberScore(2, "b"), MemberScore(3d, "c"), MemberScore(5d, "e"))
+            card <- redis.zUnionStore(dest, 3, first, second, third)()
           } yield assert(card)(equalTo(5L))
         },
         test("error when the first parameter is not set") {
@@ -1880,8 +1908,9 @@ trait SortedSetsSpec extends BaseSpec {
             redis     <- ZIO.service[Redis]
             first     <- uuid
             notExists <- uuid
-            _         <- redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
-            ret       <- redis.zRandMember(notExists).returning[String]
+            _ <-
+              redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
+            ret <- redis.zRandMember(notExists).returning[String]
           } yield assert(ret)(isNone)
         },
         test("key does not exist with count") {
@@ -1889,24 +1918,27 @@ trait SortedSetsSpec extends BaseSpec {
             redis     <- ZIO.service[Redis]
             first     <- uuid
             notExists <- uuid
-            _         <- redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
-            ret       <- redis.zRandMember(notExists, 1).returning[String]
+            _ <-
+              redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
+            ret <- redis.zRandMember(notExists, 1).returning[String]
           } yield assert(ret)(isEmpty)
         },
         test("get an element") {
           for {
             redis <- ZIO.service[Redis]
             first <- uuid
-            _     <- redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
-            ret   <- redis.zRandMember(first).returning[String]
+            _ <-
+              redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
+            ret <- redis.zRandMember(first).returning[String]
           } yield assert(ret)(isSome)
         },
         test("get elements with count") {
           for {
             redis <- ZIO.service[Redis]
             first <- uuid
-            _     <- redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
-            ret   <- redis.zRandMember(first, 2).returning[String]
+            _ <-
+              redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
+            ret <- redis.zRandMember(first, 2).returning[String]
           } yield assert(ret)(hasSize(equalTo(2)))
         }
       ),
@@ -1916,16 +1948,18 @@ trait SortedSetsSpec extends BaseSpec {
             redis     <- ZIO.service[Redis]
             first     <- uuid
             notExists <- uuid
-            _         <- redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
-            ret       <- redis.zRandMemberWithScores(notExists, 1).returning[String]
+            _ <-
+              redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
+            ret <- redis.zRandMemberWithScores(notExists, 1).returning[String]
           } yield assert(ret)(isEmpty)
         },
         test("get elements with count") {
           for {
             redis <- ZIO.service[Redis]
             first <- uuid
-            _     <- redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
-            ret   <- redis.zRandMemberWithScores(first, 2).returning[String]
+            _ <-
+              redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
+            ret <- redis.zRandMemberWithScores(first, 2).returning[String]
           } yield assert(ret)(hasSize(equalTo(2)))
         }
       )

--- a/redis/src/test/scala/zio/redis/SortedSetsSpec.scala
+++ b/redis/src/test/scala/zio/redis/SortedSetsSpec.scala
@@ -12,6 +12,7 @@ trait SortedSetsSpec extends BaseSpec {
       suite("bzPopMax")(
         test("non-empty set")(
           for {
+            redis   <- ZIO.service[Redis]
             key1    <- uuid
             key2    <- uuid
             key3    <- uuid
@@ -21,23 +22,25 @@ trait SortedSetsSpec extends BaseSpec {
             london   = MemberScore(3d, "London")
             paris    = MemberScore(4d, "Paris")
             tokyo    = MemberScore(5d, "Tokyo")
-            _       <- zAdd(key1)(delhi, tokyo)
-            _       <- zAdd(key2)(mumbai, paris)
-            _       <- zAdd(key3)(london)
-            result  <- bzPopMax(duration, key1, key2, key3).returning[String]
+            _       <- redis.zAdd(key1)(delhi, tokyo)
+            _       <- redis.zAdd(key2)(mumbai, paris)
+            _       <- redis.zAdd(key3)(london)
+            result  <- redis.bzPopMax(duration, key1, key2, key3).returning[String]
           } yield assert(result)(isSome(equalTo((key1, tokyo))))
         ),
         test("empty set")(
           for {
+            redis   <- ZIO.service[Redis]
             key     <- uuid
             duration = Duration.fromMillis(1000)
-            result  <- bzPopMax(duration, key).returning[String]
+            result  <- redis.bzPopMax(duration, key).returning[String]
           } yield assert(result)(isNone)
         )
       ) @@ clusterExecutorUnsupported,
       suite("bzPopMin")(
         test("non-empty set")(
           for {
+            redis   <- ZIO.service[Redis]
             key1    <- uuid
             key2    <- uuid
             key3    <- uuid
@@ -45,756 +48,833 @@ trait SortedSetsSpec extends BaseSpec {
             delhi    = MemberScore(1d, "Delhi")
             london   = MemberScore(3d, "London")
             paris    = MemberScore(4d, "Paris")
-            _       <- zAdd(key2)(delhi, paris)
-            _       <- zAdd(key3)(london)
-            result  <- bzPopMin(duration, key1, key2, key3).returning[String]
+            _       <- redis.zAdd(key2)(delhi, paris)
+            _       <- redis.zAdd(key3)(london)
+            result  <- redis.bzPopMin(duration, key1, key2, key3).returning[String]
           } yield assert(result)(isSome(equalTo((key2, delhi))))
         ),
         test("empty set")(
           for {
+            redis   <- ZIO.service[Redis]
             key     <- uuid
             duration = Duration.fromMillis(1000)
-            result  <- bzPopMin(duration, key).returning[String]
+            result  <- redis.bzPopMin(duration, key).returning[String]
           } yield assert(result)(isNone)
         )
       ) @@ clusterExecutorUnsupported,
       suite("zAdd")(
         test("to empty set") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
             value <- uuid
-            added <- zAdd(key)(MemberScore(1d, value))
+            added <- redis.zAdd(key)(MemberScore(1d, value))
           } yield assert(added)(equalTo(1L))
         },
         test("to the non-empty set") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
             value  <- uuid
-            _      <- zAdd(key)(MemberScore(1d, value))
+            _      <- redis.zAdd(key)(MemberScore(1d, value))
             value2 <- uuid
-            added  <- zAdd(key)(MemberScore(2d, value2))
+            added  <- redis.zAdd(key)(MemberScore(2d, value2))
           } yield assert(added)(equalTo(1L))
         },
         test("existing element to set") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
             value <- uuid
-            _     <- zAdd(key)(MemberScore(1d, value))
-            added <- zAdd(key)(MemberScore(2d, value))
+            _     <- redis.zAdd(key)(MemberScore(1d, value))
+            added <- redis.zAdd(key)(MemberScore(2d, value))
           } yield assert(added)(equalTo(0L))
         },
         test("multiple elements to set") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
-            added <- zAdd(key)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"))
+            added <- redis.zAdd(key)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"))
           } yield assert(added)(equalTo(3L))
         },
         test("error when not set") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
             value <- uuid
-            _     <- set(key, value)
-            added <- zAdd(key)(MemberScore(1d, value)).either
+            _     <- redis.set(key, value)
+            added <- redis.zAdd(key)(MemberScore(1d, value)).either
           } yield assert(added)(isLeft(isSubtype[WrongType](anything)))
         },
         test("NX - do not to update existing members, only add new") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- zAdd(key)(MemberScore(1d, "v1"))
-            _      <- zAdd(key)(MemberScore(2d, "v2"))
-            added  <- zAdd(key, Some(Update.SetNew))(MemberScore(3d, "v3"), MemberScore(22d, "v2"))
-            result <- zRange(key, 0 to -1).returning[String]
+            _      <- redis.zAdd(key)(MemberScore(1d, "v1"))
+            _      <- redis.zAdd(key)(MemberScore(2d, "v2"))
+            added  <- redis.zAdd(key, Some(Update.SetNew))(MemberScore(3d, "v3"), MemberScore(22d, "v2"))
+            result <- redis.zRange(key, 0 to -1).returning[String]
           } yield assert(added)(equalTo(1L)) && assert(result.toList)(equalTo(List("v1", "v2", "v3")))
         },
         test("XX - update existing members, not add new") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- zAdd(key)(MemberScore(1d, "v1"))
-            _      <- zAdd(key)(MemberScore(2d, "v2"))
-            added  <- zAdd(key, Some(Update.SetExisting))(MemberScore(3d, "v3"), MemberScore(11d, "v1"))
-            result <- zRange(key, 0 to -1).returning[String]
+            _      <- redis.zAdd(key)(MemberScore(1d, "v1"))
+            _      <- redis.zAdd(key)(MemberScore(2d, "v2"))
+            added  <- redis.zAdd(key, Some(Update.SetExisting))(MemberScore(3d, "v3"), MemberScore(11d, "v1"))
+            result <- redis.zRange(key, 0 to -1).returning[String]
           } yield assert(added)(equalTo(0L)) && assert(result.toList)(equalTo(List("v2", "v1")))
         },
         test("CH - return number of new and updated members") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- zAdd(key)(MemberScore(1d, "v1"))
-            _      <- zAdd(key)(MemberScore(2d, "v2"))
-            added  <- zAdd(key, change = Some(Changed))(MemberScore(3d, "v3"), MemberScore(11d, "v1"))
-            result <- zRange(key, 0 to -1).returning[String]
+            _      <- redis.zAdd(key)(MemberScore(1d, "v1"))
+            _      <- redis.zAdd(key)(MemberScore(2d, "v2"))
+            added  <- redis.zAdd(key, change = Some(Changed))(MemberScore(3d, "v3"), MemberScore(11d, "v1"))
+            result <- redis.zRange(key, 0 to -1).returning[String]
           } yield assert(added)(equalTo(2L)) && assert(result.toList)(equalTo(List("v2", "v3", "v1")))
         },
         test("LT - return number of new members") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- zAdd(key)(MemberScore(3d, "v1"))
-            _      <- zAdd(key)(MemberScore(4d, "v2"))
-            added  <- zAdd(key, update = Some(Update.SetLessThan))(MemberScore(1d, "v3"), MemberScore(2d, "v1"))
-            result <- zRange(key, 0 to -1).returning[String]
+            _      <- redis.zAdd(key)(MemberScore(3d, "v1"))
+            _      <- redis.zAdd(key)(MemberScore(4d, "v2"))
+            added  <- redis.zAdd(key, update = Some(Update.SetLessThan))(MemberScore(1d, "v3"), MemberScore(2d, "v1"))
+            result <- redis.zRange(key, 0 to -1).returning[String]
           } yield assert(added)(equalTo(1L)) && assert(result.toList)(equalTo(List("v3", "v1", "v2")))
         },
         test("GT - return number of new members") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- zAdd(key)(MemberScore(1d, "v1"))
-            _      <- zAdd(key)(MemberScore(2d, "v2"))
-            added  <- zAdd(key, update = Some(Update.SetGreaterThan))(MemberScore(1d, "v3"), MemberScore(3d, "v1"))
-            result <- zRange(key, 0 to -1).returning[String]
+            _      <- redis.zAdd(key)(MemberScore(1d, "v1"))
+            _      <- redis.zAdd(key)(MemberScore(2d, "v2"))
+            added  <- redis.zAdd(key, update = Some(Update.SetGreaterThan))(MemberScore(1d, "v3"), MemberScore(3d, "v1"))
+            result <- redis.zRange(key, 0 to -1).returning[String]
           } yield assert(added)(equalTo(1L)) && assert(result.toList)(equalTo(List("v3", "v2", "v1")))
         },
         test("GT CH - return number of new and updated members") {
           for {
-            key <- uuid
-            _   <- zAdd(key)(MemberScore(1d, "v1"))
-            _   <- zAdd(key)(MemberScore(2d, "v2"))
-            added <- zAdd(key, update = Some(Update.SetGreaterThan), change = Some(Changed))(
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.zAdd(key)(MemberScore(1d, "v1"))
+            _     <- redis.zAdd(key)(MemberScore(2d, "v2"))
+            added <- redis.zAdd(key, update = Some(Update.SetGreaterThan), change = Some(Changed))(
                        MemberScore(1d, "v3"),
                        MemberScore(3d, "v1")
                      )
-            result <- zRange(key, 0 to -1).returning[String]
+            result <- redis.zRange(key, 0 to -1).returning[String]
           } yield assert(added)(equalTo(2L)) && assert(result.toList)(equalTo(List("v3", "v2", "v1")))
         },
         test("INCR - increment by score") {
           for {
+            redis    <- ZIO.service[Redis]
             key      <- uuid
-            _        <- zAdd(key)(MemberScore(1d, "v1"))
-            _        <- zAdd(key)(MemberScore(2d, "v2"))
-            newScore <- zAddWithIncr(key)(Increment, MemberScore(3d, "v1"))
-            result   <- zRange(key, 0 to -1).returning[String]
+            _        <- redis.zAdd(key)(MemberScore(1d, "v1"))
+            _        <- redis.zAdd(key)(MemberScore(2d, "v2"))
+            newScore <- redis.zAddWithIncr(key)(Increment, MemberScore(3d, "v1"))
+            result   <- redis.zRange(key, 0 to -1).returning[String]
           } yield assert(newScore)(equalTo(Some(4.0))) && assert(result.toList)(equalTo(List("v2", "v1")))
         }
       ),
       suite("zCard")(
         test("non-empty set") {
           for {
-            key  <- uuid
-            _    <- zAdd(key)(MemberScore(1d, "hello"), MemberScore(2d, "world"))
-            card <- zCard(key)
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.zAdd(key)(MemberScore(1d, "hello"), MemberScore(2d, "world"))
+            card  <- redis.zCard(key)
           } yield assert(card)(equalTo(2L))
         },
         test("0 when key doesn't exist") {
-          assertZIO(zCard("unknownSet"))(equalTo(0L))
+          assertZIO(ZIO.serviceWithZIO[Redis](_.zCard("unknownSet")))(equalTo(0L))
         },
         test("error when not set") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
             value <- uuid
-            _     <- set(key, value)
-            card  <- zCard(key).either
+            _     <- redis.set(key, value)
+            card  <- redis.zCard(key).either
           } yield assert(card)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
       suite("zCount")(
         test("non-empty set") {
           for {
-            key <- uuid
-            _ <- zAdd(key)(
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _ <- redis.zAdd(key)(
                    MemberScore(1d, "a"),
                    MemberScore(2d, "b"),
                    MemberScore(3d, "c"),
                    MemberScore(4d, "d"),
                    MemberScore(5d, "e")
                  )
-            count <- zCount(key, 0 to 3)
+            count <- redis.zCount(key, 0 to 3)
           } yield assert(count)(equalTo(3L))
         },
         test("empty set") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
-            count <- zCount(key, 0 to 3)
+            count <- redis.zCount(key, 0 to 3)
           } yield assert(count)(equalTo(0L))
         }
       ),
       suite("zDiff")(
         test("empty sets") {
           for {
-            key1 <- uuid
-            key2 <- uuid
-            key3 <- uuid
-            diff <- zDiff(3, key1, key2, key3).returning[String]
+            redis <- ZIO.service[Redis]
+            key1  <- uuid
+            key2  <- uuid
+            key3  <- uuid
+            diff  <- redis.zDiff(3, key1, key2, key3).returning[String]
           } yield assert(diff)(isEmpty)
         },
         test("non-empty set with empty set") {
           for {
-            key1 <- uuid
-            key2 <- uuid
-            _    <- zAdd(key1)(MemberScore(1d, "a"), MemberScore(2d, "b"))
-            diff <- zDiff(2, key1, key2).returning[String]
+            redis <- ZIO.service[Redis]
+            key1  <- uuid
+            key2  <- uuid
+            _     <- redis.zAdd(key1)(MemberScore(1d, "a"), MemberScore(2d, "b"))
+            diff  <- redis.zDiff(2, key1, key2).returning[String]
           } yield assert(diff)(hasSameElements(Chunk("a", "b")))
         },
         test("non-empty sets") {
           for {
-            key1 <- uuid
-            key2 <- uuid
-            _    <- zAdd(key1)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"))
-            _    <- zAdd(key2)(MemberScore(1d, "a"), MemberScore(2d, "b"))
-            diff <- zDiff(2, key1, key2).returning[String]
+            redis <- ZIO.service[Redis]
+            key1  <- uuid
+            key2  <- uuid
+            _     <- redis.zAdd(key1)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"))
+            _     <- redis.zAdd(key2)(MemberScore(1d, "a"), MemberScore(2d, "b"))
+            diff  <- redis.zDiff(2, key1, key2).returning[String]
           } yield assert(diff)(hasSameElements(Chunk("c")))
         }
       ) @@ clusterExecutorUnsupported,
       suite("zDiffWithScores")(
         test("empty sets") {
           for {
-            key1 <- uuid
-            key2 <- uuid
-            key3 <- uuid
-            diff <- zDiffWithScores(3, key1, key2, key3).returning[String]
+            redis <- ZIO.service[Redis]
+            key1  <- uuid
+            key2  <- uuid
+            key3  <- uuid
+            diff  <- redis.zDiffWithScores(3, key1, key2, key3).returning[String]
           } yield assert(diff)(isEmpty)
         },
         test("non-empty set with empty set") {
           for {
-            key1 <- uuid
-            key2 <- uuid
-            _    <- zAdd(key1)(MemberScore(1d, "a"), MemberScore(2d, "b"))
-            diff <- zDiffWithScores(2, key1, key2).returning[String]
+            redis <- ZIO.service[Redis]
+            key1  <- uuid
+            key2  <- uuid
+            _     <- redis.zAdd(key1)(MemberScore(1d, "a"), MemberScore(2d, "b"))
+            diff  <- redis.zDiffWithScores(2, key1, key2).returning[String]
           } yield assert(diff)(hasSameElements(Chunk(MemberScore(1d, "a"), MemberScore(2d, "b"))))
         },
         test("non-empty sets") {
           for {
-            key1 <- uuid
-            key2 <- uuid
-            _    <- zAdd(key1)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"))
-            _    <- zAdd(key2)(MemberScore(1d, "a"), MemberScore(2d, "b"))
-            diff <- zDiffWithScores(2, key1, key2).returning[String]
+            redis <- ZIO.service[Redis]
+            key1  <- uuid
+            key2  <- uuid
+            _     <- redis.zAdd(key1)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"))
+            _     <- redis.zAdd(key2)(MemberScore(1d, "a"), MemberScore(2d, "b"))
+            diff  <- redis.zDiffWithScores(2, key1, key2).returning[String]
           } yield assert(diff)(hasSameElements(Chunk(MemberScore(3d, "c"))))
         }
       ) @@ clusterExecutorUnsupported,
       suite("zDiffStore")(
         test("empty sets") {
           for {
-            dest <- uuid
-            key1 <- uuid
-            key2 <- uuid
-            key3 <- uuid
-            card <- zDiffStore(dest, 3, key1, key2, key3)
+            redis <- ZIO.service[Redis]
+            dest  <- uuid
+            key1  <- uuid
+            key2  <- uuid
+            key3  <- uuid
+            card  <- redis.zDiffStore(dest, 3, key1, key2, key3)
           } yield assert(card)(equalTo(0L))
         },
         test("non-empty set with empty set") {
           for {
-            dest <- uuid
-            key1 <- uuid
-            key2 <- uuid
-            _ <- zAdd(key1)(
+            redis <- ZIO.service[Redis]
+            dest  <- uuid
+            key1  <- uuid
+            key2  <- uuid
+            _ <- redis.zAdd(key1)(
                    MemberScore(1d, "a"),
                    MemberScore(2d, "b")
                  )
-            card <- zDiffStore(dest, 2, key1, key2)
+            card <- redis.zDiffStore(dest, 2, key1, key2)
           } yield assert(card)(equalTo(2L))
         },
         test("non-empty sets") {
           for {
-            dest <- uuid
-            key1 <- uuid
-            key2 <- uuid
-            _ <- zAdd(key1)(
+            redis <- ZIO.service[Redis]
+            dest  <- uuid
+            key1  <- uuid
+            key2  <- uuid
+            _ <- redis.zAdd(key1)(
                    MemberScore(1d, "a"),
                    MemberScore(2d, "b"),
                    MemberScore(3d, "c")
                  )
-            _    <- zAdd(key2)(MemberScore(1d, "a"), MemberScore(2d, "b"))
-            card <- zDiffStore(dest, 2, key1, key2)
+            _    <- redis.zAdd(key2)(MemberScore(1d, "a"), MemberScore(2d, "b"))
+            card <- redis.zDiffStore(dest, 2, key1, key2)
           } yield assert(card)(equalTo(1L))
         }
       ) @@ clusterExecutorUnsupported,
       suite("zIncrBy")(
         test("non-empty set") {
           for {
-            key <- uuid
-            _ <- zAdd(key)(
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _ <- redis.zAdd(key)(
                    MemberScore(1d, "a"),
                    MemberScore(2d, "b"),
                    MemberScore(3d, "c"),
                    MemberScore(4d, "d"),
                    MemberScore(5d, "e")
                  )
-            incrRes <- zIncrBy(key, 10, "a")
-            count   <- zCount(key, 10 to 11)
+            incrRes <- redis.zIncrBy(key, 10, "a")
+            count   <- redis.zCount(key, 10 to 11)
           } yield assert(count)(equalTo(1L)) && assert(incrRes)(equalTo(11.0))
         },
         test("empty set") {
           for {
+            redis   <- ZIO.service[Redis]
             key     <- uuid
-            incrRes <- zIncrBy(key, 10, "a")
-            count   <- zCount(key, 0 to -1)
+            incrRes <- redis.zIncrBy(key, 10, "a")
+            count   <- redis.zCount(key, 0 to -1)
           } yield assert(count)(equalTo(0L)) && assert(incrRes)(equalTo(10.0))
         }
       ),
       suite("zInter")(
         test("two non-empty sets") {
           for {
+            redis   <- ZIO.service[Redis]
             first   <- uuid
             second  <- uuid
-            _       <- zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
-            _       <- zAdd(second)(MemberScore(1d, "a"), MemberScore(3d, "c"), MemberScore(5d, "e"))
-            members <- zInter(2, first, second)().returning[String]
+            _       <- redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
+            _       <- redis.zAdd(second)(MemberScore(1d, "a"), MemberScore(3d, "c"), MemberScore(5d, "e"))
+            members <- redis.zInter(2, first, second)().returning[String]
           } yield assert(members)(equalTo(Chunk("a", "c")))
         },
         test("empty when one of the sets is empty") {
           for {
+            redis    <- ZIO.service[Redis]
             nonEmpty <- uuid
             empty    <- uuid
-            _        <- zAdd(nonEmpty)(MemberScore(1d, "a"), MemberScore(2d, "b"))
-            members  <- zInter(2, nonEmpty, empty)().returning[String]
+            _        <- redis.zAdd(nonEmpty)(MemberScore(1d, "a"), MemberScore(2d, "b"))
+            members  <- redis.zInter(2, nonEmpty, empty)().returning[String]
           } yield assert(members)(isEmpty)
         },
         test("empty when both sets are empty") {
           for {
+            redis   <- ZIO.service[Redis]
             first   <- uuid
             second  <- uuid
-            members <- zInter(2, first, second)().returning[String]
+            members <- redis.zInter(2, first, second)().returning[String]
           } yield assert(members)(isEmpty)
         },
         test("non-empty set with multiple non-empty sets") {
           for {
+            redis   <- ZIO.service[Redis]
             first   <- uuid
             second  <- uuid
             third   <- uuid
-            _       <- zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
-            _       <- zAdd(second)(MemberScore(2d, "b"), MemberScore(2d, "b"), MemberScore(4d, "d"))
-            _       <- zAdd(third)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"))
-            members <- zInter(3, first, second, third)().returning[String]
+            _       <- redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
+            _       <- redis.zAdd(second)(MemberScore(2d, "b"), MemberScore(2d, "b"), MemberScore(4d, "d"))
+            _       <- redis.zAdd(third)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"))
+            members <- redis.zInter(3, first, second, third)().returning[String]
           } yield assert(members)(
             equalTo(Chunk("b"))
           )
         },
         test("error when first parameter is not set") {
           for {
+            redis   <- ZIO.service[Redis]
             first   <- uuid
             second  <- uuid
             value   <- uuid
-            _       <- set(first, value)
-            members <- zInter(2, first, second)().returning[String].either
+            _       <- redis.set(first, value)
+            members <- redis.zInter(2, first, second)().returning[String].either
           } yield assert(members)(isLeft(isSubtype[WrongType](anything)))
         },
         test("error with empty first set and second parameter is not set") {
           for {
+            redis   <- ZIO.service[Redis]
             first   <- uuid
             second  <- uuid
             value   <- uuid
-            _       <- set(second, value)
-            members <- zInter(2, first, second)().returning[String].either
+            _       <- redis.set(second, value)
+            members <- redis.zInter(2, first, second)().returning[String].either
           } yield assert(members)(isLeft(isSubtype[WrongType](anything)))
         },
         test("error with non-empty first set and second parameter is not set") {
           for {
+            redis   <- ZIO.service[Redis]
             first   <- uuid
             second  <- uuid
             value   <- uuid
-            _       <- zAdd(first)(MemberScore(1d, "a"))
-            _       <- set(second, value)
-            members <- zInter(2, first, second)().returning[String].either
+            _       <- redis.zAdd(first)(MemberScore(1d, "a"))
+            _       <- redis.set(second, value)
+            members <- redis.zInter(2, first, second)().returning[String].either
           } yield assert(members)(isLeft(isSubtype[WrongType](anything)))
         },
         test("parameter weights provided") {
           for {
+            redis   <- ZIO.service[Redis]
             first   <- uuid
             second  <- uuid
-            _       <- zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
-            _       <- zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
-            members <- zInter(2, first, second)(weights = Some(::(2.0, 3.0 :: Nil))).returning[String]
+            _       <- redis.zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
+            _       <- redis.zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
+            members <- redis.zInter(2, first, second)(weights = Some(::(2.0, 3.0 :: Nil))).returning[String]
           } yield assert(members)(equalTo(Chunk("O", "N")))
         },
         test("error when invalid weights provided ( less than sets number )") {
           for {
+            redis   <- ZIO.service[Redis]
             first   <- uuid
             second  <- uuid
-            _       <- zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
-            _       <- zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
-            members <- zInter(2, first, second)(weights = Some(::(2, Nil))).returning[String].either
+            _       <- redis.zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
+            _       <- redis.zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
+            members <- redis.zInter(2, first, second)(weights = Some(::(2, Nil))).returning[String].either
           } yield assert(members)(isLeft(isSubtype[ProtocolError](anything)))
         },
         test("error when invalid weights provided ( more than sets number )") {
           for {
+            redis   <- ZIO.service[Redis]
             first   <- uuid
             second  <- uuid
-            _       <- zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
-            _       <- zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
-            members <- zInter(2, first, second)(weights = Some(::(2.0, List(3.0, 5.0)))).returning[String].either
+            _       <- redis.zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
+            _       <- redis.zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
+            members <- redis.zInter(2, first, second)(weights = Some(::(2.0, List(3.0, 5.0)))).returning[String].either
           } yield assert(members)(isLeft(isSubtype[ProtocolError](anything)))
         },
         test("set aggregate parameter MAX") {
           for {
+            redis   <- ZIO.service[Redis]
             first   <- uuid
             second  <- uuid
-            _       <- zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
-            _       <- zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
-            members <- zInter(2, first, second)(Some(Aggregate.Max)).returning[String]
+            _       <- redis.zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
+            _       <- redis.zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
+            members <- redis.zInter(2, first, second)(Some(Aggregate.Max)).returning[String]
           } yield assert(members)(equalTo(Chunk("N", "O")))
         },
         test("set aggregate parameter MIN") {
           for {
+            redis   <- ZIO.service[Redis]
             first   <- uuid
             second  <- uuid
-            _       <- zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
-            _       <- zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
-            members <- zInter(2, first, second)(Some(Aggregate.Min)).returning[String]
+            _       <- redis.zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
+            _       <- redis.zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
+            members <- redis.zInter(2, first, second)(Some(Aggregate.Min)).returning[String]
           } yield assert(members)(equalTo(Chunk("O", "N")))
         }
       ) @@ clusterExecutorUnsupported,
       suite("zInterWithScores")(
         test("two non-empty sets") {
           for {
+            redis   <- ZIO.service[Redis]
             first   <- uuid
             second  <- uuid
-            _       <- zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
-            _       <- zAdd(second)(MemberScore(1d, "a"), MemberScore(3d, "c"), MemberScore(5d, "e"))
-            members <- zInterWithScores(2, first, second)().returning[String]
+            _       <- redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
+            _       <- redis.zAdd(second)(MemberScore(1d, "a"), MemberScore(3d, "c"), MemberScore(5d, "e"))
+            members <- redis.zInterWithScores(2, first, second)().returning[String]
           } yield assert(members)(equalTo(Chunk(MemberScore(2d, "a"), MemberScore(6d, "c"))))
         },
         test("empty when one of the sets is empty") {
           for {
+            redis    <- ZIO.service[Redis]
             nonEmpty <- uuid
             empty    <- uuid
-            _        <- zAdd(nonEmpty)(MemberScore(1d, "a"), MemberScore(2d, "b"))
-            members  <- zInterWithScores(2, nonEmpty, empty)().returning[String]
+            _        <- redis.zAdd(nonEmpty)(MemberScore(1d, "a"), MemberScore(2d, "b"))
+            members  <- redis.zInterWithScores(2, nonEmpty, empty)().returning[String]
           } yield assert(members)(isEmpty)
         },
         test("empty when both sets are empty") {
           for {
+            redis   <- ZIO.service[Redis]
             first   <- uuid
             second  <- uuid
-            members <- zInterWithScores(2, first, second)().returning[String]
+            members <- redis.zInterWithScores(2, first, second)().returning[String]
           } yield assert(members)(isEmpty)
         },
         test("non-empty set with multiple non-empty sets") {
           for {
+            redis   <- ZIO.service[Redis]
             first   <- uuid
             second  <- uuid
             third   <- uuid
-            _       <- zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
-            _       <- zAdd(second)(MemberScore(2d, "b"), MemberScore(2d, "b"), MemberScore(4d, "d"))
-            _       <- zAdd(third)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"))
-            members <- zInterWithScores(3, first, second, third)().returning[String]
+            _       <- redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
+            _       <- redis.zAdd(second)(MemberScore(2d, "b"), MemberScore(2d, "b"), MemberScore(4d, "d"))
+            _       <- redis.zAdd(third)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"))
+            members <- redis.zInterWithScores(3, first, second, third)().returning[String]
           } yield assert(members)(
             equalTo(Chunk(MemberScore(6d, "b")))
           )
         },
         test("error when first parameter is not set") {
           for {
+            redis   <- ZIO.service[Redis]
             first   <- uuid
             second  <- uuid
             value   <- uuid
-            _       <- set(first, value)
-            members <- zInterWithScores(2, first, second)().returning[String].either
+            _       <- redis.set(first, value)
+            members <- redis.zInterWithScores(2, first, second)().returning[String].either
           } yield assert(members)(isLeft(isSubtype[WrongType](anything)))
         },
         test("error with empty first set and second parameter is not set") {
           for {
+            redis   <- ZIO.service[Redis]
             first   <- uuid
             second  <- uuid
             value   <- uuid
-            _       <- set(second, value)
-            members <- zInterWithScores(2, first, second)().returning[String].either
+            _       <- redis.set(second, value)
+            members <- redis.zInterWithScores(2, first, second)().returning[String].either
           } yield assert(members)(isLeft(isSubtype[WrongType](anything)))
         },
         test("error with non-empty first set and second parameter is not set") {
           for {
+            redis   <- ZIO.service[Redis]
             first   <- uuid
             second  <- uuid
             value   <- uuid
-            _       <- zAdd(first)(MemberScore(1d, "a"))
-            _       <- set(second, value)
-            members <- zInterWithScores(2, first, second)().returning[String].either
+            _       <- redis.zAdd(first)(MemberScore(1d, "a"))
+            _       <- redis.set(second, value)
+            members <- redis.zInterWithScores(2, first, second)().returning[String].either
           } yield assert(members)(isLeft(isSubtype[WrongType](anything)))
         },
         test("parameter weights provided") {
           for {
+            redis   <- ZIO.service[Redis]
             first   <- uuid
             second  <- uuid
-            _       <- zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
-            _       <- zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
-            members <- zInterWithScores(2, first, second)(weights = Some(::(2.0, 3.0 :: Nil))).returning[String]
+            _       <- redis.zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
+            _       <- redis.zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
+            members <- redis.zInterWithScores(2, first, second)(weights = Some(::(2.0, 3.0 :: Nil))).returning[String]
           } yield assert(members)(equalTo(Chunk(MemberScore(20d, "O"), MemberScore(21d, "N"))))
         },
         test("error when invalid weights provided ( less than sets number )") {
           for {
+            redis   <- ZIO.service[Redis]
             first   <- uuid
             second  <- uuid
-            _       <- zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
-            _       <- zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
-            members <- zInterWithScores(2, first, second)(weights = Some(::(2, Nil))).returning[String].either
+            _       <- redis.zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
+            _       <- redis.zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
+            members <- redis.zInterWithScores(2, first, second)(weights = Some(::(2, Nil))).returning[String].either
           } yield assert(members)(isLeft(isSubtype[ProtocolError](anything)))
         },
         test("error when invalid weights provided ( more than sets number )") {
           for {
+            redis  <- ZIO.service[Redis]
             first  <- uuid
             second <- uuid
-            _      <- zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
-            _      <- zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
-            members <- zInterWithScores(2, first, second)(weights = Some(::(2.0, List(3.0, 5.0))))
+            _      <- redis.zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
+            _      <- redis.zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
+            members <- redis.zInterWithScores(2, first, second)(weights = Some(::(2.0, List(3.0, 5.0))))
                          .returning[String]
                          .either
           } yield assert(members)(isLeft(isSubtype[ProtocolError](anything)))
         },
         test("set aggregate parameter MAX") {
           for {
+            redis   <- ZIO.service[Redis]
             first   <- uuid
             second  <- uuid
-            _       <- zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
-            _       <- zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
-            members <- zInterWithScores(2, first, second)(Some(Aggregate.Max)).returning[String]
+            _       <- redis.zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
+            _       <- redis.zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
+            members <- redis.zInterWithScores(2, first, second)(Some(Aggregate.Max)).returning[String]
           } yield assert(members)(equalTo(Chunk(MemberScore(6d, "N"), MemberScore(7d, "O"))))
         },
         test("set aggregate parameter MIN") {
           for {
+            redis   <- ZIO.service[Redis]
             first   <- uuid
             second  <- uuid
-            _       <- zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
-            _       <- zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
-            members <- zInterWithScores(2, first, second)(Some(Aggregate.Min)).returning[String]
+            _       <- redis.zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
+            _       <- redis.zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
+            members <- redis.zInterWithScores(2, first, second)(Some(Aggregate.Min)).returning[String]
           } yield assert(members)(equalTo(Chunk(MemberScore(2d, "O"), MemberScore(3d, "N"))))
         }
       ) @@ clusterExecutorUnsupported,
       suite("zInterStore")(
         test("two non-empty sets") {
           for {
+            redis  <- ZIO.service[Redis]
             dest   <- uuid
             first  <- uuid
             second <- uuid
-            _      <- zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
-            _      <- zAdd(second)(MemberScore(1d, "a"), MemberScore(3d, "c"), MemberScore(5d, "e"))
-            card   <- zInterStore(s"out_$dest", 2, first, second)()
+            _      <- redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
+            _      <- redis.zAdd(second)(MemberScore(1d, "a"), MemberScore(3d, "c"), MemberScore(5d, "e"))
+            card   <- redis.zInterStore(s"out_$dest", 2, first, second)()
           } yield assert(card)(equalTo(2L))
         },
         test("empty when one of the sets is empty") {
           for {
+            redis    <- ZIO.service[Redis]
             dest     <- uuid
             nonEmpty <- uuid
             empty    <- uuid
-            _        <- zAdd(nonEmpty)(MemberScore(1d, "a"), MemberScore(2d, "b"))
-            card     <- zInterStore(dest, 2, nonEmpty, empty)()
+            _        <- redis.zAdd(nonEmpty)(MemberScore(1d, "a"), MemberScore(2d, "b"))
+            card     <- redis.zInterStore(dest, 2, nonEmpty, empty)()
           } yield assert(card)(equalTo(0L))
         },
         test("empty when both sets are empty") {
           for {
+            redis  <- ZIO.service[Redis]
             dest   <- uuid
             first  <- uuid
             second <- uuid
-            card   <- zInterStore(dest, 2, first, second)()
+            card   <- redis.zInterStore(dest, 2, first, second)()
           } yield assert(card)(equalTo(0L))
         },
         test("non-empty set with multiple non-empty sets") {
           for {
+            redis  <- ZIO.service[Redis]
             dest   <- uuid
             first  <- uuid
             second <- uuid
             third  <- uuid
-            _      <- zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
-            _      <- zAdd(second)(MemberScore(2d, "b"), MemberScore(2d, "b"), MemberScore(4d, "d"))
-            _      <- zAdd(third)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"))
-            card   <- zInterStore(dest, 3, first, second, third)()
+            _      <- redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
+            _      <- redis.zAdd(second)(MemberScore(2d, "b"), MemberScore(2d, "b"), MemberScore(4d, "d"))
+            _      <- redis.zAdd(third)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"))
+            card   <- redis.zInterStore(dest, 3, first, second, third)()
           } yield assert(card)(equalTo(1L))
         },
         test("error when first parameter is not set") {
           for {
+            redis  <- ZIO.service[Redis]
             dest   <- uuid
             first  <- uuid
             second <- uuid
             value  <- uuid
-            _      <- set(first, value)
-            card   <- zInterStore(dest, 2, first, second)().either
+            _      <- redis.set(first, value)
+            card   <- redis.zInterStore(dest, 2, first, second)().either
           } yield assert(card)(isLeft(isSubtype[WrongType](anything)))
         },
         test("error with empty first set and second parameter is not set") {
           for {
+            redis  <- ZIO.service[Redis]
             dest   <- uuid
             first  <- uuid
             second <- uuid
             value  <- uuid
-            _      <- set(second, value)
-            card   <- zInterStore(dest, 2, first, second)().either
+            _      <- redis.set(second, value)
+            card   <- redis.zInterStore(dest, 2, first, second)().either
           } yield assert(card)(isLeft(isSubtype[WrongType](anything)))
         },
         test("error with non-empty first set and second parameter is not set") {
           for {
+            redis  <- ZIO.service[Redis]
             dest   <- uuid
             first  <- uuid
             second <- uuid
             value  <- uuid
-            _      <- zAdd(first)(MemberScore(1d, "a"))
-            _      <- set(second, value)
-            card   <- zInterStore(dest, 2, first, second)().either
+            _      <- redis.zAdd(first)(MemberScore(1d, "a"))
+            _      <- redis.set(second, value)
+            card   <- redis.zInterStore(dest, 2, first, second)().either
           } yield assert(card)(isLeft(isSubtype[WrongType](anything)))
         },
         test("parameter weights provided") {
           for {
+            redis  <- ZIO.service[Redis]
             first  <- uuid
             second <- uuid
             dest   <- uuid
-            _      <- zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
-            _      <- zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
-            card   <- zInterStore(dest, 2, first, second)(weights = Some(::(2.0, 3.0 :: Nil)))
+            _      <- redis.zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
+            _      <- redis.zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
+            card   <- redis.zInterStore(dest, 2, first, second)(weights = Some(::(2.0, 3.0 :: Nil)))
           } yield assert(card)(equalTo(2L))
         },
         test("error when invalid weights provided ( less than sets number )") {
           for {
+            redis  <- ZIO.service[Redis]
             first  <- uuid
             second <- uuid
             dest   <- uuid
-            _      <- zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
-            _      <- zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
-            card   <- zInterStore(dest, 2, first, second)(weights = Some(::(2, Nil))).either
+            _      <- redis.zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
+            _      <- redis.zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
+            card   <- redis.zInterStore(dest, 2, first, second)(weights = Some(::(2, Nil))).either
           } yield assert(card)(isLeft(isSubtype[ProtocolError](anything)))
         },
         test("error when invalid weights provided ( more than sets number )") {
           for {
+            redis  <- ZIO.service[Redis]
             first  <- uuid
             second <- uuid
             dest   <- uuid
-            _      <- zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
-            _      <- zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
-            card   <- zInterStore(dest, 2, first, second)(weights = Some(::(2.0, List(3.0, 5.0)))).either
+            _      <- redis.zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
+            _      <- redis.zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
+            card   <- redis.zInterStore(dest, 2, first, second)(weights = Some(::(2.0, List(3.0, 5.0)))).either
           } yield assert(card)(isLeft(isSubtype[ProtocolError](anything)))
         },
         test("set aggregate parameter MAX") {
           for {
+            redis  <- ZIO.service[Redis]
             first  <- uuid
             second <- uuid
             dest   <- uuid
-            _      <- zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
-            _      <- zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
-            card   <- zInterStore(dest, 2, first, second)(Some(Aggregate.Max))
+            _      <- redis.zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
+            _      <- redis.zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
+            card   <- redis.zInterStore(dest, 2, first, second)(Some(Aggregate.Max))
           } yield assert(card)(equalTo(2L))
         },
         test("set aggregate parameter MIN") {
           for {
+            redis  <- ZIO.service[Redis]
             first  <- uuid
             second <- uuid
             dest   <- uuid
-            _      <- zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
-            _      <- zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
-            card   <- zInterStore(dest, 2, first, second)(Some(Aggregate.Min))
+            _      <- redis.zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
+            _      <- redis.zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
+            card   <- redis.zInterStore(dest, 2, first, second)(Some(Aggregate.Min))
           } yield assert(card)(equalTo(2L))
         }
       ) @@ clusterExecutorUnsupported,
       suite("zLexCount")(
         test("non-empty set") {
           for {
-            key <- uuid
-            _ <- zAdd(key)(
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _ <- redis.zAdd(key)(
                    MemberScore(1d, "Delhi"),
                    MemberScore(2d, "Mumbai"),
                    MemberScore(3d, "London"),
                    MemberScore(4d, "Paris"),
                    MemberScore(5d, "Tokyo")
                  )
-            count <- zLexCount(key, LexRange(min = LexMinimum.Closed("London"), max = LexMaximum.Open("Paris")))
+            count <- redis.zLexCount(key, LexRange(min = LexMinimum.Closed("London"), max = LexMaximum.Open("Paris")))
           } yield assert(count)(equalTo(2L))
         },
         test("empty set") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
-            count <- zLexCount(key, LexRange(min = LexMinimum.Closed("London"), max = LexMaximum.Open("Paris")))
+            count <- redis.zLexCount(key, LexRange(min = LexMinimum.Closed("London"), max = LexMaximum.Open("Paris")))
           } yield assert(count)(equalTo(0L))
         }
       ),
       suite("zPopMax")(
         test("non-empty set")(
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
             delhi   = MemberScore(1d, "Delhi")
             mumbai  = MemberScore(2d, "Mumbai")
             london  = MemberScore(3d, "London")
             paris   = MemberScore(4d, "Paris")
             tokyo   = MemberScore(5d, "Tokyo")
-            _      <- zAdd(key)(delhi, mumbai, london, paris, tokyo)
-            result <- zPopMax(key).returning[String]
+            _      <- redis.zAdd(key)(delhi, mumbai, london, paris, tokyo)
+            result <- redis.zPopMax(key).returning[String]
           } yield assert(result.toList)(equalTo(List(tokyo)))
         ),
         test("non-empty set with count param")(
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
             delhi   = MemberScore(1d, "Delhi")
             mumbai  = MemberScore(2d, "Mumbai")
             london  = MemberScore(3d, "London")
             paris   = MemberScore(4d, "Paris")
             tokyo   = MemberScore(5d, "Tokyo")
-            _      <- zAdd(key)(delhi, mumbai, london, paris, tokyo)
-            result <- zPopMax(key, Some(3)).returning[String]
+            _      <- redis.zAdd(key)(delhi, mumbai, london, paris, tokyo)
+            result <- redis.zPopMax(key, Some(3)).returning[String]
           } yield assert(result.toList)(equalTo(List(tokyo, paris, london)))
         ),
         test("empty set")(for {
+          redis  <- ZIO.service[Redis]
           key    <- uuid
-          result <- zPopMax(key).returning[String]
+          result <- redis.zPopMax(key).returning[String]
         } yield assert(result.toList)(equalTo(Nil)))
       ),
       suite("zPopMin")(
         test("non-empty set")(
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
             delhi   = MemberScore(1d, "Delhi")
             mumbai  = MemberScore(2d, "Mumbai")
             london  = MemberScore(3d, "London")
             paris   = MemberScore(4d, "Paris")
             tokyo   = MemberScore(5d, "Tokyo")
-            _      <- zAdd(key)(delhi, mumbai, london, paris, tokyo)
-            result <- zPopMin(key).returning[String]
+            _      <- redis.zAdd(key)(delhi, mumbai, london, paris, tokyo)
+            result <- redis.zPopMin(key).returning[String]
           } yield assert(result.toList)(equalTo(List(delhi)))
         ),
         test("non-empty set with count param")(
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
             delhi   = MemberScore(1d, "Delhi")
             mumbai  = MemberScore(2d, "Mumbai")
             london  = MemberScore(3d, "London")
             paris   = MemberScore(4d, "Paris")
             tokyo   = MemberScore(5d, "Tokyo")
-            _      <- zAdd(key)(delhi, mumbai, london, paris, tokyo)
-            result <- zPopMin(key, Some(3)).returning[String]
+            _      <- redis.zAdd(key)(delhi, mumbai, london, paris, tokyo)
+            result <- redis.zPopMin(key, Some(3)).returning[String]
           } yield assert(result.toList)(equalTo(List(delhi, mumbai, london)))
         ),
         test("empty set")(for {
+          redis  <- ZIO.service[Redis]
           key    <- uuid
-          result <- zPopMin(key).returning[String]
+          result <- redis.zPopMin(key).returning[String]
         } yield assert(result.toList)(equalTo(Nil)))
       ),
       suite("zRange")(
         test("non-empty set") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
             delhi   = MemberScore(1d, "Delhi")
             mumbai  = MemberScore(2d, "Mumbai")
             london  = MemberScore(3d, "London")
             paris   = MemberScore(4d, "Paris")
             tokyo   = MemberScore(5d, "Tokyo")
-            _      <- zAdd(key)(delhi, mumbai, london, tokyo, paris)
-            result <- zRange(key, 0 to -1).returning[String]
+            _      <- redis.zAdd(key)(delhi, mumbai, london, tokyo, paris)
+            result <- redis.zRange(key, 0 to -1).returning[String]
           } yield assert(result.toList)(equalTo(List("Delhi", "Mumbai", "London", "Paris", "Tokyo")))
         },
         test("empty set") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            result <- zRange(key, 0 to -1).returning[String]
+            result <- redis.zRange(key, 0 to -1).returning[String]
           } yield assert(result.toList)(isEmpty)
         }
       ),
       suite("zRangeWithScores")(
         test("non-empty set") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
             delhi   = MemberScore(1d, "Delhi")
             mumbai  = MemberScore(2d, "Mumbai")
             london  = MemberScore(3d, "London")
             paris   = MemberScore(4d, "Paris")
             tokyo   = MemberScore(5d, "Tokyo")
-            _      <- zAdd(key)(delhi, mumbai, london, tokyo, paris)
-            result <- zRangeWithScores(key, 0 to -1).returning[String]
+            _      <- redis.zAdd(key)(delhi, mumbai, london, tokyo, paris)
+            result <- redis.zRangeWithScores(key, 0 to -1).returning[String]
           } yield assert(result.toList)(
             equalTo(List(delhi, mumbai, london, paris, tokyo))
           )
         },
         test("empty set") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            result <- zRangeWithScores(key, 0 to -1).returning[String]
+            result <- redis.zRangeWithScores(key, 0 to -1).returning[String]
           } yield assert(result.toList)(isEmpty)
         }
       ),
       suite("zRangeByLex")(
         test("non-empty set") {
           for {
-            key <- uuid
-            _ <- zAdd(key)(
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _ <- redis.zAdd(key)(
                    MemberScore(1d, "Delhi"),
                    MemberScore(2d, "London"),
                    MemberScore(3d, "Paris"),
@@ -802,7 +882,7 @@ trait SortedSetsSpec extends BaseSpec {
                    MemberScore(5d, "NewYork"),
                    MemberScore(6d, "Seoul")
                  )
-            result <- zRangeByLex(
+            result <- redis.zRangeByLex(
                         key,
                         LexRange(min = LexMinimum.Open("London"), max = LexMaximum.Closed("Seoul"))
                       ).returning[String]
@@ -810,8 +890,9 @@ trait SortedSetsSpec extends BaseSpec {
         },
         test("non-empty set with limit") {
           for {
-            key <- uuid
-            _ <- zAdd(key)(
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _ <- redis.zAdd(key)(
                    MemberScore(1d, "Delhi"),
                    MemberScore(2d, "London"),
                    MemberScore(3d, "Paris"),
@@ -819,7 +900,7 @@ trait SortedSetsSpec extends BaseSpec {
                    MemberScore(5d, "NewYork"),
                    MemberScore(6d, "Seoul")
                  )
-            result <- zRangeByLex(
+            result <- redis.zRangeByLex(
                         key,
                         LexRange(min = LexMinimum.Unbounded, max = LexMaximum.Unbounded),
                         Some(Limit(2, 3))
@@ -828,8 +909,9 @@ trait SortedSetsSpec extends BaseSpec {
         },
         test("empty set") {
           for {
-            key <- uuid
-            result <- zRangeByLex(key, LexRange(min = LexMinimum.Open("A"), max = LexMaximum.Closed("Z")))
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            result <- redis.zRangeByLex(key, LexRange(min = LexMinimum.Open("A"), max = LexMaximum.Closed("Z")))
                         .returning[String]
           } yield assert(result.toList)(isEmpty)
         }
@@ -837,8 +919,9 @@ trait SortedSetsSpec extends BaseSpec {
       suite("zRangeByScore")(
         test("non-empty set") {
           for {
-            key <- uuid
-            _ <- zAdd(key)(
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _ <- redis.zAdd(key)(
                    MemberScore(1556d, "Samsung"),
                    MemberScore(2000d, "Nokia"),
                    MemberScore(1801d, "Micromax"),
@@ -846,14 +929,15 @@ trait SortedSetsSpec extends BaseSpec {
                    MemberScore(1800d, "MicroSoft"),
                    MemberScore(2500d, "LG")
                  )
-            result <- zRangeByScore(key, ScoreRange(ScoreMinimum.Open(1500), ScoreMaximum.Closed(1900)))
+            result <- redis.zRangeByScore(key, ScoreRange(ScoreMinimum.Open(1500), ScoreMaximum.Closed(1900)))
                         .returning[String]
           } yield assert(result.toList)(equalTo(List("Samsung", "MicroSoft", "Micromax")))
         },
         test("non-empty set, with limit") {
           for {
-            key <- uuid
-            _ <- zAdd(key)(
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _ <- redis.zAdd(key)(
                    MemberScore(1556d, "Samsung"),
                    MemberScore(2000d, "Nokia"),
                    MemberScore(1801d, "Micromax"),
@@ -862,13 +946,14 @@ trait SortedSetsSpec extends BaseSpec {
                    MemberScore(2500d, "LG")
                  )
             scoreRange = ScoreRange(ScoreMinimum.Open(1500), ScoreMaximum.Closed(2500))
-            result    <- zRangeByScore(key, scoreRange, Some(Limit(offset = 1, count = 3))).returning[String]
+            result    <- redis.zRangeByScore(key, scoreRange, Some(Limit(offset = 1, count = 3))).returning[String]
           } yield assert(result.toList)(equalTo(List("MicroSoft", "Micromax", "Nokia")))
         },
         test("empty set") {
           for {
-            key <- uuid
-            result <- zRangeByScore(key, ScoreRange(ScoreMinimum.Open(1500), ScoreMaximum.Closed(1900)))
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            result <- redis.zRangeByScore(key, ScoreRange(ScoreMinimum.Open(1500), ScoreMaximum.Closed(1900)))
                         .returning[String]
           } yield assert(result.toList)(isEmpty)
         }
@@ -876,6 +961,7 @@ trait SortedSetsSpec extends BaseSpec {
       suite("zRangeByScoreWithScores")(
         test("non-empty set") {
           for {
+            redis     <- ZIO.service[Redis]
             key       <- uuid
             samsung    = MemberScore(1556d, "Samsung")
             nokia      = MemberScore(2000d, "Nokia")
@@ -883,13 +969,14 @@ trait SortedSetsSpec extends BaseSpec {
             sunsui     = MemberScore(2200d, "Sunsui")
             microSoft  = MemberScore(1800d, "MicroSoft")
             lg         = MemberScore(2500d, "LG")
-            _         <- zAdd(key)(samsung, nokia, micromax, sunsui, microSoft, lg)
+            _         <- redis.zAdd(key)(samsung, nokia, micromax, sunsui, microSoft, lg)
             scoreRange = ScoreRange(ScoreMinimum.Open(1500), ScoreMaximum.Closed(1900))
-            result    <- zRangeByScoreWithScores(key, scoreRange).returning[String]
+            result    <- redis.zRangeByScoreWithScores(key, scoreRange).returning[String]
           } yield assert(result.toList)(equalTo(List(samsung, microSoft, micromax)))
         },
         test("non-empty set, with limit") {
           for {
+            redis     <- ZIO.service[Redis]
             key       <- uuid
             samsung    = MemberScore(1556d, "Samsung")
             nokia      = MemberScore(2000d, "Nokia")
@@ -897,189 +984,206 @@ trait SortedSetsSpec extends BaseSpec {
             sunsui     = MemberScore(2200d, "Sunsui")
             microSoft  = MemberScore(1800d, "MicroSoft")
             lg         = MemberScore(2500d, "LG")
-            _         <- zAdd(key)(samsung, nokia, micromax, sunsui, microSoft, lg)
+            _         <- redis.zAdd(key)(samsung, nokia, micromax, sunsui, microSoft, lg)
             scoreRange = ScoreRange(ScoreMinimum.Open(1500), ScoreMaximum.Closed(2500))
-            result    <- zRangeByScoreWithScores(key, scoreRange, Some(Limit(offset = 1, count = 3))).returning[String]
+            result    <- redis.zRangeByScoreWithScores(key, scoreRange, Some(Limit(offset = 1, count = 3))).returning[String]
           } yield assert(result.toList)(equalTo(List(microSoft, micromax, nokia)))
         },
         test("empty set") {
           for {
+            redis     <- ZIO.service[Redis]
             key       <- uuid
             scoreRange = ScoreRange(ScoreMinimum.Open(1500), ScoreMaximum.Closed(1900))
-            result    <- zRangeByScoreWithScores(key, scoreRange).returning[String]
+            result    <- redis.zRangeByScoreWithScores(key, scoreRange).returning[String]
           } yield assert(result.toList)(isEmpty)
         }
       ),
       suite("zRank")(
         test("existing elements from non-empty set") {
           for {
-            key  <- uuid
-            _    <- zAdd(key)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"))
-            rank <- zRank(key, "c")
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.zAdd(key)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"))
+            rank  <- redis.zRank(key, "c")
           } yield assert(rank)(equalTo(Some(2L)))
         },
         test("empty set") {
           for {
-            key  <- uuid
-            rank <- zRank(key, "c")
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            rank  <- redis.zRank(key, "c")
           } yield assert(rank)(isNone)
         }
       ),
       suite("zRem")(
         test("existing elements from non-empty set") {
           for {
+            redis   <- ZIO.service[Redis]
             key     <- uuid
-            _       <- zAdd(key)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"))
-            removed <- zRem(key, "b", "c")
+            _       <- redis.zAdd(key)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"))
+            removed <- redis.zRem(key, "b", "c")
           } yield assert(removed)(equalTo(2L))
         },
         test("when just part of elements are present in the non-empty set") {
           for {
+            redis   <- ZIO.service[Redis]
             key     <- uuid
-            _       <- zAdd(key)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"))
-            removed <- zRem(key, "b", "d")
+            _       <- redis.zAdd(key)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"))
+            removed <- redis.zRem(key, "b", "d")
           } yield assert(removed)(equalTo(1L))
         },
         test("when none of the elements are present in the non-empty set") {
           for {
+            redis   <- ZIO.service[Redis]
             key     <- uuid
-            _       <- zAdd(key)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"))
-            removed <- zRem(key, "d", "e")
+            _       <- redis.zAdd(key)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"))
+            removed <- redis.zRem(key, "d", "e")
           } yield assert(removed)(equalTo(0L))
         },
         test("elements from an empty set") {
           for {
+            redis   <- ZIO.service[Redis]
             key     <- uuid
-            removed <- zRem(key, "a", "b")
+            removed <- redis.zRem(key, "a", "b")
           } yield assert(removed)(equalTo(0L))
         },
         test("elements from not set") {
           for {
+            redis   <- ZIO.service[Redis]
             key     <- uuid
             value   <- uuid
-            _       <- set(key, value)
-            removed <- zRem(key, "a", "b").either
+            _       <- redis.set(key, value)
+            removed <- redis.zRem(key, "a", "b").either
           } yield assert(removed)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
       suite("zRemRangeByLex")(
         test("non-empty set") {
           for {
-            key <- uuid
-            _ <- zAdd(key)(
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _ <- redis.zAdd(key)(
                    MemberScore(0d, "Delhi"),
                    MemberScore(0d, "Mumbai"),
                    MemberScore(0d, "Hyderabad"),
                    MemberScore(0d, "Kolkata"),
                    MemberScore(0d, "Chennai")
                  )
-            remResult <-
-              zRemRangeByLex(key, LexRange(min = LexMinimum.Open("Hyderabad"), max = LexMaximum.Closed("Mumbai")))
-            rangeResult <- zRangeByLex(key, LexRange(min = LexMinimum.Unbounded, max = LexMaximum.Unbounded))
+            remResult <- redis.zRemRangeByLex(key, LexRange(min = LexMinimum.Open("Hyderabad"), max = LexMaximum.Closed("Mumbai")))
+            rangeResult <- redis.zRangeByLex(key, LexRange(min = LexMinimum.Unbounded, max = LexMaximum.Unbounded))
                              .returning[String]
           } yield assert(rangeResult.toList)(equalTo(List("Chennai", "Delhi", "Hyderabad"))) &&
             assert(remResult)(equalTo(2L))
         },
         test("empty set") {
           for {
-            key <- uuid
-            remResult <-
-              zRemRangeByLex(key, LexRange(min = LexMinimum.Open("Hyderabad"), max = LexMaximum.Closed("Mumbai")))
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            remResult <- redis.zRemRangeByLex(key, LexRange(min = LexMinimum.Open("Hyderabad"), max = LexMaximum.Closed("Mumbai")))
           } yield assert(remResult)(equalTo(0L))
         }
       ),
       suite("zRemRangeByRank")(
         test("non-empty set") {
           for {
-            key <- uuid
-            _ <- zAdd(key)(
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _ <- redis.zAdd(key)(
                    MemberScore(1d, "Delhi"),
                    MemberScore(2d, "Mumbai"),
                    MemberScore(3d, "Hyderabad"),
                    MemberScore(4d, "Kolkata"),
                    MemberScore(5d, "Chennai")
                  )
-            remResult   <- zRemRangeByRank(key, 1 to 2)
-            rangeResult <- zRange(key, 0 to -1).returning[String]
+            remResult   <- redis.zRemRangeByRank(key, 1 to 2)
+            rangeResult <- redis.zRange(key, 0 to -1).returning[String]
           } yield assert(rangeResult.toList)(equalTo(List("Delhi", "Kolkata", "Chennai"))) &&
             assert(remResult)(equalTo(2L))
         },
         test("empty set") {
           for {
+            redis     <- ZIO.service[Redis]
             key       <- uuid
-            remResult <- zRemRangeByRank(key, 1 to 2)
+            remResult <- redis.zRemRangeByRank(key, 1 to 2)
           } yield assert(remResult)(equalTo(0L))
         }
       ),
       suite("zRemRangeByScore")(
         test("non-empty set") {
           for {
-            key <- uuid
-            _ <- zAdd(key)(
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _ <- redis.zAdd(key)(
                    MemberScore(80d, "Delhi"),
                    MemberScore(60d, "Mumbai"),
                    MemberScore(70d, "Hyderabad"),
                    MemberScore(50d, "Kolkata"),
                    MemberScore(65d, "Chennai")
                  )
-            remResult <- zRemRangeByScore(key, ScoreRange(min = ScoreMinimum.Infinity, max = ScoreMaximum.Open(70)))
-            rangeResult <- zRangeByScore(key, ScoreRange(min = ScoreMinimum.Infinity, max = ScoreMaximum.Infinity))
+            remResult <- redis.zRemRangeByScore(key, ScoreRange(min = ScoreMinimum.Infinity, max = ScoreMaximum.Open(70)))
+            rangeResult <- redis.zRangeByScore(key, ScoreRange(min = ScoreMinimum.Infinity, max = ScoreMaximum.Infinity))
                              .returning[String]
           } yield assert(rangeResult.toList)(equalTo(List("Hyderabad", "Delhi"))) && assert(remResult)(equalTo(3L))
         },
         test("empty set") {
           for {
+            redis     <- ZIO.service[Redis]
             key       <- uuid
-            remResult <- zRemRangeByScore(key, ScoreRange(min = ScoreMinimum.Infinity, max = ScoreMaximum.Open(70)))
+            remResult <- redis.zRemRangeByScore(key, ScoreRange(min = ScoreMinimum.Infinity, max = ScoreMaximum.Open(70)))
           } yield assert(remResult)(equalTo(0L))
         }
       ),
       suite("zRevRange")(
         test("non-empty set") {
           for {
-            key <- uuid
-            _ <- zAdd(key)(
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _ <- redis.zAdd(key)(
                    MemberScore(80d, "Delhi"),
                    MemberScore(60d, "Mumbai"),
                    MemberScore(70d, "Hyderabad"),
                    MemberScore(50d, "Kolkata"),
                    MemberScore(65d, "Chennai")
                  )
-            revResult <- zRevRange(key, 0 to 1).returning[String]
+            revResult <- redis.zRevRange(key, 0 to 1).returning[String]
           } yield assert(revResult.toList)(equalTo(List("Delhi", "Hyderabad")))
         },
         test("empty set") {
           for {
+            redis     <- ZIO.service[Redis]
             key       <- uuid
-            remResult <- zRevRange(key, 0 to -1).returning[String]
+            remResult <- redis.zRevRange(key, 0 to -1).returning[String]
           } yield assert(remResult.toList)(isEmpty)
         }
       ),
       suite("zRevRangeWithScores")(
         test("non-empty set") {
           for {
+            redis     <- ZIO.service[Redis]
             key       <- uuid
             delhi      = MemberScore(80d, "Delhi")
             mumbai     = MemberScore(60d, "Mumbai")
             hyderabad  = MemberScore(70d, "Hyderabad")
             kolkata    = MemberScore(50d, "Kolkata")
             chennai    = MemberScore(65d, "Chennai")
-            _         <- zAdd(key)(delhi, mumbai, hyderabad, kolkata, chennai)
-            revResult <- zRevRangeWithScores(key, 0 to 1).returning[String]
+            _         <- redis.zAdd(key)(delhi, mumbai, hyderabad, kolkata, chennai)
+            revResult <- redis.zRevRangeWithScores(key, 0 to 1).returning[String]
           } yield assert(revResult.toList)(equalTo(List(delhi, hyderabad)))
         },
         test("empty set") {
           for {
+            redis     <- ZIO.service[Redis]
             key       <- uuid
-            remResult <- zRevRange(key, 0 to -1).returning[String]
+            remResult <- redis.zRevRange(key, 0 to -1).returning[String]
           } yield assert(remResult.toList)(isEmpty)
         }
       ),
       suite("zRevRangeByLex")(
         test("non-empty set") {
           for {
-            key <- uuid
-            _ <- zAdd(key)(
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _ <- redis.zAdd(key)(
                    MemberScore(0d, "Delhi"),
                    MemberScore(0d, "London"),
                    MemberScore(0d, "Paris"),
@@ -1088,13 +1192,14 @@ trait SortedSetsSpec extends BaseSpec {
                    MemberScore(0d, "Seoul")
                  )
             lexRange     = LexRange(min = LexMinimum.Closed("Delhi"), max = LexMaximum.Open("Seoul"))
-            rangeResult <- zRevRangeByLex(key, lexRange).returning[String]
+            rangeResult <- redis.zRevRangeByLex(key, lexRange).returning[String]
           } yield assert(rangeResult.toList)(equalTo(List("Paris", "NewYork", "London", "Delhi")))
         },
         test("non-empty set with limit") {
           for {
-            key <- uuid
-            _ <- zAdd(key)(
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _ <- redis.zAdd(key)(
                    MemberScore(0d, "Delhi"),
                    MemberScore(0d, "London"),
                    MemberScore(0d, "Paris"),
@@ -1103,22 +1208,24 @@ trait SortedSetsSpec extends BaseSpec {
                    MemberScore(0d, "Seoul")
                  )
             lexRange     = LexRange(min = LexMinimum.Closed("Delhi"), max = LexMaximum.Open("Seoul"))
-            rangeResult <- zRevRangeByLex(key, lexRange, Some(Limit(offset = 1, count = 2))).returning[String]
+            rangeResult <- redis.zRevRangeByLex(key, lexRange, Some(Limit(offset = 1, count = 2))).returning[String]
           } yield assert(rangeResult.toList)(equalTo(List("NewYork", "London")))
         },
         test("empty set") {
           for {
+            redis       <- ZIO.service[Redis]
             key         <- uuid
             lexRange     = LexRange(min = LexMinimum.Closed("Mumbai"), max = LexMaximum.Open("Hyderabad"))
-            rangeResult <- zRevRangeByLex(key, lexRange).returning[String]
+            rangeResult <- redis.zRevRangeByLex(key, lexRange).returning[String]
           } yield assert(rangeResult)(isEmpty)
         }
       ),
       suite("zRevRangeByScore")(
         test("non-empty set") {
           for {
-            key <- uuid
-            _ <- zAdd(key)(
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _ <- redis.zAdd(key)(
                    MemberScore(1556d, "Samsung"),
                    MemberScore(2000d, "Nokia"),
                    MemberScore(1800d, "Micromax"),
@@ -1127,13 +1234,14 @@ trait SortedSetsSpec extends BaseSpec {
                    MemberScore(2500d, "LG")
                  )
             scoreRange   = ScoreRange(ScoreMinimum.Closed(2000), ScoreMaximum.Open(2500))
-            rangeResult <- zRevRangeByScore(key, scoreRange).returning[String]
+            rangeResult <- redis.zRevRangeByScore(key, scoreRange).returning[String]
           } yield assert(rangeResult.toList)(equalTo(List("Sunsui", "Nokia")))
         },
         test("non-empty set with limit") {
           for {
-            key <- uuid
-            _ <- zAdd(key)(
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _ <- redis.zAdd(key)(
                    MemberScore(1556d, "Samsung"),
                    MemberScore(2000d, "Nokia"),
                    MemberScore(1800d, "Micromax"),
@@ -1142,20 +1250,22 @@ trait SortedSetsSpec extends BaseSpec {
                    MemberScore(2500d, "LG")
                  )
             scoreRange   = ScoreRange(ScoreMinimum.Closed(2000), ScoreMaximum.Open(2500))
-            rangeResult <- zRevRangeByScore(key, scoreRange, Some(Limit(1, 2))).returning[String]
+            rangeResult <- redis.zRevRangeByScore(key, scoreRange, Some(Limit(1, 2))).returning[String]
           } yield assert(rangeResult.toList)(equalTo(List("Nokia")))
         },
         test("empty set") {
           for {
+            redis       <- ZIO.service[Redis]
             key         <- uuid
             scoreRange   = ScoreRange(ScoreMinimum.Closed(2000), ScoreMaximum.Open(2500))
-            rangeResult <- zRevRangeByScore(key, scoreRange).returning[String]
+            rangeResult <- redis.zRevRangeByScore(key, scoreRange).returning[String]
           } yield assert(rangeResult)(isEmpty)
         }
       ),
       suite("zRevRangeByScoreWithScores")(
         test("non-empty set") {
           for {
+            redis       <- ZIO.service[Redis]
             key         <- uuid
             samsung      = MemberScore(1556d, "Samsung")
             nokia        = MemberScore(2000d, "Nokia")
@@ -1163,13 +1273,14 @@ trait SortedSetsSpec extends BaseSpec {
             sunsui       = MemberScore(2200d, "Sunsui")
             nicroSoft    = MemberScore(1800d, "MicroSoft")
             lg           = MemberScore(2500d, "LG")
-            _           <- zAdd(key)(samsung, nokia, micromax, sunsui, nicroSoft, lg)
+            _           <- redis.zAdd(key)(samsung, nokia, micromax, sunsui, nicroSoft, lg)
             scoreRange   = ScoreRange(ScoreMinimum.Closed(2000), ScoreMaximum.Open(2500))
-            rangeResult <- zRevRangeByScoreWithScores(key, scoreRange).returning[String]
+            rangeResult <- redis.zRevRangeByScoreWithScores(key, scoreRange).returning[String]
           } yield assert(rangeResult.toList)(equalTo(List(sunsui, nokia)))
         },
         test("non-empty set with limit") {
           for {
+            redis       <- ZIO.service[Redis]
             key         <- uuid
             samsung      = MemberScore(1556d, "Samsung")
             nokia        = MemberScore(2000d, "Nokia")
@@ -1177,72 +1288,79 @@ trait SortedSetsSpec extends BaseSpec {
             sunsui       = MemberScore(2200d, "Sunsui")
             nicroSoft    = MemberScore(1800d, "MicroSoft")
             lg           = MemberScore(2500d, "LG")
-            _           <- zAdd(key)(samsung, nokia, micromax, sunsui, nicroSoft, lg)
+            _           <- redis.zAdd(key)(samsung, nokia, micromax, sunsui, nicroSoft, lg)
             scoreRange   = ScoreRange(ScoreMinimum.Closed(2000), ScoreMaximum.Open(2500))
-            rangeResult <- zRevRangeByScoreWithScores(key, scoreRange, Some(Limit(1, 2))).returning[String]
+            rangeResult <- redis.zRevRangeByScoreWithScores(key, scoreRange, Some(Limit(1, 2))).returning[String]
           } yield assert(rangeResult.toList)(equalTo(List(nokia)))
         },
         test("empty set") {
           for {
+            redis       <- ZIO.service[Redis]
             key         <- uuid
             scoreRange   = ScoreRange(ScoreMinimum.Closed(2000), ScoreMaximum.Open(2500))
-            rangeResult <- zRevRangeByScoreWithScores(key, scoreRange).returning[String]
+            rangeResult <- redis.zRevRangeByScoreWithScores(key, scoreRange).returning[String]
           } yield assert(rangeResult)(isEmpty)
         }
       ),
       suite("zRevRank")(
         test("non-empty set") {
           for {
-            key <- uuid
-            _ <- zAdd(key)(
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _ <- redis.zAdd(key)(
                    MemberScore(10d, "Delhi"),
                    MemberScore(20d, "Mumbai"),
                    MemberScore(30d, "Hyderabad"),
                    MemberScore(40d, "Kolkata"),
                    MemberScore(50d, "Chennai")
                  )
-            result <- zRevRank(key, "Hyderabad")
+            result <- redis.zRevRank(key, "Hyderabad")
           } yield assert(result)(equalTo(Some(2L)))
         },
         test("empty set") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            result <- zRevRank(key, "Hyderabad")
+            result <- redis.zRevRank(key, "Hyderabad")
           } yield assert(result)(isNone)
         }
       ),
       suite("zScan")(
         test("non-empty set") {
           for {
+            redis   <- ZIO.service[Redis]
             key     <- uuid
             a        = MemberScore(1d, "atest")
             b        = MemberScore(2d, "btest")
             c        = MemberScore(3d, "ctest")
-            _       <- zAdd(key)(a, b, c)
+            _       <- redis.zAdd(key)(a, b, c)
             members <- scanAll(key)
           } yield assert(members)(equalTo(Chunk(a, b, c)))
         },
         test("empty set") {
           for {
+            redis            <- ZIO.service[Redis]
             key              <- uuid
-            scan             <- zScan(key, 0L).returning[String]
+            scan             <- redis.zScan(key, 0L).returning[String]
             (cursor, members) = scan
           } yield assert(cursor)(isZero) && assert(members)(isEmpty)
         },
         test("with match over non-empty set") {
           for {
+            redis   <- ZIO.service[Redis]
             key     <- uuid
             one      = MemberScore(1d, "one")
             two      = MemberScore(2d, "two")
             three    = MemberScore(3d, "three")
-            _       <- zAdd(key)(one, two, three)
+            _       <- redis.zAdd(key)(one, two, three)
             members <- scanAll(key, Some("t[a-z]*"))
           } yield assert(members)(equalTo(Chunk(two, three)))
         },
         test("with count over non-empty set") {
           for {
-            key <- uuid
-            _ <- zAdd(key)(
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _ <- redis.zAdd(key)(
                    MemberScore(1d, "a"),
                    MemberScore(2d, "b"),
                    MemberScore(3d, "c"),
@@ -1254,8 +1372,9 @@ trait SortedSetsSpec extends BaseSpec {
         },
         test("match with count over non-empty set") {
           for {
-            key <- uuid
-            _ <- zAdd(key)(
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _ <- redis.zAdd(key)(
                    MemberScore(1d, "testa"),
                    MemberScore(2d, "testb"),
                    MemberScore(3d, "testc"),
@@ -1267,173 +1386,191 @@ trait SortedSetsSpec extends BaseSpec {
         },
         test("error when not set") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
             value <- uuid
-            _     <- set(key, value)
-            scan  <- zScan(key, 0L).returning[String].either
+            _     <- redis.set(key, value)
+            scan  <- redis.zScan(key, 0L).returning[String].either
           } yield assert(scan)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
       suite("zScore")(
         test("non-empty set") {
           for {
-            key <- uuid
-            _ <- zAdd(key)(
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _ <- redis.zAdd(key)(
                    MemberScore(10d, "Delhi"),
                    MemberScore(20d, "Mumbai"),
                    MemberScore(30d, "Hyderabad"),
                    MemberScore(40d, "Kolkata"),
                    MemberScore(50d, "Chennai")
                  )
-            result <- zScore(key, "Delhi")
+            result <- redis.zScore(key, "Delhi")
           } yield assert(result)(equalTo(Some(10.0)))
         },
         test("empty set") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            result <- zScore(key, "Hyderabad")
+            result <- redis.zScore(key, "Hyderabad")
           } yield assert(result)(isNone)
         }
       ),
       suite("zMScore")(
         test("non-empty set") {
           for {
-            key <- uuid
-            _ <- zAdd(key)(
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _ <- redis.zAdd(key)(
                    MemberScore(10d, "Delhi"),
                    MemberScore(20d, "Mumbai"),
                    MemberScore(30d, "Hyderabad"),
                    MemberScore(40d, "Kolkata"),
                    MemberScore(50d, "Chennai")
                  )
-            result <- zMScore(key, "Delhi", "Mumbai", "notFound")
+            result <- redis.zMScore(key, "Delhi", "Mumbai", "notFound")
           } yield assert(result)(equalTo(Chunk(Some(10d), Some(20d), None)))
         },
         test("empty set") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            result <- zMScore(key, "Hyderabad")
+            result <- redis.zMScore(key, "Hyderabad")
           } yield assert(result)(equalTo(Chunk(None)))
         }
       ),
       suite("zUnion")(
         test("two non-empty sets") {
           for {
+            redis   <- ZIO.service[Redis]
             first   <- uuid
             second  <- uuid
-            _       <- zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
-            _       <- zAdd(second)(MemberScore(1d, "a"), MemberScore(3d, "c"), MemberScore(5d, "e"))
-            members <- zUnion(2, first, second)().returning[String]
+            _       <- redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
+            _       <- redis.zAdd(second)(MemberScore(1d, "a"), MemberScore(3d, "c"), MemberScore(5d, "e"))
+            members <- redis.zUnion(2, first, second)().returning[String]
           } yield assert(members)(equalTo(Chunk("a", "b", "d", "e", "c")))
         },
         test("equal to the non-empty set when the other one is empty") {
           for {
+            redis    <- ZIO.service[Redis]
             nonEmpty <- uuid
             empty    <- uuid
-            _        <- zAdd(nonEmpty)(MemberScore(1d, "a"), MemberScore(2d, "b"))
-            members  <- zUnion(2, nonEmpty, empty)().returning[String]
+            _        <- redis.zAdd(nonEmpty)(MemberScore(1d, "a"), MemberScore(2d, "b"))
+            members  <- redis.zUnion(2, nonEmpty, empty)().returning[String]
           } yield assert(members)(equalTo(Chunk("a", "b")))
         },
         test("empty when both sets are empty") {
           for {
+            redis   <- ZIO.service[Redis]
             first   <- uuid
             second  <- uuid
-            members <- zUnion(2, first, second)().returning[String]
+            members <- redis.zUnion(2, first, second)().returning[String]
           } yield assert(members)(isEmpty)
         },
         test("non-empty set with multiple non-empty sets") {
           for {
+            redis   <- ZIO.service[Redis]
             first   <- uuid
             second  <- uuid
             third   <- uuid
-            _       <- zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
-            _       <- zAdd(second)(MemberScore(2, "b"), MemberScore(4d, "d"))
-            _       <- zAdd(third)(MemberScore(2, "b"), MemberScore(3d, "c"), MemberScore(5d, "e"))
-            members <- zUnion(3, first, second, third)().returning[String]
+            _       <- redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
+            _       <- redis.zAdd(second)(MemberScore(2, "b"), MemberScore(4d, "d"))
+            _       <- redis.zAdd(third)(MemberScore(2, "b"), MemberScore(3d, "c"), MemberScore(5d, "e"))
+            members <- redis.zUnion(3, first, second, third)().returning[String]
           } yield assert(members)(equalTo(Chunk("a", "e", "b", "c", "d")))
         },
         test("error when the first parameter is not set") {
           for {
+            redis   <- ZIO.service[Redis]
             first   <- uuid
             second  <- uuid
             value   <- uuid
-            _       <- set(first, value)
-            members <- zUnion(2, first, second)().returning[String].either
+            _       <- redis.set(first, value)
+            members <- redis.zUnion(2, first, second)().returning[String].either
           } yield assert(members)(isLeft(isSubtype[WrongType](anything)))
         },
         test("error when the first parameter is set and the second parameter is not set") {
           for {
+            redis   <- ZIO.service[Redis]
             first   <- uuid
             second  <- uuid
             value   <- uuid
-            _       <- zAdd(first)(MemberScore(1, "a"))
-            _       <- set(second, value)
-            members <- zUnion(2, first, second)().returning[String].either
+            _       <- redis.zAdd(first)(MemberScore(1, "a"))
+            _       <- redis.set(second, value)
+            members <- redis.zUnion(2, first, second)().returning[String].either
           } yield assert(members)(isLeft(isSubtype[WrongType](anything)))
         },
         test("parameter weights provided") {
           for {
+            redis   <- ZIO.service[Redis]
             first   <- uuid
             second  <- uuid
-            _       <- zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
-            _       <- zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
-            members <- zUnion(2, first, second)(Some(::(2, List(3)))).returning[String]
+            _       <- redis.zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
+            _       <- redis.zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
+            members <- redis.zUnion(2, first, second)(Some(::(2, List(3)))).returning[String]
           } yield assert(members)(equalTo(Chunk("M", "P", "O", "N")))
         },
         test("error when invalid weights provided ( less than sets number )") {
           for {
+            redis   <- ZIO.service[Redis]
             first   <- uuid
             second  <- uuid
-            _       <- zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
-            _       <- zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
-            members <- zUnion(2, first, second)(Some(::(2, Nil))).returning[String].either
+            _       <- redis.zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
+            _       <- redis.zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
+            members <- redis.zUnion(2, first, second)(Some(::(2, Nil))).returning[String].either
           } yield assert(members)(isLeft(isSubtype[ProtocolError](anything)))
         },
         test("error when invalid weights provided ( more than sets number )") {
           for {
+            redis   <- ZIO.service[Redis]
             first   <- uuid
             second  <- uuid
-            _       <- zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
-            _       <- zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
-            members <- zUnion(2, first, second)(Some(::(2, List(3, 5)))).returning[String].either
+            _       <- redis.zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
+            _       <- redis.zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
+            members <- redis.zUnion(2, first, second)(Some(::(2, List(3, 5)))).returning[String].either
           } yield assert(members)(isLeft(isSubtype[ProtocolError](anything)))
         },
         test("set aggregate parameter MAX") {
           for {
+            redis   <- ZIO.service[Redis]
             first   <- uuid
             second  <- uuid
-            _       <- zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
-            _       <- zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
-            members <- zUnion(2, first, second)(aggregate = Some(Aggregate.Max)).returning[String]
+            _       <- redis.zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
+            _       <- redis.zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
+            members <- redis.zUnion(2, first, second)(aggregate = Some(Aggregate.Max)).returning[String]
           } yield assert(members)(equalTo(Chunk("P", "M", "N", "O")))
         },
         test("set aggregate parameter MIN") {
           for {
+            redis   <- ZIO.service[Redis]
             first   <- uuid
             second  <- uuid
-            _       <- zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
-            _       <- zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
-            members <- zUnion(2, first, second)(aggregate = Some(Aggregate.Min)).returning[String]
+            _       <- redis.zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
+            _       <- redis.zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
+            members <- redis.zUnion(2, first, second)(aggregate = Some(Aggregate.Min)).returning[String]
           } yield assert(members)(equalTo(Chunk("O", "N", "P", "M")))
         },
         test("parameter weights provided along with aggregate") {
           for {
+            redis   <- ZIO.service[Redis]
             first   <- uuid
             second  <- uuid
-            _       <- zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
-            _       <- zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
-            members <- zUnion(2, first, second)(Some(::(2, List(3))), Some(Aggregate.Max)).returning[String]
+            _       <- redis.zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
+            _       <- redis.zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
+            members <- redis.zUnion(2, first, second)(Some(::(2, List(3))), Some(Aggregate.Max)).returning[String]
           } yield assert(members)(equalTo(Chunk("M", "N", "P", "O")))
         }
       ) @@ clusterExecutorUnsupported,
       suite("zUnionWithScores")(
         test("two non-empty sets") {
           for {
+            redis   <- ZIO.service[Redis]
             first   <- uuid
             second  <- uuid
-            _       <- zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
-            _       <- zAdd(second)(MemberScore(1d, "a"), MemberScore(3d, "c"), MemberScore(5d, "e"))
-            members <- zUnionWithScores(2, first, second)().returning[String]
+            _       <- redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
+            _       <- redis.zAdd(second)(MemberScore(1d, "a"), MemberScore(3d, "c"), MemberScore(5d, "e"))
+            members <- redis.zUnionWithScores(2, first, second)().returning[String]
           } yield assert(members)(
             equalTo(
               Chunk(
@@ -1448,28 +1585,31 @@ trait SortedSetsSpec extends BaseSpec {
         },
         test("equal to the non-empty set when the other one is empty") {
           for {
+            redis    <- ZIO.service[Redis]
             nonEmpty <- uuid
             empty    <- uuid
-            _        <- zAdd(nonEmpty)(MemberScore(1d, "a"), MemberScore(2d, "b"))
-            members  <- zUnionWithScores(2, nonEmpty, empty)().returning[String]
+            _        <- redis.zAdd(nonEmpty)(MemberScore(1d, "a"), MemberScore(2d, "b"))
+            members  <- redis.zUnionWithScores(2, nonEmpty, empty)().returning[String]
           } yield assert(members)(equalTo(Chunk(MemberScore(1d, "a"), MemberScore(2d, "b"))))
         },
         test("empty when both sets are empty") {
           for {
+            redis   <- ZIO.service[Redis]
             first   <- uuid
             second  <- uuid
-            members <- zUnionWithScores(2, first, second)().returning[String]
+            members <- redis.zUnionWithScores(2, first, second)().returning[String]
           } yield assert(members)(isEmpty)
         },
         test("non-empty set with multiple non-empty sets") {
           for {
+            redis   <- ZIO.service[Redis]
             first   <- uuid
             second  <- uuid
             third   <- uuid
-            _       <- zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
-            _       <- zAdd(second)(MemberScore(2, "b"), MemberScore(4d, "d"))
-            _       <- zAdd(third)(MemberScore(2, "b"), MemberScore(3d, "c"), MemberScore(5d, "e"))
-            members <- zUnionWithScores(3, first, second, third)().returning[String]
+            _       <- redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
+            _       <- redis.zAdd(second)(MemberScore(2, "b"), MemberScore(4d, "d"))
+            _       <- redis.zAdd(third)(MemberScore(2, "b"), MemberScore(3d, "c"), MemberScore(5d, "e"))
+            members <- redis.zUnionWithScores(3, first, second, third)().returning[String]
           } yield assert(members)(
             equalTo(
               Chunk(
@@ -1484,30 +1624,33 @@ trait SortedSetsSpec extends BaseSpec {
         },
         test("error when the first parameter is not set") {
           for {
+            redis   <- ZIO.service[Redis]
             first   <- uuid
             second  <- uuid
             value   <- uuid
-            _       <- set(first, value)
-            members <- zUnionWithScores(2, first, second)().returning[String].either
+            _       <- redis.set(first, value)
+            members <- redis.zUnionWithScores(2, first, second)().returning[String].either
           } yield assert(members)(isLeft(isSubtype[WrongType](anything)))
         },
         test("error when the first parameter is set and the second parameter is not set") {
           for {
+            redis   <- ZIO.service[Redis]
             first   <- uuid
             second  <- uuid
             value   <- uuid
-            _       <- zAdd(first)(MemberScore(1, "a"))
-            _       <- set(second, value)
-            members <- zUnionWithScores(2, first, second)().returning[String].either
+            _       <- redis.zAdd(first)(MemberScore(1, "a"))
+            _       <- redis.set(second, value)
+            members <- redis.zUnionWithScores(2, first, second)().returning[String].either
           } yield assert(members)(isLeft(isSubtype[WrongType](anything)))
         },
         test("parameter weights provided") {
           for {
+            redis   <- ZIO.service[Redis]
             first   <- uuid
             second  <- uuid
-            _       <- zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
-            _       <- zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
-            members <- zUnionWithScores(2, first, second)(Some(::(2, List(3)))).returning[String]
+            _       <- redis.zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
+            _       <- redis.zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
+            members <- redis.zUnionWithScores(2, first, second)(Some(::(2, List(3)))).returning[String]
           } yield assert(members)(
             equalTo(
               Chunk(
@@ -1521,29 +1664,32 @@ trait SortedSetsSpec extends BaseSpec {
         },
         test("error when invalid weights provided ( less than sets number )") {
           for {
+            redis   <- ZIO.service[Redis]
             first   <- uuid
             second  <- uuid
-            _       <- zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
-            _       <- zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
-            members <- zUnionWithScores(2, first, second)(Some(::(2, Nil))).returning[String].either
+            _       <- redis.zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
+            _       <- redis.zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
+            members <- redis.zUnionWithScores(2, first, second)(Some(::(2, Nil))).returning[String].either
           } yield assert(members)(isLeft(isSubtype[ProtocolError](anything)))
         },
         test("error when invalid weights provided ( more than sets number )") {
           for {
+            redis   <- ZIO.service[Redis]
             first   <- uuid
             second  <- uuid
-            _       <- zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
-            _       <- zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
-            members <- zUnionWithScores(2, first, second)(Some(::(2, List(3, 5)))).returning[String].either
+            _       <- redis.zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
+            _       <- redis.zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
+            members <- redis.zUnionWithScores(2, first, second)(Some(::(2, List(3, 5)))).returning[String].either
           } yield assert(members)(isLeft(isSubtype[ProtocolError](anything)))
         },
         test("set aggregate parameter MAX") {
           for {
+            redis   <- ZIO.service[Redis]
             first   <- uuid
             second  <- uuid
-            _       <- zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
-            _       <- zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
-            members <- zUnionWithScores(2, first, second)(aggregate = Some(Aggregate.Max)).returning[String]
+            _       <- redis.zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
+            _       <- redis.zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
+            members <- redis.zUnionWithScores(2, first, second)(aggregate = Some(Aggregate.Max)).returning[String]
           } yield assert(members)(
             equalTo(
               Chunk(
@@ -1557,11 +1703,12 @@ trait SortedSetsSpec extends BaseSpec {
         },
         test("set aggregate parameter MIN") {
           for {
+            redis   <- ZIO.service[Redis]
             first   <- uuid
             second  <- uuid
-            _       <- zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
-            _       <- zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
-            members <- zUnionWithScores(2, first, second)(aggregate = Some(Aggregate.Min)).returning[String]
+            _       <- redis.zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
+            _       <- redis.zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
+            members <- redis.zUnionWithScores(2, first, second)(aggregate = Some(Aggregate.Min)).returning[String]
           } yield assert(members)(
             equalTo(
               Chunk(
@@ -1575,11 +1722,12 @@ trait SortedSetsSpec extends BaseSpec {
         },
         test("parameter weights provided along with aggregate") {
           for {
+            redis   <- ZIO.service[Redis]
             first   <- uuid
             second  <- uuid
-            _       <- zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
-            _       <- zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
-            members <- zUnionWithScores(2, first, second)(Some(::(2, List(3))), Some(Aggregate.Max)).returning[String]
+            _       <- redis.zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
+            _       <- redis.zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
+            members <- redis.zUnionWithScores(2, first, second)(Some(::(2, List(3))), Some(Aggregate.Max)).returning[String]
           } yield assert(members)(
             equalTo(
               Chunk(
@@ -1595,171 +1743,189 @@ trait SortedSetsSpec extends BaseSpec {
       suite("zUnionStore")(
         test("two non-empty sets") {
           for {
+            redis  <- ZIO.service[Redis]
             first  <- uuid
             second <- uuid
             dest   <- uuid
-            _      <- zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
-            _      <- zAdd(second)(MemberScore(1d, "a"), MemberScore(3d, "c"), MemberScore(5d, "e"))
-            card   <- zUnionStore(dest, 2, first, second)()
+            _      <- redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
+            _      <- redis.zAdd(second)(MemberScore(1d, "a"), MemberScore(3d, "c"), MemberScore(5d, "e"))
+            card   <- redis.zUnionStore(dest, 2, first, second)()
           } yield assert(card)(equalTo(5L))
         },
         test("equal to the non-empty set when the other one is empty") {
           for {
+            redis    <- ZIO.service[Redis]
             nonEmpty <- uuid
             empty    <- uuid
             dest     <- uuid
-            _        <- zAdd(nonEmpty)(MemberScore(1d, "a"), MemberScore(2d, "b"))
-            card     <- zUnionStore(dest, 2, nonEmpty, empty)()
+            _        <- redis.zAdd(nonEmpty)(MemberScore(1d, "a"), MemberScore(2d, "b"))
+            card     <- redis.zUnionStore(dest, 2, nonEmpty, empty)()
           } yield assert(card)(equalTo(2L))
         },
         test("empty when both sets are empty") {
           for {
+            redis  <- ZIO.service[Redis]
             first  <- uuid
             second <- uuid
             dest   <- uuid
-            card   <- zUnionStore(dest, 2, first, second)()
+            card   <- redis.zUnionStore(dest, 2, first, second)()
           } yield assert(card)(equalTo(0L))
         },
         test("non-empty set with multiple non-empty sets") {
           for {
+            redis  <- ZIO.service[Redis]
             first  <- uuid
             second <- uuid
             third  <- uuid
             dest   <- uuid
-            _      <- zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
-            _      <- zAdd(second)(MemberScore(2, "b"), MemberScore(4d, "d"))
-            _      <- zAdd(third)(MemberScore(2, "b"), MemberScore(3d, "c"), MemberScore(5d, "e"))
-            card   <- zUnionStore(dest, 3, first, second, third)()
+            _      <- redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
+            _      <- redis.zAdd(second)(MemberScore(2, "b"), MemberScore(4d, "d"))
+            _      <- redis.zAdd(third)(MemberScore(2, "b"), MemberScore(3d, "c"), MemberScore(5d, "e"))
+            card   <- redis.zUnionStore(dest, 3, first, second, third)()
           } yield assert(card)(equalTo(5L))
         },
         test("error when the first parameter is not set") {
           for {
+            redis  <- ZIO.service[Redis]
             first  <- uuid
             second <- uuid
             dest   <- uuid
             value  <- uuid
-            _      <- set(first, value)
-            card   <- zUnionStore(dest, 2, first, second)().either
+            _      <- redis.set(first, value)
+            card   <- redis.zUnionStore(dest, 2, first, second)().either
           } yield assert(card)(isLeft(isSubtype[WrongType](anything)))
         },
         test("error when the first parameter is set and the second parameter is not set") {
           for {
+            redis  <- ZIO.service[Redis]
             first  <- uuid
             second <- uuid
             dest   <- uuid
             value  <- uuid
-            _      <- zAdd(first)(MemberScore(1, "a"))
-            _      <- set(second, value)
-            card   <- zUnionStore(dest, 2, first, second)().either
+            _      <- redis.zAdd(first)(MemberScore(1, "a"))
+            _      <- redis.set(second, value)
+            card   <- redis.zUnionStore(dest, 2, first, second)().either
           } yield assert(card)(isLeft(isSubtype[WrongType](anything)))
         },
         test("parameter weights provided") {
           for {
+            redis  <- ZIO.service[Redis]
             first  <- uuid
             second <- uuid
             dest   <- uuid
-            _      <- zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
-            _      <- zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
-            card   <- zUnionStore(dest, 2, first, second)(Some(::(2, List(3))))
+            _      <- redis.zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
+            _      <- redis.zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
+            card   <- redis.zUnionStore(dest, 2, first, second)(Some(::(2, List(3))))
           } yield assert(card)(equalTo(4L))
         },
         test("error when invalid weights provided ( less than sets number )") {
           for {
+            redis  <- ZIO.service[Redis]
             first  <- uuid
             second <- uuid
             dest   <- uuid
-            _      <- zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
-            _      <- zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
-            card   <- zUnionStore(dest, 2, first, second)(Some(::(2, Nil))).either
+            _      <- redis.zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
+            _      <- redis.zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
+            card   <- redis.zUnionStore(dest, 2, first, second)(Some(::(2, Nil))).either
           } yield assert(card)(isLeft(isSubtype[ProtocolError](anything)))
         },
         test("error when invalid weights provided ( more than sets number )") {
           for {
+            redis  <- ZIO.service[Redis]
             first  <- uuid
             second <- uuid
             dest   <- uuid
-            _      <- zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
-            _      <- zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
-            card   <- zUnionStore(dest, 2, first, second)(Some(::(2, List(3, 5)))).either
+            _      <- redis.zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
+            _      <- redis.zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
+            card   <- redis.zUnionStore(dest, 2, first, second)(Some(::(2, List(3, 5)))).either
           } yield assert(card)(isLeft(isSubtype[ProtocolError](anything)))
         },
         test("set aggregate parameter MAX") {
           for {
+            redis  <- ZIO.service[Redis]
             first  <- uuid
             second <- uuid
             dest   <- uuid
-            _      <- zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
-            _      <- zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
-            card   <- zUnionStore(dest, 2, first, second)(aggregate = Some(Aggregate.Max))
+            _      <- redis.zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
+            _      <- redis.zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
+            card   <- redis.zUnionStore(dest, 2, first, second)(aggregate = Some(Aggregate.Max))
           } yield assert(card)(equalTo(4L))
         },
         test("set aggregate parameter MIN") {
           for {
+            redis  <- ZIO.service[Redis]
             first  <- uuid
             second <- uuid
             dest   <- uuid
-            _      <- zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
-            _      <- zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
-            card   <- zUnionStore(dest, 2, first, second)(aggregate = Some(Aggregate.Min))
+            _      <- redis.zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
+            _      <- redis.zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
+            card   <- redis.zUnionStore(dest, 2, first, second)(aggregate = Some(Aggregate.Min))
           } yield assert(card)(equalTo(4L))
         },
         test("parameter weights provided along with aggregate") {
           for {
+            redis  <- ZIO.service[Redis]
             first  <- uuid
             second <- uuid
             dest   <- uuid
-            _      <- zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
-            _      <- zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
-            card   <- zUnionStore(dest, 2, first, second)(Some(::(2, List(3))), Some(Aggregate.Max))
+            _      <- redis.zAdd(first)(MemberScore(5d, "M"), MemberScore(6d, "N"), MemberScore(7d, "O"))
+            _      <- redis.zAdd(second)(MemberScore(3d, "N"), MemberScore(2d, "O"), MemberScore(4d, "P"))
+            card   <- redis.zUnionStore(dest, 2, first, second)(Some(::(2, List(3))), Some(Aggregate.Max))
           } yield assert(card)(equalTo(4L))
         }
       ) @@ clusterExecutorUnsupported,
       suite("zRandMember")(
         test("key does not exist") {
           for {
+            redis     <- ZIO.service[Redis]
             first     <- uuid
             notExists <- uuid
-            _         <- zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
-            ret       <- zRandMember(notExists).returning[String]
+            _         <- redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
+            ret       <- redis.zRandMember(notExists).returning[String]
           } yield assert(ret)(isNone)
         },
         test("key does not exist with count") {
           for {
+            redis     <- ZIO.service[Redis]
             first     <- uuid
             notExists <- uuid
-            _         <- zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
-            ret       <- zRandMember(notExists, 1).returning[String]
+            _         <- redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
+            ret       <- redis.zRandMember(notExists, 1).returning[String]
           } yield assert(ret)(isEmpty)
         },
         test("get an element") {
           for {
+            redis <- ZIO.service[Redis]
             first <- uuid
-            _     <- zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
-            ret   <- zRandMember(first).returning[String]
+            _     <- redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
+            ret   <- redis.zRandMember(first).returning[String]
           } yield assert(ret)(isSome)
         },
         test("get elements with count") {
           for {
+            redis <- ZIO.service[Redis]
             first <- uuid
-            _     <- zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
-            ret   <- zRandMember(first, 2).returning[String]
+            _     <- redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
+            ret   <- redis.zRandMember(first, 2).returning[String]
           } yield assert(ret)(hasSize(equalTo(2)))
         }
       ),
       suite("zRandMemberWithScores")(
         test("key does not exist") {
           for {
+            redis     <- ZIO.service[Redis]
             first     <- uuid
             notExists <- uuid
-            _         <- zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
-            ret       <- zRandMemberWithScores(notExists, 1).returning[String]
+            _         <- redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
+            ret       <- redis.zRandMemberWithScores(notExists, 1).returning[String]
           } yield assert(ret)(isEmpty)
         },
         test("get elements with count") {
           for {
+            redis <- ZIO.service[Redis]
             first <- uuid
-            _     <- zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
-            ret   <- zRandMemberWithScores(first, 2).returning[String]
+            _     <- redis.zAdd(first)(MemberScore(1d, "a"), MemberScore(2d, "b"), MemberScore(3d, "c"), MemberScore(4d, "d"))
+            ret   <- redis.zRandMemberWithScores(first, 2).returning[String]
           } yield assert(ret)(hasSize(equalTo(2)))
         }
       )
@@ -1772,7 +1938,7 @@ trait SortedSetsSpec extends BaseSpec {
   ): ZIO[Redis, RedisError, Chunk[MemberScore[String]]] =
     ZStream
       .paginateChunkZIO(0L) { cursor =>
-        zScan(key, cursor, pattern, count).returning[String].map {
+        ZIO.serviceWithZIO[Redis](_.zScan(key, cursor, pattern, count).returning[String]).map {
           case (nc, nm) if nc == 0 => (nm, None)
           case (nc, nm)            => (nm, Some(nc))
         }

--- a/redis/src/test/scala/zio/redis/StreamsSpec.scala
+++ b/redis/src/test/scala/zio/redis/StreamsSpec.scala
@@ -12,482 +12,536 @@ trait StreamsSpec extends BaseSpec {
       suite("xAck")(
         test("one message") {
           for {
+            redis    <- ZIO.service[Redis]
             stream   <- uuid
             group    <- uuid
             consumer <- uuid
-            _        <- xGroupCreate(stream, group, "$", mkStream = true)
-            id       <- xAdd(stream, "*", "a" -> "b").returning[String]
-            _        <- xReadGroup(group, consumer)(stream -> ">").returning[String, String]
-            result   <- xAck(stream, group, id)
+            _        <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            id       <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            _        <- redis.xReadGroup(group, consumer)(stream -> ">").returning[String, String]
+            result   <- redis.xAck(stream, group, id)
           } yield assert(result)(equalTo(1L))
         },
         test("multiple messages") {
           for {
+            redis    <- ZIO.service[Redis]
             stream   <- uuid
             group    <- uuid
             consumer <- uuid
-            _        <- xGroupCreate(stream, group, "$", mkStream = true)
-            first    <- xAdd(stream, "*", "a" -> "b").returning[String]
-            second   <- xAdd(stream, "*", "a" -> "b").returning[String]
-            _        <- xReadGroup(group, consumer)(stream -> ">").returning[String, String]
-            result   <- xAck(stream, group, first, second)
+            _        <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            first    <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            second   <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            _        <- redis.xReadGroup(group, consumer)(stream -> ">").returning[String, String]
+            result   <- redis.xAck(stream, group, first, second)
           } yield assert(result)(equalTo(2L))
         },
         test("when stream doesn't exist") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
             group  <- uuid
             id     <- uuid
-            result <- xAck(stream, group, id)
+            result <- redis.xAck(stream, group, id)
           } yield assert(result)(equalTo(0L))
         },
         test("when group doesn't exist") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
             group  <- uuid
-            id     <- xAdd(stream, "*", "a" -> "b").returning[String]
-            result <- xAck(stream, group, id)
+            id     <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            result <- redis.xAck(stream, group, id)
           } yield assert(result)(equalTo(0L))
         },
         test("when message with the given ID doesn't exist") {
           for {
+            redis    <- ZIO.service[Redis]
             stream   <- uuid
             group    <- uuid
             consumer <- uuid
-            _        <- xGroupCreate(stream, group, "$", mkStream = true)
-            _        <- xAdd(stream, "*", "a" -> "b").returning[String]
-            _        <- xReadGroup(group, consumer)(stream -> ">").returning[String, String]
-            result   <- xAck(stream, group, "0-0")
+            _        <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            _        <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            _        <- redis.xReadGroup(group, consumer)(stream -> ">").returning[String, String]
+            result   <- redis.xAck(stream, group, "0-0")
           } yield assert(result)(equalTo(0L))
         },
         test("error when ID has an invalid format") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
             group  <- uuid
             id     <- uuid
-            _      <- xGroupCreate(stream, group, "$", mkStream = true)
-            result <- xAck(stream, group, id).either
+            _      <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            result <- redis.xAck(stream, group, id).either
           } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
         },
         test("error when not stream") {
           for {
+            redis     <- ZIO.service[Redis]
             nonStream <- uuid
             group     <- uuid
             id        <- uuid
-            _         <- set(nonStream, "value")
-            result    <- xAck(nonStream, group, id).either
+            _         <- redis.set(nonStream, "value")
+            result    <- redis.xAck(nonStream, group, id).either
           } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
       suite("xAdd")(
         test("object with one field") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
             id      = "1-0"
-            result <- xAdd(stream, id, "a" -> "b").returning[String]
+            result <- redis.xAdd(stream, id, "a" -> "b").returning[String]
           } yield assert(result)(equalTo(id))
         },
         test("object with multiple fields") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
             id      = "1-0"
-            result <- xAdd(stream, id, "a" -> "b", "c" -> "d").returning[String]
+            result <- redis.xAdd(stream, id, "a" -> "b", "c" -> "d").returning[String]
           } yield assert(result)(equalTo(id))
         },
         test("error when ID should be greater") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
             id      = "0-0"
-            result <- xAdd(stream, id, "a" -> "b").returning[String].either
+            result <- redis.xAdd(stream, id, "a" -> "b").returning[String].either
           } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
         },
         test("error when invalid ID format") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
             id     <- uuid
-            result <- xAdd(stream, id, "a" -> "b").returning[String].either
+            result <- redis.xAdd(stream, id, "a" -> "b").returning[String].either
           } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
         },
         test("error when not stream") {
           for {
+            redis     <- ZIO.service[Redis]
             nonStream <- uuid
             id         = "1-0"
-            _         <- set(nonStream, "value")
-            result    <- xAdd(nonStream, id, "a" -> "b").returning[String].either
+            _         <- redis.set(nonStream, "value")
+            result    <- redis.xAdd(nonStream, id, "a" -> "b").returning[String].either
           } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
       suite("xAddWithMaxLen")(
         test("with positive count and without approximate") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
             id      = "1-0"
-            result <- xAddWithMaxLen(stream, id, 10)("a" -> "b").returning[String]
+            result <- redis.xAddWithMaxLen(stream, id, 10)("a" -> "b").returning[String]
           } yield assert(result)(equalTo(id))
         },
         test("with positive count and with approximate") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
             id      = "1-0"
-            result <- xAddWithMaxLen(stream, id, 10, approximate = true)("a" -> "b").returning[String]
+            result <- redis.xAddWithMaxLen(stream, id, 10, approximate = true)("a" -> "b").returning[String]
           } yield assert(result)(equalTo(id))
         },
         test("error with negative count and without approximate") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
             id      = "1-0"
-            result <- xAddWithMaxLen(stream, id, -10)("a" -> "b").returning[String].either
+            result <- redis.xAddWithMaxLen(stream, id, -10)("a" -> "b").returning[String].either
           } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
         },
         test("error with negative count and with approximate") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
             id      = "1-0"
-            result <- xAddWithMaxLen(stream, id, -10, approximate = true)("a" -> "b").returning[String].either
+            result <- redis.xAddWithMaxLen(stream, id, -10, approximate = true)("a" -> "b").returning[String].either
           } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
         }
       ),
       suite("xClaim")(
         test("one pending message") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
             group  <- uuid
             first  <- uuid
             second <- uuid
-            _      <- xGroupCreate(stream, group, "$", mkStream = true)
-            id     <- xAdd(stream, "*", "a" -> "b").returning[String]
-            _      <- xReadGroup(group, first)(stream -> ">").returning[String, String]
-            result <- xClaim(stream, group, second, 0.millis)(id).returning[String, String]
+            _      <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            id     <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            _      <- redis.xReadGroup(group, first)(stream -> ">").returning[String, String]
+            result <- redis.xClaim(stream, group, second, 0.millis)(id).returning[String, String]
           } yield assert(result)(equalTo(Chunk(StreamEntry(id, Map("a" -> "b")))))
         },
         test("multiple pending messages") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
             group  <- uuid
             first  <- uuid
             second <- uuid
-            _      <- xGroupCreate(stream, group, "$", mkStream = true)
-            id     <- xAdd(stream, "*", "a" -> "b").returning[String]
-            id1    <- xAdd(stream, "*", "c" -> "d", "e" -> "f").returning[String]
-            _      <- xReadGroup(group, first)(stream -> ">").returning[String, String]
-            result <- xClaim(stream, group, second, 0.millis)(id, id1).returning[String, String]
+            _      <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            id     <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            id1    <- redis.xAdd(stream, "*", "c" -> "d", "e" -> "f").returning[String]
+            _      <- redis.xReadGroup(group, first)(stream -> ">").returning[String, String]
+            result <- redis.xClaim(stream, group, second, 0.millis)(id, id1).returning[String, String]
           } yield assert(result)(
             equalTo(Chunk(StreamEntry(id, Map("a" -> "b")), StreamEntry(id1, Map("c" -> "d", "e" -> "f"))))
           )
         },
         test("non-existent message") {
           for {
+            redis    <- ZIO.service[Redis]
             stream   <- uuid
             group    <- uuid
             consumer <- uuid
-            _        <- xGroupCreate(stream, group, "$", mkStream = true)
-            result   <- xClaim(stream, group, consumer, 0.millis)("1-0").returning[String, String]
+            _        <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            result   <- redis.xClaim(stream, group, consumer, 0.millis)("1-0").returning[String, String]
           } yield assert(result)(isEmpty)
         },
         test("existing message that is not in pending state") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
             group  <- uuid
             second <- uuid
-            _      <- xGroupCreate(stream, group, "$", mkStream = true)
-            id     <- xAdd(stream, "*", "a" -> "b").returning[String]
-            result <- xClaim(stream, group, second, 0.millis)(id).returning[String, String]
+            _      <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            id     <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            result <- redis.xClaim(stream, group, second, 0.millis)(id).returning[String, String]
           } yield assert(result)(isEmpty)
         },
         test("with non-existent group") {
           for {
+            redis    <- ZIO.service[Redis]
             stream   <- uuid
             group    <- uuid
             consumer <- uuid
-            result   <- xClaim(stream, group, consumer, 0.millis)("1-0").returning[String, String].either
+            result   <- redis.xClaim(stream, group, consumer, 0.millis)("1-0").returning[String, String].either
           } yield assert(result)(isLeft(isSubtype[NoGroup](anything)))
         },
         test("with positive min idle time") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
             group  <- uuid
             first  <- uuid
             second <- uuid
-            _      <- xGroupCreate(stream, group, "$", mkStream = true)
-            id     <- xAdd(stream, "*", "a" -> "b").returning[String]
-            _      <- xReadGroup(group, first)(stream -> ">").returning[String, String]
-            result <- xClaim(stream, group, second, 360000.millis)(id).returning[String, String]
+            _      <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            id     <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            _      <- redis.xReadGroup(group, first)(stream -> ">").returning[String, String]
+            result <- redis.xClaim(stream, group, second, 360000.millis)(id).returning[String, String]
           } yield assert(result)(isEmpty)
         },
         test("with negative min idle time") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
             group  <- uuid
             first  <- uuid
             second <- uuid
-            _      <- xGroupCreate(stream, group, "$", mkStream = true)
-            id     <- xAdd(stream, "*", "a" -> "b").returning[String]
-            _      <- xReadGroup(group, first)(stream -> ">").returning[String, String]
-            result <-
-              xClaim(stream, group, second, (-360000).millis)(id).returning[String, String]
+            _      <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            id     <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            _      <- redis.xReadGroup(group, first)(stream -> ">").returning[String, String]
+            result <- redis.xClaim(stream, group, second, (-360000).millis)(id).returning[String, String]
           } yield assert(result)(equalTo(Chunk(StreamEntry(id, Map("a" -> "b")))))
         },
         test("with positive idle time") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
             group  <- uuid
             first  <- uuid
             second <- uuid
-            _      <- xGroupCreate(stream, group, "$", mkStream = true)
-            id     <- xAdd(stream, "*", "a" -> "b").returning[String]
-            _      <- xReadGroup(group, first)(stream -> ">").returning[String, String]
-            result <- xClaim(stream, group, second, 0.millis, Some(360000.millis))(id).returning[String, String]
+            _      <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            id     <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            _      <- redis.xReadGroup(group, first)(stream -> ">").returning[String, String]
+            result <- redis.xClaim(stream, group, second, 0.millis, Some(360000.millis))(id).returning[String, String]
           } yield assert(result)(equalTo(Chunk(StreamEntry(id, Map("a" -> "b")))))
         },
         test("with negative idle time") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
             group  <- uuid
             first  <- uuid
             second <- uuid
-            _      <- xGroupCreate(stream, group, "$", mkStream = true)
-            id     <- xAdd(stream, "*", "a" -> "b").returning[String]
-            _      <- xReadGroup(group, first)(stream -> ">").returning[String, String]
-            result <- xClaim(stream, group, second, 0.millis, Some((-360000).millis))(id).returning[String, String]
+            _      <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            id     <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            _      <- redis.xReadGroup(group, first)(stream -> ">").returning[String, String]
+            result <-
+              redis.xClaim(stream, group, second, 0.millis, Some((-360000).millis))(id).returning[String, String]
           } yield assert(result)(equalTo(Chunk(StreamEntry(id, Map("a" -> "b")))))
         },
         test("with positive time") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
             group  <- uuid
             first  <- uuid
             second <- uuid
-            _      <- xGroupCreate(stream, group, "$", mkStream = true)
-            id     <- xAdd(stream, "*", "a" -> "b").returning[String]
-            _      <- xReadGroup(group, first)(stream -> ">").returning[String, String]
-            result <- xClaim(stream, group, second, 0.millis, time = Some(360000.millis))(id).returning[String, String]
+            _      <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            id     <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            _      <- redis.xReadGroup(group, first)(stream -> ">").returning[String, String]
+            result <-
+              redis.xClaim(stream, group, second, 0.millis, time = Some(360000.millis))(id).returning[String, String]
           } yield assert(result)(equalTo(Chunk(StreamEntry(id, Map("a" -> "b")))))
         },
         test("with negative time") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
             group  <- uuid
             first  <- uuid
             second <- uuid
-            _      <- xGroupCreate(stream, group, "$", mkStream = true)
-            id     <- xAdd(stream, "*", "a" -> "b").returning[String]
-            _      <- xReadGroup(group, first)(stream -> ">").returning[String, String]
+            _      <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            id     <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            _      <- redis.xReadGroup(group, first)(stream -> ">").returning[String, String]
             result <-
-              xClaim(stream, group, second, 0.millis, time = Some((-360000).millis))(id).returning[String, String]
+              redis.xClaim(stream, group, second, 0.millis, time = Some((-360000).millis))(id).returning[String, String]
           } yield assert(result)(equalTo(Chunk(StreamEntry(id, Map("a" -> "b")))))
         },
         test("with positive retry count") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
             group  <- uuid
             first  <- uuid
             second <- uuid
-            _      <- xGroupCreate(stream, group, "$", mkStream = true)
-            id     <- xAdd(stream, "*", "a" -> "b").returning[String]
-            _      <- xReadGroup(group, first)(stream -> ">").returning[String, String]
-            result <- xClaim(stream, group, second, 0.millis, retryCount = Some(3))(id).returning[String, String]
+            _      <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            id     <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            _      <- redis.xReadGroup(group, first)(stream -> ">").returning[String, String]
+            result <- redis.xClaim(stream, group, second, 0.millis, retryCount = Some(3))(id).returning[String, String]
           } yield assert(result)(equalTo(Chunk(StreamEntry(id, Map("a" -> "b")))))
         },
         test("with negative retry count") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
             group  <- uuid
             first  <- uuid
             second <- uuid
-            _      <- xGroupCreate(stream, group, "$", mkStream = true)
-            id     <- xAdd(stream, "*", "a" -> "b").returning[String]
-            _      <- xReadGroup(group, first)(stream -> ">").returning[String, String]
-            result <- xClaim(stream, group, second, 0.millis, retryCount = Some(-3))(id).returning[String, String]
+            _      <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            id     <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            _      <- redis.xReadGroup(group, first)(stream -> ">").returning[String, String]
+            result <- redis.xClaim(stream, group, second, 0.millis, retryCount = Some(-3))(id).returning[String, String]
           } yield assert(result)(equalTo(Chunk(StreamEntry(id, Map("a" -> "b")))))
         },
         test("with force when message is not in the pending state") {
           for {
+            redis    <- ZIO.service[Redis]
             stream   <- uuid
             group    <- uuid
             consumer <- uuid
-            _        <- xGroupCreate(stream, group, "$", mkStream = true)
-            id       <- xAdd(stream, "*", "a" -> "b").returning[String]
-            result   <- xClaim(stream, group, consumer, 0.millis, force = true)(id).returning[String, String]
+            _        <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            id       <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            result   <- redis.xClaim(stream, group, consumer, 0.millis, force = true)(id).returning[String, String]
           } yield assert(result)(equalTo(Chunk(StreamEntry(id, Map("a" -> "b")))))
         },
         test("when not stream") {
           for {
+            redis     <- ZIO.service[Redis]
             nonStream <- uuid
             group     <- uuid
             consumer  <- uuid
-            _         <- set(nonStream, "value")
-            result    <- xClaim(nonStream, group, consumer, 0.millis, force = true)("1-0").returning[String, String].either
+            _         <- redis.set(nonStream, "value")
+            result <-
+              redis.xClaim(nonStream, group, consumer, 0.millis, force = true)("1-0").returning[String, String].either
           } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
       suite("xClaimWithJustId")(
         test("one pending message") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
             group  <- uuid
             first  <- uuid
             second <- uuid
-            _      <- xGroupCreate(stream, group, "$", mkStream = true)
-            id     <- xAdd(stream, "*", "a" -> "b").returning[String]
-            _      <- xReadGroup(group, first)(stream -> ">").returning[String, String]
-            result <- xClaimWithJustId(stream, group, second, 0.millis)(id).returning[String]
+            _      <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            id     <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            _      <- redis.xReadGroup(group, first)(stream -> ">").returning[String, String]
+            result <- redis.xClaimWithJustId(stream, group, second, 0.millis)(id).returning[String]
           } yield assert(result)(hasSameElements(Chunk.single(id)))
         },
         test("multiple pending messages") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
             group  <- uuid
             first  <- uuid
             second <- uuid
-            _      <- xGroupCreate(stream, group, "$", mkStream = true)
-            id     <- xAdd(stream, "*", "a" -> "b").returning[String]
-            id1    <- xAdd(stream, "*", "c" -> "d", "e" -> "f").returning[String]
-            _      <- xReadGroup(group, first)(stream -> ">").returning[String, String]
-            result <- xClaimWithJustId(stream, group, second, 0.millis)(id, id1).returning[String]
+            _      <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            id     <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            id1    <- redis.xAdd(stream, "*", "c" -> "d", "e" -> "f").returning[String]
+            _      <- redis.xReadGroup(group, first)(stream -> ">").returning[String, String]
+            result <- redis.xClaimWithJustId(stream, group, second, 0.millis)(id, id1).returning[String]
           } yield assert(result)(hasSameElements(Chunk(id, id1)))
         },
         test("non-existent message") {
           for {
+            redis    <- ZIO.service[Redis]
             stream   <- uuid
             group    <- uuid
             consumer <- uuid
-            _        <- xGroupCreate(stream, group, "$", mkStream = true)
-            result   <- xClaimWithJustId(stream, group, consumer, 0.millis)("1-0").returning[String]
+            _        <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            result   <- redis.xClaimWithJustId(stream, group, consumer, 0.millis)("1-0").returning[String]
           } yield assert(result)(isEmpty)
         },
         test("existing message that is not in pending state") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
             group  <- uuid
             second <- uuid
-            _      <- xGroupCreate(stream, group, "$", mkStream = true)
-            id     <- xAdd(stream, "*", "a" -> "b").returning[String]
-            result <- xClaimWithJustId(stream, group, second, 0.millis)(id).returning[String]
+            _      <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            id     <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            result <- redis.xClaimWithJustId(stream, group, second, 0.millis)(id).returning[String]
           } yield assert(result)(isEmpty)
         },
         test("with non-existent group") {
           for {
+            redis    <- ZIO.service[Redis]
             stream   <- uuid
             group    <- uuid
             consumer <- uuid
-            result   <- xClaimWithJustId(stream, group, consumer, 0.millis)("1-0").returning[String].either
+            result   <- redis.xClaimWithJustId(stream, group, consumer, 0.millis)("1-0").returning[String].either
           } yield assert(result)(isLeft(isSubtype[NoGroup](anything)))
         },
         test("with positive min idle time") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
             group  <- uuid
             first  <- uuid
             second <- uuid
-            _      <- xGroupCreate(stream, group, "$", mkStream = true)
-            id     <- xAdd(stream, "*", "a" -> "b").returning[String]
-            _      <- xReadGroup(group, first)(stream -> ">").returning[String, String]
-            result <- xClaimWithJustId(stream, group, second, 360000.millis)(id).returning[String]
+            _      <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            id     <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            _      <- redis.xReadGroup(group, first)(stream -> ">").returning[String, String]
+            result <- redis.xClaimWithJustId(stream, group, second, 360000.millis)(id).returning[String]
           } yield assert(result)(isEmpty)
         },
         test("with negative min idle time") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
             group  <- uuid
             first  <- uuid
             second <- uuid
-            _      <- xGroupCreate(stream, group, "$", mkStream = true)
-            id     <- xAdd(stream, "*", "a" -> "b").returning[String]
-            _      <- xReadGroup(group, first)(stream -> ">").returning[String, String]
-            result <- xClaimWithJustId(stream, group, second, (-360000).millis)(id).returning[String]
+            _      <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            id     <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            _      <- redis.xReadGroup(group, first)(stream -> ">").returning[String, String]
+            result <- redis.xClaimWithJustId(stream, group, second, (-360000).millis)(id).returning[String]
           } yield assert(result)(hasSameElements(Chunk.single(id)))
         },
         test("with positive idle time") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
             group  <- uuid
             first  <- uuid
             second <- uuid
-            _      <- xGroupCreate(stream, group, "$", mkStream = true)
-            id     <- xAdd(stream, "*", "a" -> "b").returning[String]
-            _      <- xReadGroup(group, first)(stream -> ">").returning[String, String]
-            result <- xClaimWithJustId(stream, group, second, 0.millis, Some(360000.millis))(id).returning[String]
+            _      <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            id     <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            _      <- redis.xReadGroup(group, first)(stream -> ">").returning[String, String]
+            result <- redis.xClaimWithJustId(stream, group, second, 0.millis, Some(360000.millis))(id).returning[String]
           } yield assert(result)(hasSameElements(Chunk.single(id)))
         },
         test("with negative idle time") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
             group  <- uuid
             first  <- uuid
             second <- uuid
-            _      <- xGroupCreate(stream, group, "$", mkStream = true)
-            id     <- xAdd(stream, "*", "a" -> "b").returning[String]
-            _      <- xReadGroup(group, first)(stream -> ">").returning[String, String]
-            result <- xClaimWithJustId(stream, group, second, 0.millis, Some((-360000).millis))(id).returning[String]
+            _      <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            id     <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            _      <- redis.xReadGroup(group, first)(stream -> ">").returning[String, String]
+            result <-
+              redis.xClaimWithJustId(stream, group, second, 0.millis, Some((-360000).millis))(id).returning[String]
           } yield assert(result)(hasSameElements(Chunk.single(id)))
         },
         test("with positive time") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
             group  <- uuid
             first  <- uuid
             second <- uuid
-            _      <- xGroupCreate(stream, group, "$", mkStream = true)
-            id     <- xAdd(stream, "*", "a" -> "b").returning[String]
-            _      <- xReadGroup(group, first)(stream -> ">").returning[String, String]
-            result <- xClaimWithJustId(stream, group, second, 0.millis, time = Some(360000.millis))(id)
+            _      <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            id     <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            _      <- redis.xReadGroup(group, first)(stream -> ">").returning[String, String]
+            result <- redis
+                        .xClaimWithJustId(stream, group, second, 0.millis, time = Some(360000.millis))(id)
                         .returning[String]
           } yield assert(result)(hasSameElements(Chunk.single(id)))
         },
         test("with negative time") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
             group  <- uuid
             first  <- uuid
             second <- uuid
-            _      <- xGroupCreate(stream, group, "$", mkStream = true)
-            id     <- xAdd(stream, "*", "a" -> "b").returning[String]
-            _      <- xReadGroup(group, first)(stream -> ">").returning[String, String]
-            result <- xClaimWithJustId(stream, group, second, 0.millis, time = Some((-360000).millis))(id)
+            _      <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            id     <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            _      <- redis.xReadGroup(group, first)(stream -> ">").returning[String, String]
+            result <- redis
+                        .xClaimWithJustId(stream, group, second, 0.millis, time = Some((-360000).millis))(id)
                         .returning[String]
           } yield assert(result)(hasSameElements(Chunk.single(id)))
         },
         test("with positive retry count") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
             group  <- uuid
             first  <- uuid
             second <- uuid
-            _      <- xGroupCreate(stream, group, "$", mkStream = true)
-            id     <- xAdd(stream, "*", "a" -> "b").returning[String]
-            _      <- xReadGroup(group, first)(stream -> ">").returning[String, String]
-            result <- xClaimWithJustId(stream, group, second, 0.millis, retryCount = Some(3))(id).returning[String]
+            _      <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            id     <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            _      <- redis.xReadGroup(group, first)(stream -> ">").returning[String, String]
+            result <-
+              redis.xClaimWithJustId(stream, group, second, 0.millis, retryCount = Some(3))(id).returning[String]
           } yield assert(result)(hasSameElements(Chunk.single(id)))
         },
         test("with negative retry count") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
             group  <- uuid
             first  <- uuid
             second <- uuid
-            _      <- xGroupCreate(stream, group, "$", mkStream = true)
-            id     <- xAdd(stream, "*", "a" -> "b").returning[String]
-            _      <- xReadGroup(group, first)(stream -> ">").returning[String, String]
-            result <- xClaimWithJustId(stream, group, second, 0.millis, retryCount = Some(-3))(id).returning[String]
+            _      <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            id     <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            _      <- redis.xReadGroup(group, first)(stream -> ">").returning[String, String]
+            result <-
+              redis.xClaimWithJustId(stream, group, second, 0.millis, retryCount = Some(-3))(id).returning[String]
           } yield assert(result)(hasSameElements(Chunk.single(id)))
         },
         test("with force when message is not in the pending state") {
           for {
+            redis    <- ZIO.service[Redis]
             stream   <- uuid
             group    <- uuid
             consumer <- uuid
-            _        <- xGroupCreate(stream, group, "$", mkStream = true)
-            id       <- xAdd(stream, "*", "a" -> "b").returning[String]
-            result   <- xClaimWithJustId(stream, group, consumer, 0.millis, force = true)(id).returning[String]
+            _        <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            id       <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            result   <- redis.xClaimWithJustId(stream, group, consumer, 0.millis, force = true)(id).returning[String]
           } yield assert(result)(hasSameElements(Chunk.single(id)))
         },
         test("when not stream") {
           for {
+            redis     <- ZIO.service[Redis]
             nonStream <- uuid
             group     <- uuid
             consumer  <- uuid
-            _         <- set(nonStream, "value")
-            result <- xClaimWithJustId(nonStream, group, consumer, 0.millis, force = true)("1-0")
+            _         <- redis.set(nonStream, "value")
+            result <- redis
+                        .xClaimWithJustId(nonStream, group, consumer, 0.millis, force = true)("1-0")
                         .returning[String]
                         .either
           } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
@@ -496,297 +550,330 @@ trait StreamsSpec extends BaseSpec {
       suite("xDel")(
         test("an existing message") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
-            id     <- xAdd(stream, "*", "a" -> "b").returning[String]
-            result <- xDel(stream, id)
+            id     <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            result <- redis.xDel(stream, id)
           } yield assert(result)(equalTo(1L))
         },
         test("non-existent message") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
-            result <- xDel(stream, "1-0")
+            result <- redis.xDel(stream, "1-0")
           } yield assert(result)(equalTo(0L))
         },
         test("with an invalid message ID") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
             id     <- uuid
-            result <- xDel(stream, id)
+            result <- redis.xDel(stream, id)
           } yield assert(result)(equalTo(0L))
         },
         test("error when not stream") {
           for {
+            redis     <- ZIO.service[Redis]
             nonStream <- uuid
-            _         <- set(nonStream, "value")
-            result    <- xDel(nonStream, "1-0").either
+            _         <- redis.set(nonStream, "value")
+            result    <- redis.xDel(nonStream, "1-0").either
           } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
       suite("xGroupCreate")(
         test("new group") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
             group  <- uuid
-            result <- xGroupCreate(stream, group, "$", mkStream = true).either
+            result <- redis.xGroupCreate(stream, group, "$", mkStream = true).either
           } yield assert(result)(isRight)
         },
         test("error when stream doesn't exist") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
             group  <- uuid
-            result <- xGroupCreate(stream, group, "$").either
+            result <- redis.xGroupCreate(stream, group, "$").either
           } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
         },
         test("error when invalid ID") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
             group  <- uuid
             id     <- uuid
-            result <- xGroupCreate(stream, group, id, mkStream = true).either
+            result <- redis.xGroupCreate(stream, group, id, mkStream = true).either
           } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
         },
         test("error when group already exists") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
             group  <- uuid
-            _      <- xGroupCreate(stream, group, "$", mkStream = true)
-            result <- xGroupCreate(stream, group, "$").either
+            _      <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            result <- redis.xGroupCreate(stream, group, "$").either
           } yield assert(result)(isLeft(isSubtype[BusyGroup](anything)))
         },
         test("error when not stream") {
           for {
+            redis     <- ZIO.service[Redis]
             nonStream <- uuid
             group     <- uuid
-            _         <- set(nonStream, "value")
-            result    <- xGroupCreate(nonStream, group, "$").either
+            _         <- redis.set(nonStream, "value")
+            result    <- redis.xGroupCreate(nonStream, group, "$").either
           } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
       suite("xGroupSetId")(
         test("for an existing group and message") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
             group  <- uuid
-            id     <- xAdd(stream, "*", "a" -> "b").returning[String]
-            _      <- xGroupCreate(stream, group, "$")
-            result <- xGroupSetId(stream, group, id).either
+            id     <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            _      <- redis.xGroupCreate(stream, group, "$")
+            result <- redis.xGroupSetId(stream, group, id).either
           } yield assert(result)(isRight)
         },
         test("error when non-existent group and an existing message") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
             group  <- uuid
-            id     <- xAdd(stream, "*", "a" -> "b").returning[String]
-            result <- xGroupSetId(stream, group, id).either
+            id     <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            result <- redis.xGroupSetId(stream, group, id).either
           } yield assert(result)(isLeft(isSubtype[NoGroup](anything)))
         },
         test("error when an invalid ID") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
             group  <- uuid
             id     <- uuid
-            result <- xGroupSetId(stream, group, id).either
+            result <- redis.xGroupSetId(stream, group, id).either
           } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
         },
         test("error when not stream") {
           for {
+            redis     <- ZIO.service[Redis]
             nonStream <- uuid
             group     <- uuid
-            result    <- xGroupSetId(nonStream, group, "1-0").either
+            result    <- redis.xGroupSetId(nonStream, group, "1-0").either
           } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
         }
       ),
       suite("xGroupDestroy")(
         test("an existing consumer group") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
             group  <- uuid
-            _      <- xGroupCreate(stream, group, "$", mkStream = true)
-            result <- xGroupDestroy(stream, group)
+            _      <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            result <- redis.xGroupDestroy(stream, group)
           } yield assert(result)(isTrue)
         },
         test("non-existent consumer group") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
             group  <- uuid
-            _      <- xAdd(stream, "*", "a" -> "b").returning[String]
-            result <- xGroupDestroy(stream, group)
+            _      <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            result <- redis.xGroupDestroy(stream, group)
           } yield assert(result)(isFalse)
         },
         test("error when stream doesn't exist") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
             group  <- uuid
-            result <- xGroupDestroy(stream, group).either
+            result <- redis.xGroupDestroy(stream, group).either
           } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
         },
         test("error when not stream") {
           for {
+            redis     <- ZIO.service[Redis]
             nonStream <- uuid
             group     <- uuid
-            _         <- set(nonStream, "value")
-            result    <- xGroupDestroy(nonStream, group).either
+            _         <- redis.set(nonStream, "value")
+            result    <- redis.xGroupDestroy(nonStream, group).either
           } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
       suite("xGroupCreateConsumer")(
         test("new consumer") {
           for {
+            redis    <- ZIO.service[Redis]
             stream   <- uuid
             group    <- uuid
             consumer <- uuid
-            _        <- xGroupCreate(stream, group, "$", mkStream = true)
-            result   <- xGroupCreateConsumer(stream, group, consumer).either
+            _        <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            result   <- redis.xGroupCreateConsumer(stream, group, consumer).either
           } yield assert(result)(isRight)
         },
         test("error when group doesn't exist") {
           for {
+            redis    <- ZIO.service[Redis]
             stream   <- uuid
             group    <- uuid
             consumer <- uuid
-            result   <- xGroupCreateConsumer(stream, group, consumer).either
+            result   <- redis.xGroupCreateConsumer(stream, group, consumer).either
           } yield assert(result)(isLeft)
         },
         test("error when not stream") {
           for {
+            redis     <- ZIO.service[Redis]
             nonStream <- uuid
             group     <- uuid
             consumer  <- uuid
-            _         <- set(nonStream, "value")
-            result    <- xGroupCreateConsumer(nonStream, group, consumer).either
+            _         <- redis.set(nonStream, "value")
+            result    <- redis.xGroupCreateConsumer(nonStream, group, consumer).either
           } yield assert(result)(isLeft)
         }
       ),
       suite("xGroupDelConsumer")(
         test("non-existing consumer") {
           for {
+            redis    <- ZIO.service[Redis]
             stream   <- uuid
             group    <- uuid
             consumer <- uuid
-            _        <- xGroupCreate(stream, group, "$", mkStream = true)
-            result   <- xGroupDelConsumer(stream, group, consumer)
+            _        <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            result   <- redis.xGroupDelConsumer(stream, group, consumer)
           } yield assert(result)(equalTo(0L))
         },
         test("existing consumer with one pending message") {
           for {
+            redis    <- ZIO.service[Redis]
             stream   <- uuid
             group    <- uuid
             consumer <- uuid
-            _        <- xGroupCreate(stream, group, "$", mkStream = true)
-            _        <- xAdd(stream, "*", "a" -> "b").returning[String]
-            _        <- xReadGroup(group, consumer)(stream -> ">").returning[String, String]
-            result   <- xGroupDelConsumer(stream, group, consumer)
+            _        <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            _        <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            _        <- redis.xReadGroup(group, consumer)(stream -> ">").returning[String, String]
+            result   <- redis.xGroupDelConsumer(stream, group, consumer)
           } yield assert(result)(equalTo(1L))
         },
         test("existing consumer with multiple pending message") {
           for {
+            redis    <- ZIO.service[Redis]
             stream   <- uuid
             group    <- uuid
             consumer <- uuid
-            _        <- xGroupCreate(stream, group, "$", mkStream = true)
-            _        <- xAdd(stream, "*", "a" -> "b").returning[String]
-            _        <- xAdd(stream, "*", "a" -> "b").returning[String]
-            _        <- xReadGroup(group, consumer)(stream -> ">").returning[String, String]
-            result   <- xGroupDelConsumer(stream, group, consumer)
+            _        <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            _        <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            _        <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            _        <- redis.xReadGroup(group, consumer)(stream -> ">").returning[String, String]
+            result   <- redis.xGroupDelConsumer(stream, group, consumer)
           } yield assert(result)(equalTo(2L))
         },
         test("error when stream doesn't exist") {
           for {
+            redis    <- ZIO.service[Redis]
             stream   <- uuid
             group    <- uuid
             consumer <- uuid
-            result   <- xGroupDelConsumer(stream, group, consumer).either
+            result   <- redis.xGroupDelConsumer(stream, group, consumer).either
           } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
         },
         test("error when group doesn't exist") {
           for {
+            redis    <- ZIO.service[Redis]
             stream   <- uuid
             group    <- uuid
             consumer <- uuid
-            _        <- xAdd(stream, "*", "a" -> "b").returning[String]
-            result   <- xGroupDelConsumer(stream, group, consumer).either
+            _        <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            result   <- redis.xGroupDelConsumer(stream, group, consumer).either
           } yield assert(result)(isLeft(isSubtype[NoGroup](anything)))
         },
         test("error when not stream") {
           for {
+            redis     <- ZIO.service[Redis]
             nonStream <- uuid
             group     <- uuid
             consumer  <- uuid
-            _         <- set(nonStream, "value")
-            result    <- xGroupDelConsumer(nonStream, group, consumer).either
+            _         <- redis.set(nonStream, "value")
+            result    <- redis.xGroupDelConsumer(nonStream, group, consumer).either
           } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
       suite("xLen")(
         test("empty stream") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
             group  <- uuid
-            _      <- xGroupCreate(stream, group, "$", mkStream = true)
-            result <- xLen(stream)
+            _      <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            result <- redis.xLen(stream)
           } yield assert(result)(equalTo(0L))
         },
         test("non-empty stream") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
-            _      <- xAdd(stream, "*", "a" -> "b").returning[String]
-            result <- xLen(stream)
+            _      <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            result <- redis.xLen(stream)
           } yield assert(result)(equalTo(1L))
         },
         test("error when not stream") {
           for {
+            redis     <- ZIO.service[Redis]
             nonStream <- uuid
-            _         <- set(nonStream, "value")
-            result    <- xLen(nonStream).either
+            _         <- redis.set(nonStream, "value")
+            result    <- redis.xLen(nonStream).either
           } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
       suite("xPending")(
         test("with an empty stream") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
             group  <- uuid
-            _      <- xGroupCreate(stream, group, "$", mkStream = true)
-            result <- xPending(stream, group)
+            _      <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            result <- redis.xPending(stream, group)
           } yield assert(result)(equalTo(PendingInfo(0L, None, None, Map.empty[String, Long])))
         },
         test("with one consumer") {
           for {
+            redis    <- ZIO.service[Redis]
             stream   <- uuid
             group    <- uuid
             consumer <- uuid
-            _        <- xGroupCreate(stream, group, "$", mkStream = true)
-            id       <- xAdd(stream, "*", "a" -> "b").returning[String]
-            _        <- xReadGroup(group, consumer)(stream -> ">").returning[String, String]
-            result   <- xPending(stream, group)
+            _        <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            id       <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            _        <- redis.xReadGroup(group, consumer)(stream -> ">").returning[String, String]
+            result   <- redis.xPending(stream, group)
           } yield assert(result)(equalTo(PendingInfo(1L, Some(id), Some(id), Map(consumer -> 1L))))
         },
         test("with multiple consumers and multiple messages") {
           for {
+            redis    <- ZIO.service[Redis]
             stream   <- uuid
             group    <- uuid
             first    <- uuid
             second   <- uuid
-            _        <- xGroupCreate(stream, group, "$", mkStream = true)
-            firstMsg <- xAdd(stream, "*", "a" -> "b").returning[String]
-            _        <- xReadGroup(group, first)(stream -> ">").returning[String, String]
-            lastMsg  <- xAdd(stream, "*", "a" -> "b").returning[String]
-            _        <- xReadGroup(group, second)(stream -> ">").returning[String, String]
-            result   <- xPending(stream, group)
+            _        <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            firstMsg <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            _        <- redis.xReadGroup(group, first)(stream -> ">").returning[String, String]
+            lastMsg  <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            _        <- redis.xReadGroup(group, second)(stream -> ">").returning[String, String]
+            result   <- redis.xPending(stream, group)
           } yield assert(result)(
             equalTo(PendingInfo(2L, Some(firstMsg), Some(lastMsg), Map(first -> 1L, second -> 1L)))
           )
         },
         test("with 0ms idle time") {
           for {
+            redis               <- ZIO.service[Redis]
             stream              <- uuid
             group               <- uuid
             consumer            <- uuid
-            _                   <- xGroupCreate(stream, group, "$", mkStream = true)
-            id                  <- xAdd(stream, "*", "a" -> "b").returning[String]
-            _                   <- xReadGroup(group, consumer)(stream -> ">").returning[String, String]
+            _                   <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            id                  <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            _                   <- redis.xReadGroup(group, consumer)(stream -> ">").returning[String, String]
             cons: Option[String] = None
-            result              <- xPending(stream, group, "-", "+", 10L, cons, Some(0.millis))
+            result              <- redis.xPending(stream, group, "-", "+", 10L, cons, Some(0.millis))
             msg                  = result.head
           } yield assert(msg.id)(equalTo(id)) && assert(msg.owner)(equalTo(consumer)) && assert(msg.counter)(
             equalTo(1L)
@@ -794,41 +881,45 @@ trait StreamsSpec extends BaseSpec {
         },
         test("with 60s idle time") {
           for {
+            redis               <- ZIO.service[Redis]
             stream              <- uuid
             group               <- uuid
             consumer            <- uuid
-            _                   <- xGroupCreate(stream, group, "$", mkStream = true)
-            _                   <- xAdd(stream, "*", "a" -> "b").returning[String]
-            _                   <- xReadGroup(group, consumer)(stream -> ">").returning[String, String]
+            _                   <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            _                   <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            _                   <- redis.xReadGroup(group, consumer)(stream -> ">").returning[String, String]
             cons: Option[String] = None
-            result              <- xPending(stream, group, "-", "+", 10L, cons, Some(1.minute))
+            result              <- redis.xPending(stream, group, "-", "+", 10L, cons, Some(1.minute))
           } yield assert(result)(isEmpty)
         },
         test("error when group doesn't exist") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
             group  <- uuid
-            _      <- xAdd(stream, "*", "a" -> "b").returning[String]
-            result <- xPending(stream, group).either
+            _      <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            result <- redis.xPending(stream, group).either
           } yield assert(result)(isLeft(isSubtype[NoGroup](anything)))
         },
         test("error when not stream") {
           for {
+            redis     <- ZIO.service[Redis]
             nonStream <- uuid
             group     <- uuid
-            _         <- set(nonStream, "value")
-            result    <- xPending(nonStream, group).either
+            _         <- redis.set(nonStream, "value")
+            result    <- redis.xPending(nonStream, group).either
           } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
         },
         test("with one message unlimited start, unlimited end and count with value 10") {
           for {
+            redis    <- ZIO.service[Redis]
             stream   <- uuid
             group    <- uuid
             consumer <- uuid
-            _        <- xGroupCreate(stream, group, "$", mkStream = true)
-            id       <- xAdd(stream, "*", "a" -> "b").returning[String]
-            _        <- xReadGroup(group, consumer)(stream -> ">").returning[String, String]
-            messages <- xPending[String, String, String, String](stream, group, "-", "+", 10L)
+            _        <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            id       <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            _        <- redis.xReadGroup(group, consumer)(stream -> ">").returning[String, String]
+            messages <- redis.xPending[String, String, String, String](stream, group, "-", "+", 10L)
             result    = messages.head
           } yield assert(messages)(hasSize(equalTo(1))) &&
             assert(result.id)(equalTo(id)) &&
@@ -838,16 +929,17 @@ trait StreamsSpec extends BaseSpec {
         },
         test("with multiple message, unlimited start, unlimited end and count with value 10") {
           for {
+            redis                      <- ZIO.service[Redis]
             stream                     <- uuid
             group                      <- uuid
             first                      <- uuid
             second                     <- uuid
-            _                          <- xGroupCreate(stream, group, "$", mkStream = true)
-            firstMsg                   <- xAdd(stream, "*", "a" -> "b").returning[String]
-            _                          <- xReadGroup(group, first)(stream -> ">").returning[String, String]
-            secondMsg                  <- xAdd(stream, "*", "a" -> "b").returning[String]
-            _                          <- xReadGroup(group, second)(stream -> ">").returning[String, String]
-            messages                   <- xPending[String, String, String, String](stream, group, "-", "+", 10L)
+            _                          <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            firstMsg                   <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            _                          <- redis.xReadGroup(group, first)(stream -> ">").returning[String, String]
+            secondMsg                  <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            _                          <- redis.xReadGroup(group, second)(stream -> ">").returning[String, String]
+            messages                   <- redis.xPending[String, String, String, String](stream, group, "-", "+", 10L)
             (firstResult, secondResult) = (messages(0), messages(1))
           } yield assert(messages)(hasSize(equalTo(2))) &&
             assert(firstResult.id)(equalTo(firstMsg)) &&
@@ -861,16 +953,17 @@ trait StreamsSpec extends BaseSpec {
         },
         test("with unlimited start, unlimited end, count with value 10, and the specified consumer") {
           for {
+            redis    <- ZIO.service[Redis]
             stream   <- uuid
             group    <- uuid
             first    <- uuid
             second   <- uuid
-            _        <- xGroupCreate(stream, group, "$", mkStream = true)
-            id       <- xAdd(stream, "*", "a" -> "b").returning[String]
-            _        <- xReadGroup(group, first)(stream -> ">").returning[String, String]
-            _        <- xAdd(stream, "*", "a" -> "b").returning[String]
-            _        <- xReadGroup(group, second)(stream -> ">").returning[String, String]
-            messages <- xPending[String, String, String, String](stream, group, "-", "+", 10L, Some(first))
+            _        <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            id       <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            _        <- redis.xReadGroup(group, first)(stream -> ">").returning[String, String]
+            _        <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            _        <- redis.xReadGroup(group, second)(stream -> ">").returning[String, String]
+            messages <- redis.xPending[String, String, String, String](stream, group, "-", "+", 10L, Some(first))
             result    = messages.head
           } yield assert(messages)(hasSize(equalTo(1))) &&
             assert(result.id)(equalTo(id)) &&
@@ -880,91 +973,103 @@ trait StreamsSpec extends BaseSpec {
         },
         test("error when invalid ID") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
             group  <- uuid
-            result <- xPending[String, String, String, String](stream, group, "-", "invalid", 10L).either
+            result <- redis.xPending[String, String, String, String](stream, group, "-", "invalid", 10L).either
           } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
         }
       ),
       suite("xRange")(
         test("with an unlimited start and an unlimited end") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
-            id     <- xAdd(stream, "*", "a" -> "b").returning[String]
-            result <- xRange(stream, "-", "+").returning[String, String]
+            id     <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            result <- redis.xRange(stream, "-", "+").returning[String, String]
           } yield assert(result)(equalTo(Chunk(StreamEntry(id, Map("a" -> "b")))))
         },
         test("with the positive count") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
-            first  <- xAdd(stream, "*", "a" -> "b").returning[String]
-            _      <- xAdd(stream, "*", "a" -> "b").returning[String]
-            result <- xRange(stream, "-", "+", 1L).returning[String, String]
+            first  <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            _      <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            result <- redis.xRange(stream, "-", "+", 1L).returning[String, String]
           } yield assert(result)(equalTo(Chunk(StreamEntry(first, Map("a" -> "b")))))
         },
         test("with the negative count") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
-            _      <- xAdd(stream, "*", "a" -> "b").returning[String]
-            _      <- xAdd(stream, "*", "a" -> "b").returning[String]
-            result <- xRange(stream, "-", "+", -1L).returning[String, String]
+            _      <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            _      <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            result <- redis.xRange(stream, "-", "+", -1L).returning[String, String]
           } yield assert(result)(isEmpty)
         },
         test("with the zero count") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
-            _      <- xAdd(stream, "*", "a" -> "b").returning[String]
-            _      <- xAdd(stream, "*", "a" -> "b").returning[String]
-            result <- xRange(stream, "-", "+", 0L).returning[String, String]
+            _      <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            _      <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            result <- redis.xRange(stream, "-", "+", 0L).returning[String, String]
           } yield assert(result)(isEmpty)
         },
         test("when stream doesn't exist") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
-            result <- xRange(stream, "-", "+").returning[String, String]
+            result <- redis.xRange(stream, "-", "+").returning[String, String]
           } yield assert(result)(isEmpty)
         },
         test("when start is greater than an end") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
-            result <- xRange(stream, "+", "-").returning[String, String]
+            result <- redis.xRange(stream, "+", "-").returning[String, String]
           } yield assert(result)(isEmpty)
         },
         test("error when invalid ID") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
-            result <- xRange(stream, "invalid", "+").returning[String, String].either
+            result <- redis.xRange(stream, "invalid", "+").returning[String, String].either
           } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
         },
         test("error when not stream") {
           for {
+            redis     <- ZIO.service[Redis]
             nonStream <- uuid
-            _         <- set(nonStream, "value")
-            result    <- xRange(nonStream, "-", "+").returning[String, String].either
+            _         <- redis.set(nonStream, "value")
+            result    <- redis.xRange(nonStream, "-", "+").returning[String, String].either
           } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
       suite("xRead")(
         test("from the non-empty stream") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
-            id     <- xAdd(stream, "*", "a" -> "b").returning[String]
-            result <- xRead()(stream -> "0-0").returning[String, String]
+            id     <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            result <- redis.xRead()(stream -> "0-0").returning[String, String]
           } yield assert(result)(equalTo(Chunk(StreamChunk(stream, Chunk(StreamEntry(id, Map("a" -> "b")))))))
         },
         test("from the stream that doesn't exist") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
-            result <- xRead()(stream -> "0-0").returning[String, String]
+            result <- redis.xRead()(stream -> "0-0").returning[String, String]
           } yield assert(result)(isEmpty)
         },
         test("from the multiple streams") {
           for {
+            redis     <- ZIO.service[Redis]
             first     <- uuid
             second    <- uuid
-            firstMsg  <- xAdd(first, "*", "a" -> "b").returning[String]
-            secondMsg <- xAdd(second, "*", "a" -> "b").returning[String]
-            result    <- xRead()(first -> "0-0", second -> "0-0").returning[String, String]
+            firstMsg  <- redis.xAdd(first, "*", "a" -> "b").returning[String]
+            secondMsg <- redis.xAdd(second, "*", "a" -> "b").returning[String]
+            result    <- redis.xRead()(first -> "0-0", second -> "0-0").returning[String, String]
           } yield assert(result)(
             equalTo(
               Chunk(
@@ -976,18 +1081,20 @@ trait StreamsSpec extends BaseSpec {
         },
         test("with the positive count") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
-            id     <- xAdd(stream, "*", "a" -> "b").returning[String]
-            _      <- xAdd(stream, "*", "a" -> "b").returning[String]
-            result <- xRead(Some(1L))(stream -> "0-0").returning[String, String]
+            id     <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            _      <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            result <- redis.xRead(Some(1L))(stream -> "0-0").returning[String, String]
           } yield assert(result)(equalTo(Chunk(StreamChunk(stream, Chunk(StreamEntry(id, Map("a" -> "b")))))))
         },
         test("with the zero count") {
           for {
+            redis     <- ZIO.service[Redis]
             stream    <- uuid
-            firstMsg  <- xAdd(stream, "*", "a" -> "b").returning[String]
-            secondMsg <- xAdd(stream, "*", "a" -> "b").returning[String]
-            result    <- xRead(Some(0L))(stream -> "0-0").returning[String, String]
+            firstMsg  <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            secondMsg <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            result    <- redis.xRead(Some(0L))(stream -> "0-0").returning[String, String]
           } yield assert(result)(
             equalTo(
               Chunk(
@@ -1001,10 +1108,11 @@ trait StreamsSpec extends BaseSpec {
         },
         test("with the negative count") {
           for {
+            redis     <- ZIO.service[Redis]
             stream    <- uuid
-            firstMsg  <- xAdd(stream, "*", "a" -> "b").returning[String]
-            secondMsg <- xAdd(stream, "*", "a" -> "b").returning[String]
-            result    <- xRead(Some(-1L))(stream -> "0-0").returning[String, String]
+            firstMsg  <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            secondMsg <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            result    <- redis.xRead(Some(-1L))(stream -> "0-0").returning[String, String]
           } yield assert(result)(
             equalTo(
               Chunk(
@@ -1019,60 +1127,67 @@ trait StreamsSpec extends BaseSpec {
         // TODO: can be unignored when connection pool is introduced
         test("with the 1 second block") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
-            _      <- xAdd(stream, "*", "a" -> "b").returning[String]
-            result <- xRead(block = Some(1.second))(stream -> "$").returning[String, String]
+            _      <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            result <- redis.xRead(block = Some(1.second))(stream -> "$").returning[String, String]
           } yield assert(result)(isEmpty)
         } @@ ignore,
         test("with the 0 second block") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
-            _      <- xAdd(stream, "*", "a" -> "b").returning[String]
-            result <- xRead(block = Some(0.second))(stream -> "$").returning[String, String]
+            _      <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            result <- redis.xRead(block = Some(0.second))(stream -> "$").returning[String, String]
           } yield assert(result)(isEmpty)
         } @@ ignore,
         test("with the -1 second block") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
-            _      <- xAdd(stream, "*", "a" -> "b").returning[String]
-            result <- xRead(block = Some((-1).second))(stream -> "$").returning[String, String]
+            _      <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            result <- redis.xRead(block = Some((-1).second))(stream -> "$").returning[String, String]
           } yield assert(result)(isEmpty)
         } @@ ignore,
         test("error when an invalid ID") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
-            _      <- xAdd(stream, "*", "a" -> "b").returning[String]
-            result <- xRead()(stream -> "invalid").returning[String, String].either
+            _      <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            result <- redis.xRead()(stream -> "invalid").returning[String, String].either
           } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
         },
         test("error when not stream") {
           for {
+            redis     <- ZIO.service[Redis]
             nonStream <- uuid
-            _         <- set(nonStream, "value")
-            result    <- xRead()(nonStream -> "0-0").returning[String, String].either
+            _         <- redis.set(nonStream, "value")
+            result    <- redis.xRead()(nonStream -> "0-0").returning[String, String].either
           } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
       suite("xReadGroup")(
         test("when stream has only one message") {
           for {
+            redis    <- ZIO.service[Redis]
             stream   <- uuid
             group    <- uuid
             consumer <- uuid
-            _        <- xGroupCreate(stream, group, "$", mkStream = true)
-            id       <- xAdd(stream, "*", "a" -> "b").returning[String]
-            result   <- xReadGroup(group, consumer)(stream -> ">").returning[String, String]
+            _        <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            id       <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            result   <- redis.xReadGroup(group, consumer)(stream -> ">").returning[String, String]
           } yield assert(result)(equalTo(Chunk(StreamChunk(stream, Chunk(StreamEntry(id, Map("a" -> "b")))))))
         },
         test("when stream has multiple messages") {
           for {
+            redis    <- ZIO.service[Redis]
             stream   <- uuid
             group    <- uuid
             consumer <- uuid
-            _        <- xGroupCreate(stream, group, "$", mkStream = true)
-            first    <- xAdd(stream, "*", "a" -> "b").returning[String]
-            second   <- xAdd(stream, "*", "a" -> "b").returning[String]
-            result   <- xReadGroup(group, consumer)(stream -> ">").returning[String, String]
+            _        <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            first    <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            second   <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            result   <- redis.xReadGroup(group, consumer)(stream -> ">").returning[String, String]
           } yield assert(result)(
             equalTo(
               Chunk(
@@ -1083,25 +1198,26 @@ trait StreamsSpec extends BaseSpec {
         },
         test("when empty stream") {
           for {
+            redis    <- ZIO.service[Redis]
             stream   <- uuid
             group    <- uuid
             consumer <- uuid
-            _        <- xGroupCreate(stream, group, "$", mkStream = true)
-            result   <- xReadGroup(group, consumer)(stream -> ">").returning[String, String]
+            _        <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            result   <- redis.xReadGroup(group, consumer)(stream -> ">").returning[String, String]
           } yield assert(result)(isEmpty)
         },
         test("when multiple streams") {
           for {
+            redis     <- ZIO.service[Redis]
             first     <- uuid
             second    <- uuid
             group     <- uuid
             consumer  <- uuid
-            _         <- xGroupCreate(first, group, "$", mkStream = true)
-            _         <- xGroupCreate(second, group, "$", mkStream = true)
-            firstMsg  <- xAdd(first, "*", "a" -> "b").returning[String]
-            secondMsg <- xAdd(second, "*", "a" -> "b").returning[String]
-            result <-
-              xReadGroup(group, consumer)(first -> ">", second -> ">").returning[String, String]
+            _         <- redis.xGroupCreate(first, group, "$", mkStream = true)
+            _         <- redis.xGroupCreate(second, group, "$", mkStream = true)
+            firstMsg  <- redis.xAdd(first, "*", "a" -> "b").returning[String]
+            secondMsg <- redis.xAdd(second, "*", "a" -> "b").returning[String]
+            result    <- redis.xReadGroup(group, consumer)(first -> ">", second -> ">").returning[String, String]
           } yield assert(result)(
             equalTo(
               Chunk(
@@ -1113,26 +1229,26 @@ trait StreamsSpec extends BaseSpec {
         },
         test("with positive count") {
           for {
+            redis    <- ZIO.service[Redis]
             stream   <- uuid
             group    <- uuid
             consumer <- uuid
-            _        <- xGroupCreate(stream, group, "$", mkStream = true)
-            first    <- xAdd(stream, "*", "a" -> "b").returning[String]
-            _        <- xAdd(stream, "*", "a" -> "b").returning[String]
-            result <-
-              xReadGroup(group, consumer, Some(1L))(stream -> ">").returning[String, String]
+            _        <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            first    <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            _        <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            result   <- redis.xReadGroup(group, consumer, Some(1L))(stream -> ">").returning[String, String]
           } yield assert(result)(equalTo(Chunk(StreamChunk(stream, Chunk(StreamEntry(first, Map("a" -> "b")))))))
         },
         test("with zero count") {
           for {
+            redis    <- ZIO.service[Redis]
             stream   <- uuid
             group    <- uuid
             consumer <- uuid
-            _        <- xGroupCreate(stream, group, "$", mkStream = true)
-            first    <- xAdd(stream, "*", "a" -> "b").returning[String]
-            second   <- xAdd(stream, "*", "a" -> "b").returning[String]
-            result <-
-              xReadGroup(group, consumer, Some(0L))(stream -> ">").returning[String, String]
+            _        <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            first    <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            second   <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            result   <- redis.xReadGroup(group, consumer, Some(0L))(stream -> ">").returning[String, String]
           } yield assert(result)(
             equalTo(
               Chunk(
@@ -1143,14 +1259,14 @@ trait StreamsSpec extends BaseSpec {
         },
         test("with negative count") {
           for {
+            redis    <- ZIO.service[Redis]
             stream   <- uuid
             group    <- uuid
             consumer <- uuid
-            _        <- xGroupCreate(stream, group, "$", mkStream = true)
-            first    <- xAdd(stream, "*", "a" -> "b").returning[String]
-            second   <- xAdd(stream, "*", "a" -> "b").returning[String]
-            result <-
-              xReadGroup(group, consumer, Some(-1L))(stream -> ">").returning[String, String]
+            _        <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            first    <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            second   <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            result   <- redis.xReadGroup(group, consumer, Some(-1L))(stream -> ">").returning[String, String]
           } yield assert(result)(
             equalTo(
               Chunk(
@@ -1161,223 +1277,248 @@ trait StreamsSpec extends BaseSpec {
         },
         test("with NOACK flag") {
           for {
+            redis    <- ZIO.service[Redis]
             stream   <- uuid
             group    <- uuid
             consumer <- uuid
-            _        <- xGroupCreate(stream, group, "$", mkStream = true)
-            _ <-
-              xReadGroup(group, consumer, noAck = true)(stream -> ">").returning[String, String]
-            result <- xPending(stream, group)
+            _        <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            _        <- redis.xReadGroup(group, consumer, noAck = true)(stream -> ">").returning[String, String]
+            result   <- redis.xPending(stream, group)
           } yield assert(result.total)(equalTo(0L))
         },
         test("error when group doesn't exist") {
           for {
+            redis    <- ZIO.service[Redis]
             stream   <- uuid
             group    <- uuid
             consumer <- uuid
-            result   <- xReadGroup(group, consumer)(stream -> ">").returning[String, String].either
+            result   <- redis.xReadGroup(group, consumer)(stream -> ">").returning[String, String].either
           } yield assert(result)(isLeft(isSubtype[NoGroup](anything)))
         },
         test("error when invalid ID") {
           for {
+            redis    <- ZIO.service[Redis]
             stream   <- uuid
             group    <- uuid
             consumer <- uuid
-            _        <- xGroupCreate(stream, group, "$", mkStream = true)
-            result <-
-              xReadGroup(group, consumer)(stream -> "invalid").returning[String, String].either
+            _        <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            result   <- redis.xReadGroup(group, consumer)(stream -> "invalid").returning[String, String].either
           } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
         },
         test("error when not stream") {
           for {
+            redis    <- ZIO.service[Redis]
             stream   <- uuid
             group    <- uuid
             consumer <- uuid
-            _        <- set(stream, "value")
-            result   <- xReadGroup(group, consumer)(stream -> ">").returning[String, String].either
+            _        <- redis.set(stream, "value")
+            result   <- redis.xReadGroup(group, consumer)(stream -> ">").returning[String, String].either
           } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
       suite("xRevRange")(
         test("with an unlimited start and an unlimited end") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
-            id     <- xAdd(stream, "*", "a" -> "b").returning[String]
-            result <- xRevRange(stream, "+", "-").returning[String, String]
+            id     <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            result <- redis.xRevRange(stream, "+", "-").returning[String, String]
           } yield assert(result)(equalTo(Chunk(StreamEntry(id, Map("a" -> "b")))))
         },
         test("with the positive count") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
-            _      <- xAdd(stream, "*", "a" -> "b").returning[String]
-            second <- xAdd(stream, "*", "a" -> "b").returning[String]
-            result <- xRevRange(stream, "+", "-", 1L).returning[String, String]
+            _      <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            second <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            result <- redis.xRevRange(stream, "+", "-", 1L).returning[String, String]
           } yield assert(result)(equalTo(Chunk(StreamEntry(second, Map("a" -> "b")))))
         },
         test("with the negative count") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
-            _      <- xAdd(stream, "*", "a" -> "b").returning[String]
-            _      <- xAdd(stream, "*", "a" -> "b").returning[String]
-            result <- xRevRange(stream, "+", "-", -1L).returning[String, String]
+            _      <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            _      <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            result <- redis.xRevRange(stream, "+", "-", -1L).returning[String, String]
           } yield assert(result)(isEmpty)
         },
         test("with the zero count") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
-            _      <- xAdd(stream, "*", "a" -> "b").returning[String]
-            _      <- xAdd(stream, "*", "a" -> "b").returning[String]
-            result <- xRevRange(stream, "+", "-", 0L).returning[String, String]
+            _      <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            _      <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            result <- redis.xRevRange(stream, "+", "-", 0L).returning[String, String]
           } yield assert(result)(isEmpty)
         },
         test("when stream doesn't exist") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
-            result <- xRevRange(stream, "+", "-").returning[String, String]
+            result <- redis.xRevRange(stream, "+", "-").returning[String, String]
           } yield assert(result)(isEmpty)
         },
         test("when start is greater than an end") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
-            result <- xRevRange(stream, "-", "+").returning[String, String]
+            result <- redis.xRevRange(stream, "-", "+").returning[String, String]
           } yield assert(result)(isEmpty)
         },
         test("error when invalid ID") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
-            result <- xRevRange(stream, "invalid", "-").returning[String, String].either
+            result <- redis.xRevRange(stream, "invalid", "-").returning[String, String].either
           } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
         },
         test("error when not stream") {
           for {
+            redis     <- ZIO.service[Redis]
             nonStream <- uuid
-            _         <- set(nonStream, "value")
-            result    <- xRevRange(nonStream, "+", "-").returning[String, String].either
+            _         <- redis.set(nonStream, "value")
+            result    <- redis.xRevRange(nonStream, "+", "-").returning[String, String].either
           } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
       suite("xTrim")(
         test("an empty stream") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
-            result <- xTrim(stream, 1000L)
+            result <- redis.xTrim(stream, 1000L)
           } yield assert(result)(equalTo(0L))
         },
         test("a non-empty stream") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
-            _      <- xAdd(stream, "*", "a" -> "b").returning[String].repeatN(3)
-            result <- xTrim(stream, 2L)
+            _      <- redis.xAdd(stream, "*", "a" -> "b").returning[String].repeatN(3)
+            result <- redis.xTrim(stream, 2L)
           } yield assert(result)(equalTo(2L))
         },
         test("a non-empty stream with an approximate") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
-            _      <- xAdd(stream, "*", "a" -> "b").returning[String]
-            result <- xTrim(stream, 1000L, approximate = true)
+            _      <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            result <- redis.xTrim(stream, 1000L, approximate = true)
           } yield assert(result)(equalTo(0L))
         },
         test("error when negative count") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
-            _      <- xAdd(stream, "*", "a" -> "b").returning[String]
-            result <- xTrim(stream, -1000L).either
+            _      <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            result <- redis.xTrim(stream, -1000L).either
           } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
         },
         test("error when not stream") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
-            _      <- set(stream, "value")
-            result <- xTrim(stream, 1000L).either
+            _      <- redis.set(stream, "value")
+            result <- redis.xTrim(stream, 1000L).either
           } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
       suite("xInfoStream")(
         test("an existing stream") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
             group  <- uuid
-            _      <- xGroupCreate(stream, group, "$", mkStream = true)
-            id     <- xAdd(stream, "*", "a" -> "b").returning[String]
-            result <- xInfoStream(stream).returning[String, String, String]
+            _      <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            id     <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            result <- redis.xInfoStream(stream).returning[String, String, String]
           } yield assert(result.lastEntry.map(_.id))(isSome(equalTo(id)))
         },
         test("error when no such key") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
-            result <- xInfoStream(stream).returning[String, String, String].either
+            result <- redis.xInfoStream(stream).returning[String, String, String].either
           } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
         },
         test("error when not a stream") {
           for {
+            redis     <- ZIO.service[Redis]
             nonStream <- uuid
-            _         <- set(nonStream, "helloworld")
-            result    <- xInfoStream(nonStream).returning[String, String, String].either
+            _         <- redis.set(nonStream, "helloworld")
+            result    <- redis.xInfoStream(nonStream).returning[String, String, String].either
           } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
       suite("xInfoGroups")(
         test("of an existing stream") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
             group  <- uuid
-            _      <- xGroupCreate(stream, group, "$", mkStream = true)
-            _      <- xAdd(stream, "*", "a" -> "b").returning[String]
-            result <- xInfoGroups[String](stream)
+            _      <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            _      <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            result <- redis.xInfoGroups[String](stream)
           } yield assert(result.toList.head.name)(equalTo(group))
         },
         test("error when no such key") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
-            result <- xInfoGroups[String](stream).either
+            result <- redis.xInfoGroups[String](stream).either
           } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
         },
         test("error when not a stream") {
           for {
+            redis     <- ZIO.service[Redis]
             nonStream <- uuid
-            _         <- set(nonStream, "helloworld")
-            result    <- xInfoGroups[String](nonStream).either
+            _         <- redis.set(nonStream, "helloworld")
+            result    <- redis.xInfoGroups[String](nonStream).either
           } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
       suite("xInfoConsumers")(
         test("of an existing stream") {
           for {
+            redis    <- ZIO.service[Redis]
             stream   <- uuid
             group    <- uuid
             consumer <- uuid
-            _        <- xGroupCreate(stream, group, "$", mkStream = true)
-            _        <- xAdd(stream, "*", "a" -> "b").returning[String]
-            _        <- xReadGroup(group, consumer)(stream -> ">").returning[String, String]
-            result   <- xInfoConsumers(stream, group)
+            _        <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            _        <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            _        <- redis.xReadGroup(group, consumer)(stream -> ">").returning[String, String]
+            result   <- redis.xInfoConsumers(stream, group)
           } yield assert(result.toList.head.name)(equalTo(consumer))
         },
         test("error when no such key") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
             group  <- uuid
-            result <- xInfoConsumers(stream, group).either
+            result <- redis.xInfoConsumers(stream, group).either
           } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
         },
         test("error when not a stream") {
           for {
+            redis     <- ZIO.service[Redis]
             nonStream <- uuid
             group     <- uuid
-            _         <- set(nonStream, "helloworld")
-            result    <- xInfoConsumers(nonStream, group).either
+            _         <- redis.set(nonStream, "helloworld")
+            result    <- redis.xInfoConsumers(nonStream, group).either
           } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
       suite("xInfoStreamFull")(
         test("of an existing stream") {
           for {
+            redis    <- ZIO.service[Redis]
             stream   <- uuid
             group    <- uuid
             consumer <- uuid
-            _        <- xGroupCreate(stream, group, "$", mkStream = true)
-            id       <- xAdd(stream, "*", "a" -> "b").returning[String]
-            _        <- xReadGroup(group, consumer)(stream -> ">").returning[String, String]
-            result   <- xInfoStreamFull(stream).returning[String, String, String]
+            _        <- redis.xGroupCreate(stream, group, "$", mkStream = true)
+            id       <- redis.xAdd(stream, "*", "a" -> "b").returning[String]
+            _        <- redis.xReadGroup(group, consumer)(stream -> ">").returning[String, String]
+            result   <- redis.xInfoStreamFull(stream).returning[String, String, String]
           } yield assert {
             val entries       = result.entries
             val length        = result.length
@@ -1388,15 +1529,17 @@ trait StreamsSpec extends BaseSpec {
         },
         test("error when no such key") {
           for {
+            redis  <- ZIO.service[Redis]
             stream <- uuid
-            result <- xInfoStreamFull(stream).returning[String, String, String].either
+            result <- redis.xInfoStreamFull(stream).returning[String, String, String].either
           } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
         },
         test("error when not a stream") {
           for {
+            redis     <- ZIO.service[Redis]
             nonStream <- uuid
-            _         <- set(nonStream, "helloworld")
-            result    <- xInfoStreamFull(nonStream).returning[String, String, String].either
+            _         <- redis.set(nonStream, "helloworld")
+            result    <- redis.xInfoStreamFull(nonStream).returning[String, String, String].either
           } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
         }
       )

--- a/redis/src/test/scala/zio/redis/StringsSpec.scala
+++ b/redis/src/test/scala/zio/redis/StringsSpec.scala
@@ -12,232 +12,265 @@ trait StringsSpec extends BaseSpec {
       suite("append")(
         test("to the end of non-empty string") {
           for {
-            key <- uuid
-            _   <- set(key, "val")
-            len <- append(key, "ue")
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.set(key, "val")
+            len   <- redis.append(key, "ue")
           } yield assert(len)(equalTo(5L))
         },
         test("to the end of empty string") {
           for {
-            key <- uuid
-            len <- append(key, "value")
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            len   <- redis.append(key, "value")
           } yield assert(len)(equalTo(5L))
         },
         test("empty value to the end of non-empty string") {
           for {
-            key <- uuid
-            _   <- set(key, "value")
-            len <- append(key, "")
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.set(key, "value")
+            len   <- redis.append(key, "")
           } yield assert(len)(equalTo(5L))
         },
         test("empty value to the end of empty string") {
           for {
-            key <- uuid
-            len <- append(key, "")
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            len   <- redis.append(key, "")
           } yield assert(len)(equalTo(0L))
         },
         test("error when not string") {
           for {
-            key <- uuid
-            _   <- sAdd(key, "a")
-            len <- append(key, "b").either
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.sAdd(key, "a")
+            len   <- redis.append(key, "b").either
           } yield assert(len)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
       suite("bitCount")(
         test("over non-empty string") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
-            _     <- set(key, "value")
-            count <- bitCount(key)
+            _     <- redis.set(key, "value")
+            count <- redis.bitCount(key)
           } yield assert(count)(equalTo(21L))
         },
         test("over empty string") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
-            count <- bitCount(key)
+            count <- redis.bitCount(key)
           } yield assert(count)(equalTo(0L))
         },
         test("error when not string") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
-            _     <- sAdd(key, "a")
-            count <- bitCount(key).either
+            _     <- redis.sAdd(key, "a")
+            count <- redis.bitCount(key).either
           } yield assert(count)(isLeft(isSubtype[WrongType](anything)))
         },
         test("over non-empty string with range") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
-            _     <- set(key, "value")
-            count <- bitCount(key, Some(1 to 3))
+            _     <- redis.set(key, "value")
+            count <- redis.bitCount(key, Some(1 to 3))
           } yield assert(count)(equalTo(12L))
         },
         test("over non-empty string with range that is too large") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
-            _     <- set(key, "value")
-            count <- bitCount(key, Some(1 to 20))
+            _     <- redis.set(key, "value")
+            count <- redis.bitCount(key, Some(1 to 20))
           } yield assert(count)(equalTo(16L))
         },
         test("over non-empty string with range that ends with the string") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
-            _     <- set(key, "value")
-            count <- bitCount(key, Some(1 to -1))
+            _     <- redis.set(key, "value")
+            count <- redis.bitCount(key, Some(1 to -1))
           } yield assert(count)(equalTo(16L))
         },
         test("over non-empty string with range whose start is bigger than end") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
-            _     <- set(key, "value")
-            count <- bitCount(key, Some(3 to 1))
+            _     <- redis.set(key, "value")
+            count <- redis.bitCount(key, Some(3 to 1))
           } yield assert(count)(equalTo(0L))
         },
         test("over empty string with range") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
-            count <- bitCount(key, Some(1 to 3))
+            count <- redis.bitCount(key, Some(1 to 3))
           } yield assert(count)(equalTo(0L))
         },
         test("over not string with range") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
-            _     <- sAdd(key, "a")
-            count <- bitCount(key, Some(1 to 3)).either
+            _     <- redis.sAdd(key, "a")
+            count <- redis.bitCount(key, Some(1 to 3)).either
           } yield assert(count)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
       suite("bitField")(
         test("get second byte with signed 8 type from existing value") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- set(key, "value")
-            result <- bitField(key, BitFieldCommand.BitFieldGet(BitFieldType.SignedInt(8), 8))
+            _      <- redis.set(key, "value")
+            result <- redis.bitField(key, BitFieldCommand.BitFieldGet(BitFieldType.SignedInt(8), 8))
           } yield assert(result)(equalTo(Chunk(Some(97L))))
         },
         test("get second byte with unsigned 8 type from existing value") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- set(key, "value")
-            result <- bitField(key, BitFieldCommand.BitFieldGet(BitFieldType.UnsignedInt(8), 8))
+            _      <- redis.set(key, "value")
+            result <- redis.bitField(key, BitFieldCommand.BitFieldGet(BitFieldType.UnsignedInt(8), 8))
           } yield assert(result)(equalTo(Chunk(Some(97L))))
         },
         test("get bit with offset out of range from existing value") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- set(key, "value")
-            result <- bitField(key, BitFieldCommand.BitFieldGet(BitFieldType.UnsignedInt(1), 100))
+            _      <- redis.set(key, "value")
+            result <- redis.bitField(key, BitFieldCommand.BitFieldGet(BitFieldType.UnsignedInt(1), 100))
           } yield assert(result)(equalTo(Chunk(Some(0L))))
         },
         test("get bit when empty string") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            result <- bitField(key, BitFieldCommand.BitFieldGet(BitFieldType.UnsignedInt(1), 10))
+            result <- redis.bitField(key, BitFieldCommand.BitFieldGet(BitFieldType.UnsignedInt(1), 10))
           } yield assert(result)(equalTo(Chunk(Some(0L))))
         },
         test("get error when negative offset") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- set(key, "value")
-            result <- bitField(key, BitFieldCommand.BitFieldGet(BitFieldType.UnsignedInt(1), -10)).either
+            _      <- redis.set(key, "value")
+            result <- redis.bitField(key, BitFieldCommand.BitFieldGet(BitFieldType.UnsignedInt(1), -10)).either
           } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
         },
         test("get error when not string") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- sAdd(key, "a")
-            result <- bitField(key, BitFieldCommand.BitFieldGet(BitFieldType.UnsignedInt(1), 10)).either
+            _      <- redis.sAdd(key, "a")
+            result <- redis.bitField(key, BitFieldCommand.BitFieldGet(BitFieldType.UnsignedInt(1), 10)).either
           } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
         },
         test("set second byte when non-empty string") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- set(key, "vblue")
-            result <- bitField(key, BitFieldCommand.BitFieldSet(BitFieldType.UnsignedInt(8), 8, 97))
+            _      <- redis.set(key, "vblue")
+            result <- redis.bitField(key, BitFieldCommand.BitFieldSet(BitFieldType.UnsignedInt(8), 8, 97))
           } yield assert(result)(equalTo(Chunk(Some(98L))))
         },
         test("set bit when offset out of range") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- set(key, "value")
-            result <- bitField(key, BitFieldCommand.BitFieldSet(BitFieldType.UnsignedInt(8), 100, 97))
+            _      <- redis.set(key, "value")
+            result <- redis.bitField(key, BitFieldCommand.BitFieldSet(BitFieldType.UnsignedInt(8), 100, 97))
           } yield assert(result)(equalTo(Chunk(Some(0L))))
         },
         test("set negative value when unsigned type and existing string") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- set(key, "value")
-            result <- bitField(key, BitFieldCommand.BitFieldSet(BitFieldType.UnsignedInt(4), 10, -10))
+            _      <- redis.set(key, "value")
+            result <- redis.bitField(key, BitFieldCommand.BitFieldSet(BitFieldType.UnsignedInt(4), 10, -10))
           } yield assert(result)(equalTo(Chunk(Some(8L))))
         },
         test("set too big value when unsigned type and existing string") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- set(key, "value")
-            result <- bitField(key, BitFieldCommand.BitFieldSet(BitFieldType.UnsignedInt(2), 10, 100))
+            _      <- redis.set(key, "value")
+            result <- redis.bitField(key, BitFieldCommand.BitFieldSet(BitFieldType.UnsignedInt(2), 10, 100))
           } yield assert(result)(equalTo(Chunk(Some(2L))))
         },
         test("set error when negative offset") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- set(key, "value")
-            result <- bitField(key, BitFieldCommand.BitFieldSet(BitFieldType.UnsignedInt(1), -10, 10)).either
+            _      <- redis.set(key, "value")
+            result <- redis.bitField(key, BitFieldCommand.BitFieldSet(BitFieldType.UnsignedInt(1), -10, 10)).either
           } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
         },
         test("set error when not string") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- sAdd(key, "a")
-            result <- bitField(key, BitFieldCommand.BitFieldSet(BitFieldType.UnsignedInt(8), 8, 97)).either
+            _      <- redis.sAdd(key, "a")
+            result <- redis.bitField(key, BitFieldCommand.BitFieldSet(BitFieldType.UnsignedInt(8), 8, 97)).either
           } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
         },
         test("increment byte when non-empty string") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- set(key, "value")
-            result <- bitField(key, BitFieldCommand.BitFieldIncr(BitFieldType.UnsignedInt(8), 8, 3))
+            _      <- redis.set(key, "value")
+            result <- redis.bitField(key, BitFieldCommand.BitFieldIncr(BitFieldType.UnsignedInt(8), 8, 3))
           } yield assert(result)(equalTo(Chunk(Some(100L))))
         },
         test("increment byte by negative value when non-empty string") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- set(key, "value")
-            result <- bitField(key, BitFieldCommand.BitFieldIncr(BitFieldType.UnsignedInt(8), 8, -2))
+            _      <- redis.set(key, "value")
+            result <- redis.bitField(key, BitFieldCommand.BitFieldIncr(BitFieldType.UnsignedInt(8), 8, -2))
           } yield assert(result)(equalTo(Chunk(Some(95L))))
         },
         test("increment bit when offset out of range") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- set(key, "value")
-            result <- bitField(key, BitFieldCommand.BitFieldIncr(BitFieldType.UnsignedInt(1), 100, 1))
+            _      <- redis.set(key, "value")
+            result <- redis.bitField(key, BitFieldCommand.BitFieldIncr(BitFieldType.UnsignedInt(1), 100, 1))
           } yield assert(result)(equalTo(Chunk(Some(1L))))
         },
         test("increment bit when value will overflow") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- set(key, "value")
-            result <- bitField(key, BitFieldCommand.BitFieldIncr(BitFieldType.UnsignedInt(8), 8, 200))
+            _      <- redis.set(key, "value")
+            result <- redis.bitField(key, BitFieldCommand.BitFieldIncr(BitFieldType.UnsignedInt(8), 8, 200))
           } yield assert(result)(equalTo(Chunk(Some(41L))))
         },
         test("increment error when negative offset") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- set(key, "value")
-            result <- bitField(key, BitFieldCommand.BitFieldIncr(BitFieldType.UnsignedInt(1), -10, 1)).either
+            _      <- redis.set(key, "value")
+            result <- redis.bitField(key, BitFieldCommand.BitFieldIncr(BitFieldType.UnsignedInt(1), -10, 1)).either
           } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
         },
         test("increment error when not string") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- sAdd(key, "a")
-            result <- bitField(key, BitFieldCommand.BitFieldIncr(BitFieldType.UnsignedInt(1), 10, 1)).either
+            _      <- redis.sAdd(key, "a")
+            result <- redis.bitField(key, BitFieldCommand.BitFieldIncr(BitFieldType.UnsignedInt(1), 10, 1)).either
           } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
         },
         test("increment with overflow saturation") {
           for {
-            key <- uuid
-            _   <- set(key, "value")
-            result <- bitField(
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.set(key, "value")
+            result <- redis.bitField(
                         key,
                         BitFieldCommand.BitFieldOverflow.Sat,
                         BitFieldCommand.BitFieldIncr(BitFieldType.UnsignedInt(8), 8, 200)
@@ -246,9 +279,10 @@ trait StringsSpec extends BaseSpec {
         },
         test("increment with overflow fail") {
           for {
-            key <- uuid
-            _   <- set(key, "value")
-            result <- bitField(
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.set(key, "value")
+            result <- redis.bitField(
                         key,
                         BitFieldCommand.BitFieldOverflow.Fail,
                         BitFieldCommand.BitFieldIncr(BitFieldType.UnsignedInt(8), 8, 200)
@@ -257,9 +291,10 @@ trait StringsSpec extends BaseSpec {
         },
         test("increment first with overflow wrap and then overflow fail") {
           for {
-            key <- uuid
-            _   <- set(key, "value")
-            result <- bitField(
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.set(key, "value")
+            result <- redis.bitField(
                         key,
                         BitFieldCommand.BitFieldOverflow.Wrap,
                         BitFieldCommand.BitFieldIncr(BitFieldType.UnsignedInt(8), 8, 200),
@@ -270,9 +305,10 @@ trait StringsSpec extends BaseSpec {
         },
         test("first set, then increment and then get same bits") {
           for {
-            key <- uuid
-            _   <- set(key, "value", None, None, None)
-            result <- bitField(
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.set(key, "value", None, None, None)
+            result <- redis.bitField(
                         key,
                         BitFieldCommand.BitFieldSet(BitFieldType.UnsignedInt(8), 8, 98L),
                         BitFieldCommand.BitFieldIncr(BitFieldType.UnsignedInt(8), 8, 2L),
@@ -285,7 +321,7 @@ trait StringsSpec extends BaseSpec {
         test("get LCS from 2 strings") {
           val str1 = "foo"
           val str2 = "fao"
-          assertZIO(stralgoLcs(StralgoLCS.Strings, str1, str2))(
+          assertZIO(ZIO.serviceWithZIO[Redis](_.stralgoLcs(StralgoLCS.Strings, str1, str2)))(
             equalTo(LcsOutput.Lcs("fo"))
           )
         },
@@ -294,11 +330,12 @@ trait StringsSpec extends BaseSpec {
           val str2 = "fao"
 
           for {
+            redis  <- ZIO.service[Redis]
             key1   <- uuid
-            _      <- set(key1, str1, None, None, None)
+            _      <- redis.set(key1, str1, None, None, None)
             key2   <- uuid
-            _      <- set(key2, str2, None, None, None)
-            result <- stralgoLcs(StralgoLCS.Keys, key1, key2)
+            _      <- redis.set(key2, str2, None, None, None)
+            result <- redis.stralgoLcs(StralgoLCS.Keys, key1, key2)
           } yield assert(result)(equalTo(LcsOutput.Lcs("fo")))
         },
         test("get LCS from unknown keys") {
@@ -306,18 +343,19 @@ trait StringsSpec extends BaseSpec {
           val str2 = "fao"
 
           for {
+            redis  <- ZIO.service[Redis]
             key1   <- uuid
-            _      <- set(key1, str1, None, None, None)
+            _      <- redis.set(key1, str1, None, None, None)
             key2   <- uuid
-            _      <- set(key2, str2, None, None, None)
-            result <- stralgoLcs(StralgoLCS.Keys, "unknown", "unknown")
+            _      <- redis.set(key2, str2, None, None, None)
+            result <- redis.stralgoLcs(StralgoLCS.Keys, "unknown", "unknown")
           } yield assert(result)(equalTo(LcsOutput.Lcs("")))
         },
         test("Get length of LCS for strings") {
           val str1 = "foo"
           val str2 = "fao"
           assertZIO(
-            stralgoLcs(StralgoLCS.Strings, str1, str2, Some(StrAlgoLcsQueryType.Len))
+            ZIO.serviceWithZIO[Redis](_.stralgoLcs(StralgoLCS.Strings, str1, str2, Some(StrAlgoLcsQueryType.Len)))
           )(
             equalTo(LcsOutput.Length(2))
           )
@@ -327,12 +365,12 @@ trait StringsSpec extends BaseSpec {
           val str2 = "fao"
 
           for {
-            key1 <- uuid
-            _    <- set(key1, str1, None, None, None)
-            key2 <- uuid
-            _    <- set(key2, str2, None, None, None)
-            result <-
-              stralgoLcs(StralgoLCS.Keys, key1, key2, Some(StrAlgoLcsQueryType.Len))
+            redis  <- ZIO.service[Redis]
+            key1   <- uuid
+            _      <- redis.set(key1, str1, None, None, None)
+            key2   <- uuid
+            _      <- redis.set(key2, str2, None, None, None)
+            result <- redis.stralgoLcs(StralgoLCS.Keys, key1, key2, Some(StrAlgoLcsQueryType.Len))
           } yield assert(result)(equalTo(LcsOutput.Length(2)))
         },
         test("get length of LCS for unknown keys") {
@@ -340,24 +378,24 @@ trait StringsSpec extends BaseSpec {
           val str2 = "fao"
 
           for {
-            key1 <- uuid
-            _    <- set(key1, str1, None, None, None)
-            key2 <- uuid
-            _    <- set(key2, str2, None, None, None)
-            result <-
-              stralgoLcs(
-                StralgoLCS.Keys,
-                "unknown",
-                "unknown",
-                Some(StrAlgoLcsQueryType.Len)
-              )
+            redis <- ZIO.service[Redis]
+            key1  <- uuid
+            _     <- redis.set(key1, str1, None, None, None)
+            key2  <- uuid
+            _     <- redis.set(key2, str2, None, None, None)
+            result <- redis.stralgoLcs(
+                        StralgoLCS.Keys,
+                        "unknown",
+                        "unknown",
+                        Some(StrAlgoLcsQueryType.Len)
+                      )
           } yield assert(result)(equalTo(LcsOutput.Length(0)))
         },
         test("get index of LCS for strings") {
           val str1 = "ohmytext"
           val str2 = "mynewtext"
           assertZIO(
-            stralgoLcs(StralgoLCS.Strings, str1, str2, Some(StrAlgoLcsQueryType.Idx()))
+            ZIO.serviceWithZIO[Redis](_.stralgoLcs(StralgoLCS.Strings, str1, str2, Some(StrAlgoLcsQueryType.Idx())))
           )(
             equalTo(
               LcsOutput.Matches(
@@ -375,12 +413,12 @@ trait StringsSpec extends BaseSpec {
           val str2 = "!mynewtext"
 
           for {
-            key1 <- uuid
-            _    <- set(key1, str1)
-            key2 <- uuid
-            _    <- set(key2, str2)
-            result <-
-              stralgoLcs(StralgoLCS.Keys, key1, key2, Some(StrAlgoLcsQueryType.Idx()))
+            redis  <- ZIO.service[Redis]
+            key1   <- uuid
+            _      <- redis.set(key1, str1)
+            key2   <- uuid
+            _      <- redis.set(key2, str2)
+            result <- redis.stralgoLcs(StralgoLCS.Keys, key1, key2, Some(StrAlgoLcsQueryType.Idx()))
           } yield {
             assert(result)(
               equalTo(
@@ -401,17 +439,17 @@ trait StringsSpec extends BaseSpec {
           val str2 = "!mynewtext"
 
           for {
-            key1 <- uuid
-            _    <- set(key1, str1)
-            key2 <- uuid
-            _    <- set(key2, str2)
-            result <-
-              stralgoLcs(
-                StralgoLCS.Keys,
-                key1,
-                key2,
-                Some(StrAlgoLcsQueryType.Idx(minMatchLength = 2))
-              )
+            redis <- ZIO.service[Redis]
+            key1  <- uuid
+            _     <- redis.set(key1, str1)
+            key2  <- uuid
+            _     <- redis.set(key2, str2)
+            result <- redis.stralgoLcs(
+                        StralgoLCS.Keys,
+                        key1,
+                        key2,
+                        Some(StrAlgoLcsQueryType.Idx(minMatchLength = 2))
+                      )
           } yield {
             assert(result)(
               equalTo(
@@ -431,17 +469,17 @@ trait StringsSpec extends BaseSpec {
           val str2 = "!mynewtext"
 
           for {
-            key1 <- uuid
-            _    <- set(key1, str1)
-            key2 <- uuid
-            _    <- set(key2, str2)
-            result <-
-              stralgoLcs(
-                StralgoLCS.Keys,
-                key1,
-                key2,
-                Some(StrAlgoLcsQueryType.Idx(withMatchLength = true))
-              )
+            redis <- ZIO.service[Redis]
+            key1  <- uuid
+            _     <- redis.set(key1, str1)
+            key2  <- uuid
+            _     <- redis.set(key2, str2)
+            result <- redis.stralgoLcs(
+                        StralgoLCS.Keys,
+                        key1,
+                        key2,
+                        Some(StrAlgoLcsQueryType.Idx(withMatchLength = true))
+                      )
           } yield {
             assert(result)(
               equalTo(
@@ -462,17 +500,17 @@ trait StringsSpec extends BaseSpec {
           val str2 = "!mynewtext"
 
           for {
-            key1 <- uuid
-            _    <- set(key1, str1)
-            key2 <- uuid
-            _    <- set(key2, str2)
-            result <-
-              stralgoLcs(
-                StralgoLCS.Keys,
-                key1,
-                key2,
-                Some(StrAlgoLcsQueryType.Idx(minMatchLength = 2, withMatchLength = true))
-              )
+            redis <- ZIO.service[Redis]
+            key1  <- uuid
+            _     <- redis.set(key1, str1)
+            key2  <- uuid
+            _     <- redis.set(key2, str2)
+            result <- redis.stralgoLcs(
+                        StralgoLCS.Keys,
+                        key1,
+                        key2,
+                        Some(StrAlgoLcsQueryType.Idx(minMatchLength = 2, withMatchLength = true))
+                      )
           } yield {
             assert(result)(
               equalTo(
@@ -491,1246 +529,1401 @@ trait StringsSpec extends BaseSpec {
       suite("bitOp")(
         test("AND over multiple non-empty strings") {
           for {
+            redis  <- ZIO.service[Redis]
             dest   <- uuid
             first  <- uuid
             second <- uuid
             third  <- uuid
-            _      <- set(first, "a")
-            _      <- set(second, "ab")
-            _      <- set(third, "abc")
-            result <- bitOp(BitOperation.AND, dest, first, second, third)
+            _      <- redis.set(first, "a")
+            _      <- redis.set(second, "ab")
+            _      <- redis.set(third, "abc")
+            result <- redis.bitOp(BitOperation.AND, dest, first, second, third)
           } yield assert(result)(equalTo(3L))
         },
         test("AND over two non-empty strings") {
           for {
+            redis  <- ZIO.service[Redis]
             dest   <- uuid
             first  <- uuid
             second <- uuid
-            _      <- set(first, "first")
-            _      <- set(second, "second")
-            result <- bitOp(BitOperation.AND, dest, first, second)
+            _      <- redis.set(first, "first")
+            _      <- redis.set(second, "second")
+            result <- redis.bitOp(BitOperation.AND, dest, first, second)
           } yield assert(result)(equalTo(6L))
         },
         test("AND over one empty and one non-empty string") {
           for {
+            redis    <- ZIO.service[Redis]
             dest     <- uuid
             empty    <- uuid
             nonEmpty <- uuid
-            _        <- set(nonEmpty, "value")
-            result   <- bitOp(BitOperation.AND, dest, empty, nonEmpty)
+            _        <- redis.set(nonEmpty, "value")
+            result   <- redis.bitOp(BitOperation.AND, dest, empty, nonEmpty)
           } yield assert(result)(equalTo(5L))
         },
         test("AND over two empty strings") {
           for {
+            redis  <- ZIO.service[Redis]
             dest   <- uuid
             first  <- uuid
             second <- uuid
-            result <- bitOp(BitOperation.AND, dest, first, second)
+            result <- redis.bitOp(BitOperation.AND, dest, first, second)
           } yield assert(result)(equalTo(0L))
         },
         test("error when AND over one empty and one not string") {
           for {
+            redis     <- ZIO.service[Redis]
             dest      <- uuid
             empty     <- uuid
             notString <- uuid
-            _         <- sAdd(notString, "a")
-            result    <- bitOp(BitOperation.AND, dest, empty, notString).either
+            _         <- redis.sAdd(notString, "a")
+            result    <- redis.bitOp(BitOperation.AND, dest, empty, notString).either
           } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
         },
         test("error when AND over non-empty and one not string") {
           for {
+            redis     <- ZIO.service[Redis]
             dest      <- uuid
             nonEmpty  <- uuid
             notString <- uuid
-            _         <- sAdd(notString, "a")
-            result    <- bitOp(BitOperation.AND, dest, nonEmpty, notString).either
+            _         <- redis.sAdd(notString, "a")
+            result    <- redis.bitOp(BitOperation.AND, dest, nonEmpty, notString).either
           } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
         },
         test("OR over multiple non-empty strings") {
           for {
+            redis  <- ZIO.service[Redis]
             dest   <- uuid
             first  <- uuid
             second <- uuid
             third  <- uuid
-            _      <- set(first, "a")
-            _      <- set(second, "ab")
-            _      <- set(third, "abc")
-            result <- bitOp(BitOperation.OR, dest, first, second, third)
+            _      <- redis.set(first, "a")
+            _      <- redis.set(second, "ab")
+            _      <- redis.set(third, "abc")
+            result <- redis.bitOp(BitOperation.OR, dest, first, second, third)
           } yield assert(result)(equalTo(3L))
         },
         test("OR over two non-empty strings") {
           for {
+            redis  <- ZIO.service[Redis]
             dest   <- uuid
             first  <- uuid
             second <- uuid
-            _      <- set(first, "first")
-            _      <- set(second, "second")
-            result <- bitOp(BitOperation.OR, dest, first, second)
+            _      <- redis.set(first, "first")
+            _      <- redis.set(second, "second")
+            result <- redis.bitOp(BitOperation.OR, dest, first, second)
           } yield assert(result)(equalTo(6L))
         },
         test("OR over one empty and one non-empty string") {
           for {
+            redis    <- ZIO.service[Redis]
             dest     <- uuid
             empty    <- uuid
             nonEmpty <- uuid
-            _        <- set(nonEmpty, "value")
-            result   <- bitOp(BitOperation.OR, dest, empty, nonEmpty)
+            _        <- redis.set(nonEmpty, "value")
+            result   <- redis.bitOp(BitOperation.OR, dest, empty, nonEmpty)
           } yield assert(result)(equalTo(5L))
         },
         test("OR over two empty strings") {
           for {
+            redis  <- ZIO.service[Redis]
             dest   <- uuid
             first  <- uuid
             second <- uuid
-            result <- bitOp(BitOperation.OR, dest, first, second)
+            result <- redis.bitOp(BitOperation.OR, dest, first, second)
           } yield assert(result)(equalTo(0L))
         },
         test("error when OR over one empty and one not string") {
           for {
+            redis     <- ZIO.service[Redis]
             dest      <- uuid
             empty     <- uuid
             notString <- uuid
-            _         <- sAdd(notString, "a")
-            result    <- bitOp(BitOperation.OR, dest, empty, notString).either
+            _         <- redis.sAdd(notString, "a")
+            result    <- redis.bitOp(BitOperation.OR, dest, empty, notString).either
           } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
         },
         test("error when OR over non-empty and one not string") {
           for {
+            redis     <- ZIO.service[Redis]
             dest      <- uuid
             nonEmpty  <- uuid
             notString <- uuid
-            _         <- sAdd(notString, "a")
-            result    <- bitOp(BitOperation.OR, dest, nonEmpty, notString).either
+            _         <- redis.sAdd(notString, "a")
+            result    <- redis.bitOp(BitOperation.OR, dest, nonEmpty, notString).either
           } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
         },
         test("XOR over multiple non-empty strings") {
           for {
+            redis  <- ZIO.service[Redis]
             dest   <- uuid
             first  <- uuid
             second <- uuid
             third  <- uuid
-            _      <- set(first, "a")
-            _      <- set(second, "ab")
-            _      <- set(third, "abc")
-            result <- bitOp(BitOperation.XOR, dest, first, second, third)
+            _      <- redis.set(first, "a")
+            _      <- redis.set(second, "ab")
+            _      <- redis.set(third, "abc")
+            result <- redis.bitOp(BitOperation.XOR, dest, first, second, third)
           } yield assert(result)(equalTo(3L))
         },
         test("XOR over two non-empty strings") {
           for {
+            redis  <- ZIO.service[Redis]
             dest   <- uuid
             first  <- uuid
             second <- uuid
-            _      <- set(first, "first")
-            _      <- set(second, "second")
-            result <- bitOp(BitOperation.XOR, dest, first, second)
+            _      <- redis.set(first, "first")
+            _      <- redis.set(second, "second")
+            result <- redis.bitOp(BitOperation.XOR, dest, first, second)
           } yield assert(result)(equalTo(6L))
         },
         test("XOR over one empty and one non-empty string") {
           for {
+            redis    <- ZIO.service[Redis]
             dest     <- uuid
             empty    <- uuid
             nonEmpty <- uuid
-            _        <- set(nonEmpty, "value")
-            result   <- bitOp(BitOperation.XOR, dest, empty, nonEmpty)
+            _        <- redis.set(nonEmpty, "value")
+            result   <- redis.bitOp(BitOperation.XOR, dest, empty, nonEmpty)
           } yield assert(result)(equalTo(5L))
         },
         test("XOR over two empty strings") {
           for {
+            redis  <- ZIO.service[Redis]
             dest   <- uuid
             first  <- uuid
             second <- uuid
-            result <- bitOp(BitOperation.XOR, dest, first, second)
+            result <- redis.bitOp(BitOperation.XOR, dest, first, second)
           } yield assert(result)(equalTo(0L))
         },
         test("error when XOR over one empty and one not string") {
           for {
+            redis     <- ZIO.service[Redis]
             dest      <- uuid
             empty     <- uuid
             notString <- uuid
-            _         <- sAdd(notString, "a")
-            result    <- bitOp(BitOperation.XOR, dest, empty, notString).either
+            _         <- redis.sAdd(notString, "a")
+            result    <- redis.bitOp(BitOperation.XOR, dest, empty, notString).either
           } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
         },
         test("error when XOR over non-empty and one not string") {
           for {
+            redis     <- ZIO.service[Redis]
             dest      <- uuid
             nonEmpty  <- uuid
             notString <- uuid
-            _         <- sAdd(notString, "a")
-            result    <- bitOp(BitOperation.XOR, dest, nonEmpty, notString).either
+            _         <- redis.sAdd(notString, "a")
+            result    <- redis.bitOp(BitOperation.XOR, dest, nonEmpty, notString).either
           } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
         },
         test("error when NOT over multiple non-empty strings") {
           for {
+            redis  <- ZIO.service[Redis]
             dest   <- uuid
             first  <- uuid
             second <- uuid
             third  <- uuid
-            _      <- set(first, "a")
-            _      <- set(second, "ab")
-            _      <- set(third, "abc")
-            result <- bitOp(BitOperation.NOT, dest, first, second, third).either
+            _      <- redis.set(first, "a")
+            _      <- redis.set(second, "ab")
+            _      <- redis.set(third, "abc")
+            result <- redis.bitOp(BitOperation.NOT, dest, first, second, third).either
           } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
         },
         test("error when NOT over one non-empty and one empty string") {
           for {
+            redis    <- ZIO.service[Redis]
             dest     <- uuid
             nonEmpty <- uuid
             empty    <- uuid
-            _        <- set(nonEmpty, "a")
-            result   <- bitOp(BitOperation.NOT, dest, nonEmpty, empty).either
+            _        <- redis.set(nonEmpty, "a")
+            result   <- redis.bitOp(BitOperation.NOT, dest, nonEmpty, empty).either
           } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
         },
         test("NOT over non-empty string") {
           for {
+            redis  <- ZIO.service[Redis]
             dest   <- uuid
             key    <- uuid
-            _      <- set(key, "value")
-            result <- bitOp(BitOperation.NOT, dest, key)
+            _      <- redis.set(key, "value")
+            result <- redis.bitOp(BitOperation.NOT, dest, key)
           } yield assert(result)(equalTo(5L))
         },
         test("NOT over empty string") {
           for {
+            redis  <- ZIO.service[Redis]
             dest   <- uuid
             key    <- uuid
-            result <- bitOp(BitOperation.NOT, dest, key)
+            result <- redis.bitOp(BitOperation.NOT, dest, key)
           } yield assert(result)(equalTo(0L))
         },
         test("error when NOT over not string") {
           for {
+            redis  <- ZIO.service[Redis]
             dest   <- uuid
             key    <- uuid
-            _      <- sAdd(key, "a")
-            result <- bitOp(BitOperation.NOT, dest, key).either
+            _      <- redis.sAdd(key, "a")
+            result <- redis.bitOp(BitOperation.NOT, dest, key).either
           } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
         }
       ) @@ clusterExecutorUnsupported,
       suite("bitPos")(
         test("of 1 when non-empty string") {
           for {
-            key <- uuid
-            _   <- set(key, "value")
-            pos <- bitPos(key, true)
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.set(key, "value")
+            pos   <- redis.bitPos(key, true)
           } yield assert(pos)(equalTo(1L))
         },
         test("of 0 when non-empty string") {
           for {
-            key <- uuid
-            _   <- set(key, "value")
-            pos <- bitPos(key, false)
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.set(key, "value")
+            pos   <- redis.bitPos(key, false)
           } yield assert(pos)(equalTo(0L))
         },
         test("of 1 when empty string") {
           for {
-            key <- uuid
-            pos <- bitPos(key, true)
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            pos   <- redis.bitPos(key, true)
           } yield assert(pos)(equalTo(-1L))
         },
         test("of 0 when empty string") {
           for {
-            key <- uuid
-            pos <- bitPos(key, false)
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            pos   <- redis.bitPos(key, false)
           } yield assert(pos)(equalTo(0L))
         },
         test("of 1 when non-empty string with start") {
           for {
-            key <- uuid
-            _   <- set(key, "value")
-            pos <- bitPos(key, true, Some(BitPosRange(2L, None)))
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.set(key, "value")
+            pos   <- redis.bitPos(key, true, Some(BitPosRange(2L, None)))
           } yield assert(pos)(equalTo(17L))
         },
         test("of 0 when non-empty string with start") {
           for {
-            key <- uuid
-            _   <- set(key, "value")
-            pos <- bitPos(key, false, Some(BitPosRange(2L, None)))
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.set(key, "value")
+            pos   <- redis.bitPos(key, false, Some(BitPosRange(2L, None)))
           } yield assert(pos)(equalTo(16L))
         },
         test("of 1 when start is greater than non-empty string length") {
           for {
-            key <- uuid
-            _   <- set(key, "value")
-            pos <- bitPos(key, true, Some(BitPosRange(10L, None)))
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.set(key, "value")
+            pos   <- redis.bitPos(key, true, Some(BitPosRange(10L, None)))
           } yield assert(pos)(equalTo(-1L))
         },
         test("of 0 when start is greater than non-empty string length") {
           for {
-            key <- uuid
-            _   <- set(key, "value")
-            pos <- bitPos(key, false, Some(BitPosRange(10L, None)))
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.set(key, "value")
+            pos   <- redis.bitPos(key, false, Some(BitPosRange(10L, None)))
           } yield assert(pos)(equalTo(-1L))
         },
         test("of 1 when empty string with start") {
           for {
-            key <- uuid
-            pos <- bitPos(key, true, Some(BitPosRange(1L, None)))
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            pos   <- redis.bitPos(key, true, Some(BitPosRange(1L, None)))
           } yield assert(pos)(equalTo(-1L))
         },
         test("of 0 when empty string with start") {
           for {
-            key <- uuid
-            pos <- bitPos(key, false, Some(BitPosRange(10L, None)))
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            pos   <- redis.bitPos(key, false, Some(BitPosRange(10L, None)))
           } yield assert(pos)(equalTo(0L))
         },
         test("of 1 when non-empty string with start and end") {
           for {
-            key <- uuid
-            _   <- set(key, "value")
-            pos <- bitPos(key, true, Some(BitPosRange(2L, Some(4L))))
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.set(key, "value")
+            pos   <- redis.bitPos(key, true, Some(BitPosRange(2L, Some(4L))))
           } yield assert(pos)(equalTo(17L))
         },
         test("of 0 when non-empty string with start and end") {
           for {
-            key <- uuid
-            _   <- set(key, "value")
-            pos <- bitPos(key, false, Some(BitPosRange(2L, Some(4L))))
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.set(key, "value")
+            pos   <- redis.bitPos(key, false, Some(BitPosRange(2L, Some(4L))))
           } yield assert(pos)(equalTo(16L))
         },
         test("of 1 when start is greater than end with non-empty string") {
           for {
-            key <- uuid
-            _   <- set(key, "value")
-            pos <- bitPos(key, true, Some(BitPosRange(4L, Some(2L))))
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.set(key, "value")
+            pos   <- redis.bitPos(key, true, Some(BitPosRange(4L, Some(2L))))
           } yield assert(pos)(equalTo(-1L))
         },
         test("of 0 when start is greater than end with non-empty string") {
           for {
-            key <- uuid
-            _   <- set(key, "value")
-            pos <- bitPos(key, false, Some(BitPosRange(4L, Some(2L))))
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.set(key, "value")
+            pos   <- redis.bitPos(key, false, Some(BitPosRange(4L, Some(2L))))
           } yield assert(pos)(equalTo(-1L))
         },
         test("of 1 when range is out of non-empty string") {
           for {
-            key <- uuid
-            _   <- set(key, "value")
-            pos <- bitPos(key, true, Some(BitPosRange(10L, Some(15L))))
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.set(key, "value")
+            pos   <- redis.bitPos(key, true, Some(BitPosRange(10L, Some(15L))))
           } yield assert(pos)(equalTo(-1L))
         },
         test("of 0 when range is out of non-empty string") {
           for {
-            key <- uuid
-            _   <- set(key, "value")
-            pos <- bitPos(key, false, Some(BitPosRange(10L, Some(15L))))
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.set(key, "value")
+            pos   <- redis.bitPos(key, false, Some(BitPosRange(10L, Some(15L))))
           } yield assert(pos)(equalTo(-1L))
         },
         test("of 1 when start is equal to end with non-empty string") {
           for {
-            key <- uuid
-            _   <- set(key, "value")
-            pos <- bitPos(key, true, Some(BitPosRange(1L, Some(1L))))
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.set(key, "value")
+            pos   <- redis.bitPos(key, true, Some(BitPosRange(1L, Some(1L))))
           } yield assert(pos)(equalTo(9L))
         },
         test("of 0 when start is equal to end with non-empty string") {
           for {
-            key <- uuid
-            _   <- set(key, "value")
-            pos <- bitPos(key, false, Some(BitPosRange(1L, Some(1L))))
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.set(key, "value")
+            pos   <- redis.bitPos(key, false, Some(BitPosRange(1L, Some(1L))))
           } yield assert(pos)(equalTo(8L))
         },
         test("of 1 when empty string with start and end") {
           for {
-            key <- uuid
-            pos <- bitPos(key, true, Some(BitPosRange(2L, Some(4L))))
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            pos   <- redis.bitPos(key, true, Some(BitPosRange(2L, Some(4L))))
           } yield assert(pos)(equalTo(-1L))
         },
         test("of 0 when empty string with start and end") {
           for {
-            key <- uuid
-            pos <- bitPos(key, false, Some(BitPosRange(2L, Some(4L))))
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            pos   <- redis.bitPos(key, false, Some(BitPosRange(2L, Some(4L))))
           } yield assert(pos)(equalTo(0L))
         },
         test("of 1 when start is greater than end with empty string") {
           for {
-            key <- uuid
-            pos <- bitPos(key, true, Some(BitPosRange(4L, Some(2L))))
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            pos   <- redis.bitPos(key, true, Some(BitPosRange(4L, Some(2L))))
           } yield assert(pos)(equalTo(-1L))
         },
         test("of 0 when start is greater than end with empty string") {
           for {
-            key <- uuid
-            pos <- bitPos(key, false, Some(BitPosRange(4L, Some(2L))))
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            pos   <- redis.bitPos(key, false, Some(BitPosRange(4L, Some(2L))))
           } yield assert(pos)(equalTo(0L))
         },
         test("error when not string") {
           for {
-            key <- uuid
-            _   <- sAdd(key, "a")
-            pos <- bitPos(key, true).either
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.sAdd(key, "a")
+            pos   <- redis.bitPos(key, true).either
           } yield assert(pos)(isLeft(isSubtype[WrongType](anything)))
         },
         test("error when not string and start is greater than end") {
           for {
-            key <- uuid
-            _   <- sAdd(key, "a")
-            pos <- bitPos(key, false, Some(BitPosRange(4L, Some(2L)))).either
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.sAdd(key, "a")
+            pos   <- redis.bitPos(key, false, Some(BitPosRange(4L, Some(2L)))).either
           } yield assert(pos)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
       suite("decr")(
         test("non-empty integer") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- set(key, "5")
-            result <- decr(key)
+            _      <- redis.set(key, "5")
+            result <- redis.decr(key)
           } yield assert(result)(equalTo(4L))
         },
         test("empty integer") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            result <- decr(key)
+            result <- redis.decr(key)
           } yield assert(result)(equalTo(-1L))
         },
         test("error when out of range integer") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- set(key, "234293482390480948029348230948")
-            result <- decr(key).either
+            _      <- redis.set(key, "234293482390480948029348230948")
+            result <- redis.decr(key).either
           } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
         },
         test("error when not integer") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- set(key, "not-integer")
-            result <- decr(key).either
+            _      <- redis.set(key, "not-integer")
+            result <- redis.decr(key).either
           } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
         }
       ),
       suite("decrBy")(
         test("3 when non-empty integer") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- set(key, "10")
-            result <- decrBy(key, 3L)
+            _      <- redis.set(key, "10")
+            result <- redis.decrBy(key, 3L)
           } yield assert(result)(equalTo(7L))
         },
         test("3 when empty integer") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            result <- decrBy(key, 3L)
+            result <- redis.decrBy(key, 3L)
           } yield assert(result)(equalTo(-3L))
         },
         test("-3 when non-empty integer") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- set(key, "10")
-            result <- decrBy(key, -3L)
+            _      <- redis.set(key, "10")
+            result <- redis.decrBy(key, -3L)
           } yield assert(result)(equalTo(13L))
         },
         test("error when out of range integer") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- set(key, "234293482390480948029348230948")
-            result <- decrBy(key, 3).either
+            _      <- redis.set(key, "234293482390480948029348230948")
+            result <- redis.decrBy(key, 3).either
           } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
         },
         test("error when not integer") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- set(key, "not-integer")
-            result <- decrBy(key, 3).either
+            _      <- redis.set(key, "not-integer")
+            result <- redis.decrBy(key, 3).either
           } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
         }
       ),
       suite("get")(
         test("non-emtpy string") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- set(key, "value")
-            result <- get(key).returning[String]
+            _      <- redis.set(key, "value")
+            result <- redis.get(key).returning[String]
           } yield assert(result)(isSome(equalTo("value")))
         },
         test("emtpy string") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            result <- get(key).returning[String]
+            result <- redis.get(key).returning[String]
           } yield assert(result)(isNone)
         },
         test("error when not string") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- sAdd(key, "a")
-            result <- get(key).returning[String].either
+            _      <- redis.sAdd(key, "a")
+            result <- redis.get(key).returning[String].either
           } yield assert(result)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
       suite("getBit")(
         test("from non-empty string") {
           for {
-            key <- uuid
-            _   <- set(key, "value")
-            bit <- getBit(key, 17L)
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.set(key, "value")
+            bit   <- redis.getBit(key, 17L)
           } yield assert(bit)(equalTo(1L))
         },
         test("with offset larger then string length") {
           for {
-            key <- uuid
-            _   <- set(key, "value")
-            bit <- getBit(key, 100L)
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.set(key, "value")
+            bit   <- redis.getBit(key, 100L)
           } yield assert(bit)(equalTo(0L))
         },
         test("with empty string") {
           for {
-            key <- uuid
-            bit <- getBit(key, 10L)
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            bit   <- redis.getBit(key, 10L)
           } yield assert(bit)(equalTo(0L))
         },
         test("error when negative offset") {
           for {
-            key <- uuid
-            bit <- getBit(key, -1L).either
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            bit   <- redis.getBit(key, -1L).either
           } yield assert(bit)(isLeft(isSubtype[ProtocolError](anything)))
         },
         test("error when not string") {
           for {
-            key <- uuid
-            _   <- sAdd(key, "a")
-            bit <- getBit(key, 10L).either
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.sAdd(key, "a")
+            bit   <- redis.getBit(key, 10L).either
           } yield assert(bit)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
       suite("getRange")(
         test("from non-empty string") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- set(key, "value")
-            substr <- getRange(key, 1 to 3).returning[String]
+            _      <- redis.set(key, "value")
+            substr <- redis.getRange(key, 1 to 3).returning[String]
           } yield assert(substr)(isSome(equalTo("alu")))
         },
         test("with range that exceeds non-empty string length") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- set(key, "value")
-            substr <- getRange(key, 1 to 10).returning[String]
+            _      <- redis.set(key, "value")
+            substr <- redis.getRange(key, 1 to 10).returning[String]
           } yield assert(substr)(isSome(equalTo("alue")))
         },
         test("with range that is outside of non-empty string") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- set(key, "value")
-            substr <- getRange(key, 10 to 15).returning[String]
+            _      <- redis.set(key, "value")
+            substr <- redis.getRange(key, 10 to 15).returning[String]
           } yield assert(substr)(isNone)
         },
         test("with inverse range of non-empty string") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- set(key, "value")
-            substr <- getRange(key, 15 to 3).returning[String]
+            _      <- redis.set(key, "value")
+            substr <- redis.getRange(key, 15 to 3).returning[String]
           } yield assert(substr)(isNone)
         },
         test("with negative range end from non-empty string") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- set(key, "value")
-            substr <- getRange(key, 1 to -1).returning[String]
+            _      <- redis.set(key, "value")
+            substr <- redis.getRange(key, 1 to -1).returning[String]
           } yield assert(substr)(isSome(equalTo("alue")))
         },
         test("with start and end equal from non-empty string") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- set(key, "value")
-            substr <- getRange(key, 1 to 1).returning[String]
+            _      <- redis.set(key, "value")
+            substr <- redis.getRange(key, 1 to 1).returning[String]
           } yield assert(substr)(isSome(equalTo("a")))
         },
         test("from empty string") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            substr <- getRange(key, 1 to 3).returning[String]
+            substr <- redis.getRange(key, 1 to 3).returning[String]
           } yield assert(substr)(isNone)
         },
         test("error when not string") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- sAdd(key, "a")
-            substr <- getRange(key, 1 to 3).returning[String].either
+            _      <- redis.sAdd(key, "a")
+            substr <- redis.getRange(key, 1 to 3).returning[String].either
           } yield assert(substr)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
       suite("getSet")(
         test("non-empty value to the existing string") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- set(key, "value")
-            oldVal <- getSet(key, "abc").returning[String]
+            _      <- redis.set(key, "value")
+            oldVal <- redis.getSet(key, "abc").returning[String]
           } yield assert(oldVal)(isSome(equalTo("value")))
         },
         test("empty value to the existing string") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- set(key, "value")
-            oldVal <- getSet(key, "").returning[String]
+            _      <- redis.set(key, "value")
+            oldVal <- redis.getSet(key, "").returning[String]
           } yield assert(oldVal)(isSome(equalTo("value")))
         },
         test("non-empty value to the empty string") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            oldVal <- getSet(key, "value").returning[String]
+            oldVal <- redis.getSet(key, "value").returning[String]
           } yield assert(oldVal)(isNone)
         },
         test("empty value to the empty string") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            oldVal <- getSet(key, "").returning[String]
+            oldVal <- redis.getSet(key, "").returning[String]
           } yield assert(oldVal)(isNone)
         },
         test("error when not string") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- sAdd(key, "a")
-            oldVal <- getSet(key, "value").returning[String].either
+            _      <- redis.sAdd(key, "a")
+            oldVal <- redis.getSet(key, "value").returning[String].either
           } yield assert(oldVal)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
       suite("incr")(
         test("non-empty integer") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- set(key, "5")
-            result <- incr(key)
+            _      <- redis.set(key, "5")
+            result <- redis.incr(key)
           } yield assert(result)(equalTo(6L))
         },
         test("empty integer") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            result <- incr(key)
+            result <- redis.incr(key)
           } yield assert(result)(equalTo(1L))
         },
         test("error when out of range integer") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- set(key, "234293482390480948029348230948")
-            result <- incr(key).either
+            _      <- redis.set(key, "234293482390480948029348230948")
+            result <- redis.incr(key).either
           } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
         },
         test("error when not integer") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- set(key, "not-integer")
-            result <- incr(key).either
+            _      <- redis.set(key, "not-integer")
+            result <- redis.incr(key).either
           } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
         }
       ),
       suite("incrBy")(
         test("3 when non-empty integer") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- set(key, "10")
-            result <- incrBy(key, 3L)
+            _      <- redis.set(key, "10")
+            result <- redis.incrBy(key, 3L)
           } yield assert(result)(equalTo(13L))
         },
         test("3 when empty integer") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            result <- incrBy(key, 3L)
+            result <- redis.incrBy(key, 3L)
           } yield assert(result)(equalTo(3L))
         },
         test("-3 when non-empty integer") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- set(key, "10")
-            result <- incrBy(key, -3L)
+            _      <- redis.set(key, "10")
+            result <- redis.incrBy(key, -3L)
           } yield assert(result)(equalTo(7L))
         },
         test("error when out of range integer") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- set(key, "234293482390480948029348230948")
-            result <- incrBy(key, 3).either
+            _      <- redis.set(key, "234293482390480948029348230948")
+            result <- redis.incrBy(key, 3).either
           } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
         },
         test("error when not integer") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- set(key, "not-integer")
-            result <- incrBy(key, 3).either
+            _      <- redis.set(key, "not-integer")
+            result <- redis.incrBy(key, 3).either
           } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
         }
       ),
       suite("incrByFloat")(
         test("3.4 when non-empty float") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- set(key, "5.1")
-            result <- incrByFloat(key, 3.4d)
+            _      <- redis.set(key, "5.1")
+            result <- redis.incrByFloat(key, 3.4d)
           } yield assert(result)(equalTo(8.5))
         },
         test("3.4 when empty float") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            result <- incrByFloat(key, 3.4d)
+            result <- redis.incrByFloat(key, 3.4d)
           } yield assert(result)(equalTo(3.4))
         },
         test("-3.4 when non-empty float") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- set(key, "5")
-            result <- incrByFloat(key, -3.4d)
+            _      <- redis.set(key, "5")
+            result <- redis.incrByFloat(key, -3.4d)
           } yield assert(result)(equalTo(1.6))
         },
         test("error when out of range value") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- set(key, s"${Double.MaxValue.toString}1234")
-            result <- incrByFloat(key, 3d).either
+            _      <- redis.set(key, s"${Double.MaxValue.toString}1234")
+            result <- redis.incrByFloat(key, 3d).either
           } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
         },
         test("error when not integer") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- set(key, "not-integer")
-            result <- incrByFloat(key, 3).either
+            _      <- redis.set(key, "not-integer")
+            result <- redis.incrByFloat(key, 3).either
           } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
         }
       ),
       suite("mGet")(
         test("from multiple non-empty strings") {
           for {
+            redis  <- ZIO.service[Redis]
             first  <- uuid
             second <- uuid
-            _      <- set(first, "1")
-            _      <- set(second, "2")
-            result <- mGet(first, second).returning[String]
+            _      <- redis.set(first, "1")
+            _      <- redis.set(second, "2")
+            result <- redis.mGet(first, second).returning[String]
           } yield assert(result)(equalTo(Chunk(Some("1"), Some("2"))))
         },
         test("from one non-empty and one empty string") {
           for {
+            redis    <- ZIO.service[Redis]
             nonEmpty <- uuid
             empty    <- uuid
-            _        <- set(nonEmpty, "value")
-            result   <- mGet(nonEmpty, empty).returning[String]
+            _        <- redis.set(nonEmpty, "value")
+            result   <- redis.mGet(nonEmpty, empty).returning[String]
           } yield assert(result)(equalTo(Chunk(Some("value"), None)))
         },
         test("from two empty strings") {
           for {
+            redis  <- ZIO.service[Redis]
             first  <- uuid
             second <- uuid
-            result <- mGet(first, second).returning[String]
+            result <- redis.mGet(first, second).returning[String]
           } yield assert(result)(equalTo(Chunk(None, None)))
         },
         test("from one string and one not string") {
           for {
+            redis  <- ZIO.service[Redis]
             str    <- uuid
             notStr <- uuid
-            _      <- set(str, "value")
-            _      <- sAdd(notStr, "a")
-            result <- mGet(str, notStr).returning[String]
+            _      <- redis.set(str, "value")
+            _      <- redis.sAdd(notStr, "a")
+            result <- redis.mGet(str, notStr).returning[String]
           } yield assert(result)(equalTo(Chunk(Some("value"), None)))
         },
         test("from one not string") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- sAdd(key, "a")
-            result <- mGet(key).returning[String]
+            _      <- redis.sAdd(key, "a")
+            result <- redis.mGet(key).returning[String]
           } yield assert(result)(equalTo(Chunk(None)))
         }
       ) @@ clusterExecutorUnsupported,
       suite("mSet")(
         test("one new value") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
             value  <- uuid
-            _      <- mSet((key, value))
-            result <- get(key).returning[String]
+            _      <- redis.mSet((key, value))
+            result <- redis.get(key).returning[String]
           } yield assert(result)(isSome(equalTo(value)))
         },
         test("multiple new values") {
           for {
+            redis     <- ZIO.service[Redis]
             first     <- uuid
             second    <- uuid
             firstVal  <- uuid
             secondVal <- uuid
-            _         <- mSet((first, firstVal), (second, secondVal))
-            result    <- mGet(first, second).returning[String]
+            _         <- redis.mSet((first, firstVal), (second, secondVal))
+            result    <- redis.mGet(first, second).returning[String]
           } yield assert(result)(equalTo(Chunk(Some(firstVal), Some(secondVal))))
         },
         test("replace existing values") {
           for {
+            redis       <- ZIO.service[Redis]
             first       <- uuid
             second      <- uuid
             firstVal    <- uuid
             secondVal   <- uuid
             replacement <- uuid
-            _           <- mSet((first, firstVal), (second, secondVal))
-            _           <- mSet((first, replacement), (second, replacement))
-            result      <- mGet(first, second).returning[String]
+            _           <- redis.mSet((first, firstVal), (second, secondVal))
+            _           <- redis.mSet((first, replacement), (second, replacement))
+            result      <- redis.mGet(first, second).returning[String]
           } yield assert(result)(equalTo(Chunk(Some(replacement), Some(replacement))))
         },
         test("one value multiple times at once") {
           for {
+            redis     <- ZIO.service[Redis]
             key       <- uuid
             firstVal  <- uuid
             secondVal <- uuid
-            _         <- mSet((key, firstVal), (key, secondVal))
-            result    <- get(key).returning[String]
+            _         <- redis.mSet((key, firstVal), (key, secondVal))
+            result    <- redis.get(key).returning[String]
           } yield assert(result)(isSome(equalTo(secondVal)))
         },
         test("replace not string value") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
             value  <- uuid
-            _      <- sAdd(key, "a")
-            result <- mSet((key, value)).either
+            _      <- redis.sAdd(key, "a")
+            result <- redis.mSet((key, value)).either
           } yield assert(result)(isRight)
         }
       ) @@ clusterExecutorUnsupported,
       suite("mSetNx")(
         test("one new value") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
             value <- uuid
-            set   <- mSetNx((key, value))
+            set   <- redis.mSetNx((key, value))
           } yield assert(set)(isTrue)
         },
         test("multiple new values") {
           for {
+            redis     <- ZIO.service[Redis]
             first     <- uuid
             second    <- uuid
             firstVal  <- uuid
             secondVal <- uuid
-            set       <- mSetNx((first, firstVal), (second, secondVal))
+            set       <- redis.mSetNx((first, firstVal), (second, secondVal))
           } yield assert(set)(isTrue)
         },
         test("replace existing values") {
           for {
+            redis       <- ZIO.service[Redis]
             first       <- uuid
             second      <- uuid
             firstVal    <- uuid
             secondVal   <- uuid
             replacement <- uuid
-            _           <- mSetNx((first, firstVal), (second, secondVal))
-            set         <- mSetNx((first, replacement), (second, replacement))
+            _           <- redis.mSetNx((first, firstVal), (second, secondVal))
+            set         <- redis.mSetNx((first, replacement), (second, replacement))
           } yield assert(set)(isFalse)
         },
         test("one value multiple times at once") {
           for {
+            redis     <- ZIO.service[Redis]
             key       <- uuid
             firstVal  <- uuid
             secondVal <- uuid
-            set       <- mSetNx((key, firstVal), (key, secondVal))
+            set       <- redis.mSetNx((key, firstVal), (key, secondVal))
           } yield assert(set)(isTrue)
         },
         test("replace not string value") {
           for {
+            redis <- ZIO.service[Redis]
             key   <- uuid
             value <- uuid
-            _     <- sAdd(key, "a")
-            set   <- mSetNx((key, value))
+            _     <- redis.sAdd(key, "a")
+            set   <- redis.mSetNx((key, value))
           } yield assert(set)(isFalse)
         }
       ) @@ clusterExecutorUnsupported,
       suite("pSetEx")(
         test("new value with 1000 milliseconds") {
           for {
+            redis        <- ZIO.service[Redis]
             key          <- uuid
             value        <- uuid
-            _            <- pSetEx(key, 1000.millis, value)
-            existsBefore <- exists(key)
+            _            <- redis.pSetEx(key, 1000.millis, value)
+            existsBefore <- redis.exists(key)
             fiber        <- ZIO.sleep(1010.millis).fork <* TestClock.adjust(1010.millis)
             _            <- fiber.join
-            existsAfter  <- exists(key)
+            existsAfter  <- redis.exists(key)
           } yield assert(existsBefore)(equalTo(1L)) && assert(existsAfter)(equalTo(0L))
         } @@ eventually,
         test("override existing string") {
           for {
+            redis      <- ZIO.service[Redis]
             key        <- uuid
             value      <- uuid
-            _          <- set(key, "value")
-            _          <- pSetEx(key, 1000.millis, value)
-            currentVal <- get(key).returning[String]
+            _          <- redis.set(key, "value")
+            _          <- redis.pSetEx(key, 1000.millis, value)
+            currentVal <- redis.get(key).returning[String]
           } yield assert(currentVal)(isSome(equalTo(value)))
         },
         test("override not string") {
           for {
+            redis      <- ZIO.service[Redis]
             key        <- uuid
             value      <- uuid
-            _          <- sAdd(key, "a")
-            _          <- pSetEx(key, 1000.millis, value)
-            currentVal <- get(key).returning[String]
+            _          <- redis.sAdd(key, "a")
+            _          <- redis.pSetEx(key, 1000.millis, value)
+            currentVal <- redis.get(key).returning[String]
           } yield assert(currentVal)(isSome(equalTo(value)))
         },
         test("error when 0 milliseconds") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
             value  <- uuid
-            result <- pSetEx(key, 0.millis, value).either
+            result <- redis.pSetEx(key, 0.millis, value).either
           } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
         },
         test("error when negative milliseconds") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
             value  <- uuid
-            result <- pSetEx(key, (-1).millis, value).either
+            result <- redis.pSetEx(key, (-1).millis, value).either
           } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
         }
       ),
       suite("set")(
         test("new value") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
             value  <- uuid
-            result <- set(key, value)
+            result <- redis.set(key, value)
           } yield assert(result)(isTrue)
         },
         test("override existing string") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
             value  <- uuid
-            _      <- set(key, "value")
-            result <- set(key, value)
+            _      <- redis.set(key, "value")
+            result <- redis.set(key, value)
           } yield assert(result)(isTrue)
         },
         test("override not string") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
             value  <- uuid
-            _      <- sAdd(key, "a")
-            result <- set(key, value)
+            _      <- redis.sAdd(key, "a")
+            result <- redis.set(key, value)
           } yield assert(result)(isTrue)
         },
         test("new value with ttl 1 second") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
             value  <- uuid
-            result <- set(key, value, Some(1.second))
+            result <- redis.set(key, value, Some(1.second))
           } yield assert(result)(isTrue)
         },
         test("new value with ttl 100 milliseconds") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
             value  <- uuid
-            result <- set(key, value, Some(100.milliseconds))
+            result <- redis.set(key, value, Some(100.milliseconds))
           } yield assert(result)(isTrue)
         },
         test("error when negative ttl") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
             value  <- uuid
-            result <- set(key, value, Some((-1).millisecond)).either
+            result <- redis.set(key, value, Some((-1).millisecond)).either
           } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
         },
         test("new value with SetNew parameter") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
             value  <- uuid
-            result <- set(key, value, update = Some(Update.SetNew))
+            result <- redis.set(key, value, update = Some(Update.SetNew))
           } yield assert(result)(isTrue)
         },
         test("existing value with SetNew parameter") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
             value  <- uuid
-            _      <- set(key, "value")
-            result <- set(key, value, update = Some(Update.SetNew))
+            _      <- redis.set(key, "value")
+            result <- redis.set(key, value, update = Some(Update.SetNew))
           } yield assert(result)(isFalse)
         },
         test("new value with SetExisting parameter") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
             value  <- uuid
-            result <- set(key, value, update = Some(Update.SetExisting))
+            result <- redis.set(key, value, update = Some(Update.SetExisting))
           } yield assert(result)(isFalse)
         },
         test("existing value with SetExisting parameter") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
             value  <- uuid
-            _      <- set(key, "value")
-            result <- set(key, value, update = Some(Update.SetExisting))
+            _      <- redis.set(key, "value")
+            result <- redis.set(key, value, update = Some(Update.SetExisting))
           } yield assert(result)(isTrue)
         },
         test("existing not string value with SetExisting parameter") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
             value  <- uuid
-            _      <- sAdd(key, "a")
-            result <- set(key, value, update = Some(Update.SetExisting))
+            _      <- redis.sAdd(key, "a")
+            result <- redis.set(key, value, update = Some(Update.SetExisting))
           } yield assert(result)(isTrue)
         },
         // next three tests include KEEPTTL parameter that is valid for Redis version >= 6
         test("new value with KeepTtl parameter") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
             value  <- uuid
-            result <- set(key, value, keepTtl = Some(KeepTtl))
+            result <- redis.set(key, value, keepTtl = Some(KeepTtl))
           } yield assert(result)(isTrue)
         } @@ ignore,
         test("existing value with KeepTtl parameter") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
             value  <- uuid
-            _      <- set(key, "value", Some(1.second))
-            result <- set(key, value, keepTtl = Some(KeepTtl))
+            _      <- redis.set(key, "value", Some(1.second))
+            result <- redis.set(key, value, keepTtl = Some(KeepTtl))
           } yield assert(result)(isTrue)
         } @@ ignore,
         test("existing value with both ttl and KeepTtl parameters") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
             value  <- uuid
-            _      <- set(key, "value", Some(1.second))
-            result <- set(key, value, Some(1.second), keepTtl = Some(KeepTtl))
+            _      <- redis.set(key, "value", Some(1.second))
+            result <- redis.set(key, value, Some(1.second), keepTtl = Some(KeepTtl))
           } yield assert(result)(isTrue)
         } @@ ignore
       ),
       suite("setBit")(
         test("for existing key") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- set(key, "value")
-            oldBit <- setBit(key, 16L, true)
+            _      <- redis.set(key, "value")
+            oldBit <- redis.setBit(key, 16L, true)
           } yield assert(oldBit)(isFalse)
         },
         test("for non-existent key") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            oldBit <- setBit(key, 16L, true)
+            oldBit <- redis.setBit(key, 16L, true)
           } yield assert(oldBit)(isFalse)
         },
         test("for offset that is out of string range") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- set(key, "value")
-            oldBit <- setBit(key, 100L, true)
+            _      <- redis.set(key, "value")
+            oldBit <- redis.setBit(key, 100L, true)
           } yield assert(oldBit)(isFalse)
         },
         test("error when negative offset") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- set(key, "value")
-            oldBit <- setBit(key, -1L, false).either
+            _      <- redis.set(key, "value")
+            oldBit <- redis.setBit(key, -1L, false).either
           } yield assert(oldBit)(isLeft(isSubtype[ProtocolError](anything)))
         },
         test("error when not string") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
-            _      <- sAdd(key, "a")
-            oldBit <- setBit(key, 10L, true).either
+            _      <- redis.sAdd(key, "a")
+            oldBit <- redis.setBit(key, 10L, true).either
           } yield assert(oldBit)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
       suite("setEx")(
         test("new value with 1 second ttl") {
           for {
+            redis        <- ZIO.service[Redis]
             key          <- uuid
             value        <- uuid
-            _            <- setEx(key, 1.second, value)
-            existsBefore <- exists(key)
+            _            <- redis.setEx(key, 1.second, value)
+            existsBefore <- redis.exists(key)
             fiber        <- ZIO.sleep(1010.millis).fork <* TestClock.adjust(1010.millis)
             _            <- fiber.join
-            existsAfter  <- exists(key)
+            existsAfter  <- redis.exists(key)
           } yield assert(existsBefore)(equalTo(1L)) && assert(existsAfter)(equalTo(0L))
         } @@ eventually,
         test("existing value with 1 second ttl") {
           for {
+            redis        <- ZIO.service[Redis]
             key          <- uuid
             value        <- uuid
-            _            <- set(key, "value")
-            _            <- setEx(key, 1.second, value)
-            existsBefore <- exists(key)
+            _            <- redis.set(key, "value")
+            _            <- redis.setEx(key, 1.second, value)
+            existsBefore <- redis.exists(key)
             fiber        <- ZIO.sleep(1010.millis).fork <* TestClock.adjust(1010.millis)
             _            <- fiber.join
-            existsAfter  <- exists(key)
+            existsAfter  <- redis.exists(key)
           } yield assert(existsBefore)(equalTo(1L)) && assert(existsAfter)(equalTo(0L))
         } @@ eventually,
         test("override when not string") {
           for {
+            redis        <- ZIO.service[Redis]
             key          <- uuid
             value        <- uuid
-            _            <- sAdd(key, "a")
-            _            <- setEx(key, 1.second, value)
-            existsBefore <- exists(key)
+            _            <- redis.sAdd(key, "a")
+            _            <- redis.setEx(key, 1.second, value)
+            existsBefore <- redis.exists(key)
             fiber        <- ZIO.sleep(1010.millis).fork <* TestClock.adjust(1010.millis)
             _            <- fiber.join
-            existsAfter  <- exists(key)
+            existsAfter  <- redis.exists(key)
           } yield assert(existsBefore)(equalTo(1L)) && assert(existsAfter)(equalTo(0L))
         },
         test("error when 0 seconds ttl") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
             value  <- uuid
-            result <- setEx(key, 0.seconds, value).either
+            result <- redis.setEx(key, 0.seconds, value).either
           } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
         },
         test("error when negative ttl") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
             value  <- uuid
-            result <- setEx(key, (-1).second, value).either
+            result <- redis.setEx(key, (-1).second, value).either
           } yield assert(result)(isLeft(isSubtype[ProtocolError](anything)))
         }
       ),
       suite("setNx")(
         test("new value") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
             value  <- uuid
-            result <- setNx(key, value)
+            result <- redis.setNx(key, value)
           } yield assert(result)(isTrue)
         },
         test("existing value") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
             value  <- uuid
-            _      <- set(key, "value")
-            result <- setNx(key, value)
+            _      <- redis.set(key, "value")
+            result <- redis.setNx(key, value)
           } yield assert(result)(isFalse)
         },
         test("not string") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
             value  <- uuid
-            _      <- sAdd(key, "a")
-            result <- setNx(key, value)
+            _      <- redis.sAdd(key, "a")
+            result <- redis.setNx(key, value)
           } yield assert(result)(isFalse)
         }
       ),
       suite("setRange")(
         test("in existing string") {
           for {
-            key <- uuid
-            _   <- set(key, "val")
-            len <- setRange(key, 3L, "ue")
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.set(key, "val")
+            len   <- redis.setRange(key, 3L, "ue")
           } yield assert(len)(equalTo(5L))
         },
         test("in non-existent string") {
           for {
-            key <- uuid
-            len <- setRange(key, 2L, "value")
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            len   <- redis.setRange(key, 2L, "value")
           } yield assert(len)(equalTo(7L))
         },
         test("when offset is larger then string length") {
           for {
-            key <- uuid
-            _   <- set(key, "value")
-            len <- setRange(key, 7L, "value")
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.set(key, "value")
+            len   <- redis.setRange(key, 7L, "value")
           } yield assert(len)(equalTo(12L))
         },
         test("error when negative offset") {
           for {
-            key <- uuid
-            len <- setRange(key, -1L, "value").either
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            len   <- redis.setRange(key, -1L, "value").either
           } yield assert(len)(isLeft(isSubtype[ProtocolError](anything)))
         },
         test("error when not string") {
           for {
-            key <- uuid
-            _   <- sAdd(key, "a")
-            len <- setRange(key, 1L, "value").either
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.sAdd(key, "a")
+            len   <- redis.setRange(key, 1L, "value").either
           } yield assert(len)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
       suite("strLen")(
         test("for non-empty string") {
           for {
-            key <- uuid
-            _   <- set(key, "value")
-            len <- strLen(key)
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.set(key, "value")
+            len   <- redis.strLen(key)
           } yield assert(len)(equalTo(5L))
         },
         test("for empty string") {
           for {
-            key <- uuid
-            len <- strLen(key)
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            len   <- redis.strLen(key)
           } yield assert(len)(equalTo(0L))
         },
         test("error when not string") {
           for {
-            key <- uuid
-            _   <- sAdd(key, "a")
-            len <- strLen(key).either
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.sAdd(key, "a")
+            len   <- redis.strLen(key).either
           } yield assert(len)(isLeft(isSubtype[WrongType](anything)))
         }
       ),
       suite("getEx")(
         test("value exists after removing ttl") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
             value  <- uuid
-            _      <- pSetEx(key, 10.millis, value)
-            exists <- getEx(key, true).returning[String]
+            _      <- redis.pSetEx(key, 10.millis, value)
+            exists <- redis.getEx(key, true).returning[String]
             fiber  <- ZIO.sleep(20.millis).fork <* TestClock.adjust(20.millis)
             _      <- fiber.join
-            res    <- get(key).returning[String]
+            res    <- redis.get(key).returning[String]
           } yield assert(res.isDefined)(equalTo(true)) && assert(exists)(equalTo(Some(value)))
         } @@ eventually,
         test("not found value when set seconds ttl") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
             value  <- uuid
-            _      <- set(key, value)
-            exists <- getEx(key, Expire.SetExpireSeconds, 1.second).returning[String]
+            _      <- redis.set(key, value)
+            exists <- redis.getEx(key, Expire.SetExpireSeconds, 1.second).returning[String]
             fiber  <- ZIO.sleep(1020.millis).fork <* TestClock.adjust(1020.millis)
             _      <- fiber.join
-            res    <- get(key).returning[String]
+            res    <- redis.get(key).returning[String]
           } yield assert(res.isDefined)(equalTo(false)) && assert(exists)(equalTo(Some(value)))
         } @@ eventually,
         test("not found value when set milliseconds ttl") {
           for {
+            redis  <- ZIO.service[Redis]
             key    <- uuid
             value  <- uuid
-            _      <- set(key, value)
-            exists <- getEx(key, Expire.SetExpireMilliseconds, 10.millis).returning[String]
+            _      <- redis.set(key, value)
+            exists <- redis.getEx(key, Expire.SetExpireMilliseconds, 10.millis).returning[String]
             fiber  <- ZIO.sleep(20.millis).fork <* TestClock.adjust(20.millis)
             _      <- fiber.join
-            res    <- get(key).returning[String]
+            res    <- redis.get(key).returning[String]
           } yield assert(res.isDefined)(equalTo(false)) && assert(exists)(equalTo(Some(value)))
         } @@ eventually,
         test("not found value when set seconds timestamp") {
           for {
+            redis     <- ZIO.service[Redis]
             key       <- uuid
             value     <- uuid
-            _         <- set(key, value)
+            _         <- redis.set(key, value)
             expiresAt <- Clock.instant.map(_.plusMillis(10.millis.toMillis))
-            exists    <- getEx(key, ExpiredAt.SetExpireAtSeconds, expiresAt).returning[String]
+            exists    <- redis.getEx(key, ExpiredAt.SetExpireAtSeconds, expiresAt).returning[String]
             fiber     <- ZIO.sleep(20.millis).fork <* TestClock.adjust(20.millis)
             _         <- fiber.join
-            res       <- get(key).returning[String]
+            res       <- redis.get(key).returning[String]
           } yield assert(res.isDefined)(equalTo(false)) && assert(exists)(equalTo(Some(value)))
         } @@ eventually,
         test("not found value when set milliseconds timestamp") {
           for {
+            redis     <- ZIO.service[Redis]
             key       <- uuid
             value     <- uuid
-            _         <- set(key, value)
+            _         <- redis.set(key, value)
             expiresAt <- Clock.instant.map(_.plusMillis(10.millis.toMillis))
-            exists    <- getEx(key, ExpiredAt.SetExpireAtMilliseconds, expiresAt).returning[String]
+            exists    <- redis.getEx(key, ExpiredAt.SetExpireAtMilliseconds, expiresAt).returning[String]
             fiber     <- ZIO.sleep(20.millis).fork <* TestClock.adjust(20.millis)
             _         <- fiber.join
-            res       <- get(key).returning[String]
+            res       <- redis.get(key).returning[String]
           } yield assert(res.isDefined)(equalTo(false)) && assert(exists)(equalTo(Some(value)))
         } @@ eventually,
         test("key not found") {
           for {
+            redis     <- ZIO.service[Redis]
             key       <- uuid
             value     <- uuid
-            _         <- set(key, value)
+            _         <- redis.set(key, value)
             expiresAt <- Clock.instant.map(_.plusMillis(10.millis.toMillis))
-            res       <- getEx(value, ExpiredAt.SetExpireAtMilliseconds, expiresAt).returning[String]
-            res2      <- getEx(value, Expire.SetExpireMilliseconds, 10.millis).returning[String]
-            res3      <- getEx(value, true).returning[String]
+            res       <- redis.getEx(value, ExpiredAt.SetExpireAtMilliseconds, expiresAt).returning[String]
+            res2      <- redis.getEx(value, Expire.SetExpireMilliseconds, 10.millis).returning[String]
+            res3      <- redis.getEx(value, true).returning[String]
           } yield assert(res)(equalTo(None)) && assert(res2)(equalTo(None)) && assert(res3)(equalTo(None))
         } @@ eventually
       ),
       suite("getDel")(
         test("error when not string") {
           for {
-            key <- uuid
-            _   <- sAdd(key, "a")
-            res <- getDel(key).returning[String].either
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            _     <- redis.sAdd(key, "a")
+            res   <- redis.getDel(key).returning[String].either
           } yield assert(res)(isLeft(isSubtype[WrongType](anything)))
         },
         test("key not exists") {
           for {
-            key <- uuid
-            res <- getDel(key).returning[String]
+            redis <- ZIO.service[Redis]
+            key   <- uuid
+            res   <- redis.getDel(key).returning[String]
           } yield assert(res)(equalTo(None))
         },
         test("get and remove key") {
           for {
+            redis    <- ZIO.service[Redis]
             key      <- uuid
             value    <- uuid
-            _        <- set(key, value)
-            res      <- getDel(key).returning[String]
-            notFound <- getDel(key).returning[String]
+            _        <- redis.set(key, value)
+            res      <- redis.getDel(key).returning[String]
+            notFound <- redis.getDel(key).returning[String]
           } yield assert(res)(equalTo(Some(value))) && assert(notFound)(equalTo(None))
         }
       )

--- a/redis/src/test/scala/zio/redis/codecs/CRC16Spec.scala
+++ b/redis/src/test/scala/zio/redis/codecs/CRC16Spec.scala
@@ -1,4 +1,4 @@
-package zio.redis.codec
+package zio.redis.codecs
 
 import zio.Chunk
 import zio.redis.BaseSpec


### PR DESCRIPTION
Resolves #548 

* getting rid of `Redis` environment dependency from all the API traits
* mixing API traits in the `Redis` trait
* getting rid of "accessors" from `redis` package object and fixing tests
