### PR TITLE
[WIP] separation of Redis command and execution

### DIFF
--- a/redis/src/main/scala/zio/redis/Executable.scala
+++ b/redis/src/main/scala/zio/redis/Executable.scala
@@ -1,0 +1,22 @@
+package zio.redis
+
+import zio._
+import zio.redis.Input.{StringInput, Varargs}
+import zio.schema.codec.BinaryCodec
+
+class Executable[-In, +Out](cmd: RedisCommand[In, Out], data: In) {
+  def execute: ZIO[RedisExecutor & BinaryCodec, RedisError, Out] = for {
+    executor <- ZIO.service[RedisExecutor]
+    codec    <- ZIO.service[BinaryCodec]
+    out <- executor
+             .execute(resp(data, codec))
+             .flatMap[Any, Throwable, Out](out => ZIO.attempt(cmd.output.unsafeDecode(out)(codec)))
+             .refineToOrDie[RedisError]
+  } yield out
+  private[redis] def resp(in: In, codec: BinaryCodec): Chunk[RespValue.BulkString] =
+    Varargs(StringInput).encode(cmd.name.split(" "))(codec) ++ cmd.input.encode(in)(codec)
+}
+
+object Executable {
+  def apply[In, Out](cmd: RedisCommand[In, Out], data: In): Executable[In, Out] = new Executable(cmd, data)
+}

--- a/redis/src/main/scala/zio/redis/RedisCommand.scala
+++ b/redis/src/main/scala/zio/redis/RedisCommand.scala
@@ -28,6 +28,8 @@ final class RedisCommand[-In, +Out] private (
   val executor: RedisExecutor
 ) {
 
+  private[redis] def runWith(in: In): Executable[In, Out] = Executable(this, in)
+
   private[redis] def run(in: In): IO[RedisError, Out] =
     executor
       .execute(resp(in))

--- a/redis/src/main/scala/zio/redis/api/Cluster.scala
+++ b/redis/src/main/scala/zio/redis/api/Cluster.scala
@@ -34,8 +34,8 @@ trait Cluster extends RedisEnvironment {
    * @return
    *   the Unit value.
    */
-  def asking: IO[RedisError, Unit] =
-    AskingCommand(codec, executor).run(())
+  def asking: Executable[Unit, Unit] =
+    AskingCommand(codec, executor).runWith(())
 
   /**
    * Returns details about which cluster slots map to which Redis instances.
@@ -43,9 +43,9 @@ trait Cluster extends RedisEnvironment {
    * @return
    *   details about which cluster
    */
-  def slots: IO[RedisError, Chunk[Partition]] = {
+  def slots: Executable[Unit, Chunk[Partition]] = {
     val command = RedisCommand(ClusterSlots, NoInput, ChunkOutput(ClusterPartitionOutput), codec, executor)
-    command.run(())
+    command.runWith(())
   }
 
   /**
@@ -56,10 +56,10 @@ trait Cluster extends RedisEnvironment {
    * @return
    *   the Unit value.
    */
-  def setSlotStable(slot: Slot): IO[RedisError, Unit] = {
+  def setSlotStable(slot: Slot): Executable[(Long, String), Unit] = {
     val command =
       RedisCommand(ClusterSetSlots, Tuple2(LongInput, ArbitraryInput[String]()), UnitOutput, codec, executor)
-    command.run((slot.number, Stable.stringify))
+    command.runWith((slot.number, Stable.stringify))
   }
 
   /**
@@ -73,7 +73,7 @@ trait Cluster extends RedisEnvironment {
    * @return
    *   the Unit value.
    */
-  def setSlotMigrating(slot: Slot, nodeId: String): IO[RedisError, Unit] = {
+  def setSlotMigrating(slot: Slot, nodeId: String): Executable[(Long, String, String), Unit] = {
     val command = RedisCommand(
       ClusterSetSlots,
       Tuple3(LongInput, ArbitraryInput[String](), ArbitraryInput[String]()),
@@ -81,7 +81,7 @@ trait Cluster extends RedisEnvironment {
       codec,
       executor
     )
-    command.run((slot.number, Migrating.stringify, nodeId))
+    command.runWith((slot.number, Migrating.stringify, nodeId))
   }
 
   /**
@@ -95,7 +95,7 @@ trait Cluster extends RedisEnvironment {
    * @return
    *   the Unit value.
    */
-  def setSlotImporting(slot: Slot, nodeId: String): IO[RedisError, Unit] = {
+  def setSlotImporting(slot: Slot, nodeId: String): Executable[(Long, String, String), Unit] = {
     val command = RedisCommand(
       ClusterSetSlots,
       Tuple3(LongInput, ArbitraryInput[String](), ArbitraryInput[String]()),
@@ -103,7 +103,7 @@ trait Cluster extends RedisEnvironment {
       codec,
       executor
     )
-    command.run((slot.number, Importing.stringify, nodeId))
+    command.runWith((slot.number, Importing.stringify, nodeId))
   }
 
   /**
@@ -117,7 +117,7 @@ trait Cluster extends RedisEnvironment {
    * @return
    *   the Unit value.
    */
-  def setSlotNode(slot: Slot, nodeId: String): IO[RedisError, Unit] = {
+  def setSlotNode(slot: Slot, nodeId: String): Executable[(Long, String, String), Unit] = {
     val command = RedisCommand(
       ClusterSetSlots,
       Tuple3(LongInput, ArbitraryInput[String](), ArbitraryInput[String]()),
@@ -125,7 +125,7 @@ trait Cluster extends RedisEnvironment {
       codec,
       executor
     )
-    command.run((slot.number, Node.stringify, nodeId))
+    command.runWith((slot.number, Node.stringify, nodeId))
   }
 }
 

--- a/redis/src/test/scala/zio/redis/ClusterExecutorSpec.scala
+++ b/redis/src/test/scala/zio/redis/ClusterExecutorSpec.scala
@@ -11,7 +11,7 @@ object ClusterExecutorSpec extends BaseSpec {
       test("check cluster responsiveness when ASK redirect happens") {
         for {
           redis           <- ZIO.service[Redis]
-          initSlots       <- redis.slots
+          initSlots       <- redis.slots.execute
           key             <- uuid
           value1          <- redis.get(key).returning[String]
           keySlot          = Slot(CRC16.get(Chunk.fromArray(key.getBytes)).toLong % SlotsAmount)
@@ -21,13 +21,15 @@ object ClusterExecutorSpec extends BaseSpec {
           destMaster       = destPart.master
           destMasterConn   = getRedisNodeLayer(destMaster.address)
           _                = ZIO.logDebug(s"$key _____ Importing $keySlot to ${destMaster.id} - ${destMaster.address}")
-          _               <- ZIO.serviceWithZIO[Redis](_.setSlotImporting(keySlot, sourceMaster.id)).provideLayer(destMasterConn)
+          _ <-
+            ZIO.serviceWithZIO[Redis](_.setSlotImporting(keySlot, sourceMaster.id).execute).provideLayer(destMasterConn)
           _                = ZIO.logDebug(s"$key _____ Migrating $keySlot from ${sourceMaster.id}- ${sourceMaster.address}")
           sourceMasterConn = getRedisNodeLayer(sourceMaster.address)
-          _               <- ZIO.serviceWithZIO[Redis](_.setSlotMigrating(keySlot, destMaster.id)).provideLayer(sourceMasterConn)
-          value2          <- redis.get(key).returning[String] // have to redirect without error ASK
-          value3          <- redis.get(key).returning[String] // have to redirect without creating new connection
-          _               <- ZIO.serviceWithZIO[Redis](_.setSlotStable(keySlot)).provideLayer(destMasterConn)
+          _ <-
+            ZIO.serviceWithZIO[Redis](_.setSlotMigrating(keySlot, destMaster.id).execute).provideLayer(sourceMasterConn)
+          value2 <- redis.get(key).returning[String] // have to redirect without error ASK
+          value3 <- redis.get(key).returning[String] // have to redirect without creating new connection
+          _      <- ZIO.serviceWithZIO[Redis](_.setSlotStable(keySlot).execute).provideLayer(destMasterConn)
         } yield {
           assertTrue(value1 == value2) && assertTrue(value2 == value3)
         }
@@ -35,7 +37,7 @@ object ClusterExecutorSpec extends BaseSpec {
       test("check client responsiveness when Moved redirect happened") {
         for {
           redis           <- ZIO.service[Redis]
-          initSlots       <- redis.slots
+          initSlots       <- redis.slots.execute
           key             <- uuid
           _               <- redis.set(key, "value")
           value1          <- redis.get(key).returning[String]
@@ -46,17 +48,19 @@ object ClusterExecutorSpec extends BaseSpec {
           destMaster       = destPart.master
           destMasterConn   = getRedisNodeLayer(destMaster.address)
           _               <- ZIO.logDebug(s"$key _____ Importing $keySlot to ${destMaster.id}")
-          _               <- ZIO.serviceWithZIO[Redis](_.setSlotImporting(keySlot, sourceMaster.id)).provideLayer(destMasterConn)
+          _ <-
+            ZIO.serviceWithZIO[Redis](_.setSlotImporting(keySlot, sourceMaster.id).execute).provideLayer(destMasterConn)
           _               <- ZIO.logDebug(s"$key _____ Migrating $keySlot from ${sourceMaster.id}")
           sourceMasterConn = getRedisNodeLayer(sourceMaster.address)
-          _               <- ZIO.serviceWithZIO[Redis](_.setSlotMigrating(keySlot, destMaster.id)).provideLayer(sourceMasterConn)
+          _ <-
+            ZIO.serviceWithZIO[Redis](_.setSlotMigrating(keySlot, destMaster.id).execute).provideLayer(sourceMasterConn)
           _ <- ZIO
                  .serviceWithZIO[Redis](
                    _.migrate(destMaster.address.host, destMaster.address.port.toLong, key, 0, 5.seconds, keys = None)
                  )
                  .provideLayer(sourceMasterConn)
-          _      <- ZIO.serviceWithZIO[Redis](_.setSlotNode(keySlot, destMaster.id)).provideLayer(destMasterConn)
-          _      <- ZIO.serviceWithZIO[Redis](_.setSlotNode(keySlot, destMaster.id)).provideLayer(sourceMasterConn)
+          _      <- ZIO.serviceWithZIO[Redis](_.setSlotNode(keySlot, destMaster.id).execute).provideLayer(destMasterConn)
+          _      <- ZIO.serviceWithZIO[Redis](_.setSlotNode(keySlot, destMaster.id).execute).provideLayer(sourceMasterConn)
           value2 <- redis.get(key).returning[String] // have to refresh connection
           value3 <- redis.get(key).returning[String] // have to get value without refreshing connection
         } yield {

--- a/redis/src/test/scala/zio/redis/ClusterSpec.scala
+++ b/redis/src/test/scala/zio/redis/ClusterSpec.scala
@@ -10,7 +10,7 @@ trait ClusterSpec extends BaseSpec {
       suite("slots")(
         test("get cluster slots") {
           for {
-            res <- ZIO.serviceWithZIO[Redis](_.slots)
+            res <- ZIO.serviceWithZIO[Redis](_.slots.execute)
           } yield {
             val addresses    = (5000 to 5005).map(port => RedisUri("127.0.0.1", port))
             val resAddresses = res.map(_.master.address) ++ res.flatMap(_.slaves.map(_.address))


### PR DESCRIPTION
* if we split command definition and actual execution we're able to remove` executor` and `codec` dependency from `RedisCommand` itself and push it down to actual execution