### PR TITLE
Include `sbt-header` plugin in `check` and `prepare` process

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,12 +22,12 @@ ThisBuild / libraryDependencySchemes ++= Seq(
 
 addCommandAlias("compileBenchmarks", "benchmarks/Jmh/compile")
 addCommandAlias("compileSources", "example/Test/compile; redis/Test/compile")
-addCommandAlias("check", "fixCheck; fmtCheck")
+addCommandAlias("check", "fixCheck; fmtCheck; headerCheck")
 addCommandAlias("fix", "scalafixAll")
 addCommandAlias("fixCheck", "scalafixAll --check")
 addCommandAlias("fmt", "all scalafmtSbt scalafmtAll")
 addCommandAlias("fmtCheck", "all scalafmtSbtCheck scalafmtCheckAll")
-addCommandAlias("prepare", "fix; fmt")
+addCommandAlias("prepare", "fix; fmt; headerCreate")
 
 lazy val root =
   project

--- a/redis/src/main/scala/zio/redis/RedisClusterConfig.scala
+++ b/redis/src/main/scala/zio/redis/RedisClusterConfig.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 John A. De Goes and the ZIO contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package zio.redis
 
 import zio.{Chunk, Duration, durationInt}

--- a/redis/src/main/scala/zio/redis/RedisConnectionLive.scala
+++ b/redis/src/main/scala/zio/redis/RedisConnectionLive.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 John A. De Goes and the ZIO contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package zio.redis
 
 import zio._

--- a/redis/src/main/scala/zio/redis/RedisEnvironment.scala
+++ b/redis/src/main/scala/zio/redis/RedisEnvironment.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 John A. De Goes and the ZIO contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package zio.redis
 
 import zio.schema.codec.BinaryCodec

--- a/redis/src/main/scala/zio/redis/RedisExecutor.scala
+++ b/redis/src/main/scala/zio/redis/RedisExecutor.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 John A. De Goes and the ZIO contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package zio.redis
 
 import zio.{Chunk, IO, ZLayer}

--- a/redis/src/main/scala/zio/redis/RedisUri.scala
+++ b/redis/src/main/scala/zio/redis/RedisUri.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 John A. De Goes and the ZIO contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package zio.redis
 
 final case class RedisUri(host: String, port: Int) {

--- a/redis/src/main/scala/zio/redis/codecs/CRC16.scala
+++ b/redis/src/main/scala/zio/redis/codecs/CRC16.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 John A. De Goes and the ZIO contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package zio.redis.codecs
 
 import zio.Chunk

--- a/redis/src/main/scala/zio/redis/codecs/StringUtf8Codec.scala
+++ b/redis/src/main/scala/zio/redis/codecs/StringUtf8Codec.scala
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package zio.redis.codecs
 
 import zio.redis.RedisError.CodecError

--- a/redis/src/main/scala/zio/redis/options/Cluster.scala
+++ b/redis/src/main/scala/zio/redis/options/Cluster.scala
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package zio.redis.options
 
 import zio.redis.{RedisExecutor, RedisUri}


### PR DESCRIPTION
### Description:

- `sbt-header` was included, but I have introduced `headerCheck` in `sbt check` command and `headerCreate` in `sbt prepare` command.
- Created headers for missing files. 