### PR TITLE
ADD zio-redis-embedded module

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,50 @@ object ZIORedisExample extends ZIOAppDefault {
 }
 ```
 
+## Testing
+
+To test you can use the embedded redis instance by adding to your build:
+
+```libraryDependencies := "dev.zio" %% "zio-redis-embedded" % <version>```
+
+Then you can supply `EmbeddedRedis.layer.orDie` as your `RedisConfig` and you're good to go!
+
+```scala
+import zio._
+import zio.redis._
+import zio.schema.{DeriveSchema, Schema}
+import zio.schema.codec.{BinaryCodec, ProtobufCodec}
+import zio.test._
+import zio.test.Assertion._
+
+import java.util.UUID
+
+object EmbeddedRedisSpec extends ZIOSpecDefault {
+
+  final case class Item private (id: UUID, name: String, quantity: Int)
+  object Item {
+    implicit val itemSchema: Schema[Item] = DeriveSchema.gen[Item]
+  }
+
+  def spec = suite("EmbeddedRedis should")(
+    test("set and get values") {
+      for {
+        redis <- ZIO.service[Redis]
+        item   = Item(UUID.randomUUID, "foo", 2)
+        _     <- redis.set(s"item.${item.id.toString}", item)
+        found <- redis.get(s"item.${item.id.toString}").returning[Item]
+      } yield assert(found)(isSome(equalTo(item)))
+    }
+  ).provideShared(
+    EmbeddedRedis.layer.orDie,
+    RedisExecutor.layer.orDie,
+    ZLayer.succeed[BinaryCodec](ProtobufCodec),
+    Redis.layer
+  ) @@ TestAspect.silentLogging
+}
+
+```
+
 ## Resources
 
 - [ZIO Redis](https://www.youtube.com/watch?v=yqFt3b3RBkI) by Dejan Mijic — Redis is one of the most commonly used

--- a/README.md
+++ b/README.md
@@ -84,16 +84,12 @@ import zio.schema.{DeriveSchema, Schema}
 import zio.schema.codec.{BinaryCodec, ProtobufCodec}
 import zio.test._
 import zio.test.Assertion._
-
 import java.util.UUID
-
 object EmbeddedRedisSpec extends ZIOSpecDefault {
-
   final case class Item private (id: UUID, name: String, quantity: Int)
   object Item {
     implicit val itemSchema: Schema[Item] = DeriveSchema.gen[Item]
   }
-
   def spec = suite("EmbeddedRedis should")(
     test("set and get values") {
       for {
@@ -110,7 +106,6 @@ object EmbeddedRedisSpec extends ZIOSpecDefault {
     Redis.layer
   ) @@ TestAspect.silentLogging
 }
-
 ```
 
 ## Resources

--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ lazy val root =
   project
     .in(file("."))
     .settings(publish / skip := true)
-    .aggregate(redis, benchmarks, example, docs)
+    .aggregate(redis, embedded, benchmarks, example, docs)
 
 lazy val redis =
   project
@@ -54,6 +54,26 @@ lazy val redis =
       ),
       testFrameworks := List(new TestFramework("zio.test.sbt.ZTestFramework"))
     )
+
+lazy val embedded =
+  project
+    .in(file("embedded"))
+    .enablePlugins(BuildInfoPlugin)
+    .settings(buildInfoSettings("zio.redis.embedded"))
+    .settings(scala3Settings)
+    .settings(stdSettings("zio-redis-embedded"))
+    .settings(
+      libraryDependencies ++= List(
+        "dev.zio"          %% "zio"                 % "2.0.8",
+        "com.github.kstyrc" % "embedded-redis"      % "0.6",
+        "dev.zio"          %% "zio-schema"          % "0.3.1" % Test,
+        "dev.zio"          %% "zio-schema-protobuf" % "0.3.1" % Test,
+        "dev.zio"          %% "zio-test"            % "2.0.8" % Test,
+        "dev.zio"          %% "zio-test-sbt"        % "2.0.8" % Test
+      ),
+      testFrameworks := List(new TestFramework("zio.test.sbt.ZTestFramework"))
+    )
+    .dependsOn(redis)
 
 lazy val benchmarks =
   project

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ ZIO Redis is in the experimental phase of development, but its goals are:
 Since the ZIO Redis is in the experimental phase, it is not released yet, but we can use snapshots:
 
 ```scala
-libraryDependencies += "dev.zio" %% "zio-redis" % "@VERSION@"
+libraryDependencies += "dev.zio" %% "zio-redis" % "<version>"
 ```
 
 ## Example
@@ -39,7 +39,7 @@ To run this example we should put following dependencies in our `build.sbt` file
 
 ```scala
 libraryDependencies ++= Seq(
-  "dev.zio" %% "zio-redis" % "@VERSION@",
+  "dev.zio" %% "zio-redis" % "<version>",
   "dev.zio" %% "zio-schema-protobuf" % "0.3.0"
 )
 ```
@@ -66,6 +66,45 @@ object ZIORedisExample extends ZIOAppDefault {
     ZLayer.succeed(RedisConfig.Default),
     ZLayer.succeed[BinaryCodec](ProtobufCodec)
   )
+}
+```
+
+## Testing
+
+To test you can use the embedded redis instance by adding to your build:
+
+```libraryDependencies := "dev.zio" %% "zio-redis-embedded" % <version>```
+
+Then you can supply `EmbeddedRedis.layer.orDie` as your `RedisConfig` and you're good to go!
+
+```scala
+import zio._
+import zio.redis._
+import zio.schema.{DeriveSchema, Schema}
+import zio.schema.codec.{BinaryCodec, ProtobufCodec}
+import zio.test._
+import zio.test.Assertion._
+import java.util.UUID
+object EmbeddedRedisSpec extends ZIOSpecDefault {
+  final case class Item private (id: UUID, name: String, quantity: Int)
+  object Item {
+    implicit val itemSchema: Schema[Item] = DeriveSchema.gen[Item]
+  }
+  def spec = suite("EmbeddedRedis should")(
+    test("set and get values") {
+      for {
+        redis <- ZIO.service[Redis]
+        item   = Item(UUID.randomUUID, "foo", 2)
+        _     <- redis.set(s"item.${item.id.toString}", item)
+        found <- redis.get(s"item.${item.id.toString}").returning[Item]
+      } yield assert(found)(isSome(equalTo(item)))
+    }
+  ).provideShared(
+    EmbeddedRedis.layer.orDie,
+    RedisExecutor.layer.orDie,
+    ZLayer.succeed[BinaryCodec](ProtobufCodec),
+    Redis.layer
+  ) @@ TestAspect.silentLogging
 }
 ```
 

--- a/embedded/src/main/scala/zio/redis/embedded/EmbeddedRedis.scala
+++ b/embedded/src/main/scala/zio/redis/embedded/EmbeddedRedis.scala
@@ -30,7 +30,7 @@ object EmbeddedRedis {
       socket <- ZIO.attemptBlockingIO(new ServerSocket(0))
       port    = socket.getLocalPort
       _      <- ZIO.attemptBlockingIO(socket.close)
-    } yield port).catchSome { case ex: IOException =>
+    } yield port).catchSome { case _: IOException =>
       findFreePort
     }
 

--- a/embedded/src/main/scala/zio/redis/embedded/EmbeddedRedis.scala
+++ b/embedded/src/main/scala/zio/redis/embedded/EmbeddedRedis.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 John A. De Goes and the ZIO contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package zio.redis.embedded
 
 import redis.embedded.RedisServer

--- a/embedded/src/main/scala/zio/redis/embedded/EmbeddedRedis.scala
+++ b/embedded/src/main/scala/zio/redis/embedded/EmbeddedRedis.scala
@@ -1,0 +1,33 @@
+package zio.redis.embedded
+
+import redis.embedded.RedisServer
+import zio._
+import zio.redis.RedisConfig
+
+import scala.jdk.CollectionConverters._
+
+import java.io.IOException
+import java.net.ServerSocket
+
+object EmbeddedRedis {
+
+  private def findFreePort: Task[Int] =
+    (for {
+      socket <- ZIO.attemptBlockingIO(new ServerSocket(0))
+      port    = socket.getLocalPort
+      _      <- ZIO.attemptBlockingIO(socket.close)
+    } yield port).catchSome { case ex: IOException =>
+      findFreePort
+    }
+
+  val layer: ZLayer[Any, Throwable, RedisConfig] = ZLayer.scoped(
+    for {
+      port <- findFreePort
+      redisServer <- ZIO.acquireRelease(ZIO.attemptBlockingIO(new RedisServer(port)))(redisServer =>
+                       ZIO.attemptBlockingIO(redisServer.stop).ignoreLogged
+                     )
+      _ <- ZIO.attemptBlockingIO(redisServer.start)
+    } yield RedisConfig("localhost", port)
+  )
+
+}

--- a/embedded/src/main/scala/zio/redis/embedded/EmbeddedRedis.scala
+++ b/embedded/src/main/scala/zio/redis/embedded/EmbeddedRedis.scala
@@ -4,8 +4,6 @@ import redis.embedded.RedisServer
 import zio._
 import zio.redis.RedisConfig
 
-import scala.jdk.CollectionConverters._
-
 import java.io.IOException
 import java.net.ServerSocket
 

--- a/embedded/src/test/scala/zio/redis/embedded/EmbeddedRedisSpec.scala
+++ b/embedded/src/test/scala/zio/redis/embedded/EmbeddedRedisSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 John A. De Goes and the ZIO contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package zio.redis.embedded
 
 import zio._

--- a/embedded/src/test/scala/zio/redis/embedded/EmbeddedRedisSpec.scala
+++ b/embedded/src/test/scala/zio/redis/embedded/EmbeddedRedisSpec.scala
@@ -2,10 +2,10 @@ package zio.redis.embedded
 
 import zio._
 import zio.redis._
-import zio.schema.{DeriveSchema, Schema}
 import zio.schema.codec.{BinaryCodec, ProtobufCodec}
-import zio.test._
+import zio.schema.{DeriveSchema, Schema}
 import zio.test.Assertion._
+import zio.test._
 
 import java.util.UUID
 

--- a/embedded/src/test/scala/zio/redis/embedded/EmbeddedRedisSpec.scala
+++ b/embedded/src/test/scala/zio/redis/embedded/EmbeddedRedisSpec.scala
@@ -1,0 +1,35 @@
+package zio.redis.embedded
+
+import zio._
+import zio.redis._
+import zio.schema.{DeriveSchema, Schema}
+import zio.schema.codec.{BinaryCodec, ProtobufCodec}
+import zio.test._
+import zio.test.Assertion._
+
+import java.util.UUID
+
+object EmbeddedRedisSpec extends ZIOSpecDefault {
+
+  final case class Item private (id: UUID, name: String, quantity: Int)
+  object Item {
+    implicit val itemSchema: Schema[Item] = DeriveSchema.gen[Item]
+  }
+
+  def spec = suite("EmbeddedRedis should")(
+    test("set and get values") {
+      for {
+        redis <- ZIO.service[Redis]
+        item   = Item(UUID.randomUUID, "foo", 2)
+        _     <- redis.set(s"item.${item.id.toString}", item)
+        found <- redis.get(s"item.${item.id.toString}").returning[Item]
+      } yield assert(found)(isSome(equalTo(item)))
+    }
+  ).provideShared(
+    EmbeddedRedis.layer.orDie,
+    RedisExecutor.layer.orDie,
+    ZLayer.succeed[BinaryCodec](ProtobufCodec),
+    Redis.layer
+  ) @@ TestAspect.silentLogging
+
+}


### PR DESCRIPTION
This PR introduces `zio-redis-embedded` module for integration testing with embedded redis instance.

See README for details.