### PR TITLE
Support username in AUTH command

### DIFF
--- a/redis/src/main/scala/zio/redis/Input.scala
+++ b/redis/src/main/scala/zio/redis/Input.scala
@@ -59,7 +59,13 @@ object Input {
 
   case object AuthInput extends Input[Auth] {
     def encode(data: Auth)(implicit codec: BinaryCodec): RespCommand =
-      RespCommand(RespArgument.Literal("AUTH"), RespArgument.Value(data.password))
+      data.username match {
+        case Some(username) =>
+          RespCommand(RespArgument.Literal("AUTH"), RespArgument.Value(username), RespArgument.Value(data.password))
+        case None =>
+          RespCommand(RespArgument.Literal("AUTH"), RespArgument.Value(data.password))
+      }
+
   }
 
   case object BoolInput extends Input[Boolean] {

--- a/redis/src/main/scala/zio/redis/Input.scala
+++ b/redis/src/main/scala/zio/redis/Input.scala
@@ -60,10 +60,8 @@ object Input {
   case object AuthInput extends Input[Auth] {
     def encode(data: Auth)(implicit codec: BinaryCodec): RespCommand =
       data.username match {
-        case Some(username) =>
-          RespCommand(RespArgument.Literal("AUTH"), RespArgument.Value(username), RespArgument.Value(data.password))
-        case None =>
-          RespCommand(RespArgument.Literal("AUTH"), RespArgument.Value(data.password))
+        case Some(username) => RespCommand(RespArgument.Value(username), RespArgument.Value(data.password))
+        case None           => RespCommand(RespArgument.Value(data.password))
       }
 
   }

--- a/redis/src/main/scala/zio/redis/api/Connection.scala
+++ b/redis/src/main/scala/zio/redis/api/Connection.scala
@@ -43,15 +43,12 @@ trait Connection extends RedisEnvironment {
   }
 
   /**
-   * Authenticates the current connection to the server in two cases:
-   *   - If the Redis server is password protected via the the ''requirepass'' option
-   *   - If a Redis 6.0 instance, or greater, is using the [[https://redis.io/topics/acl Redis ACL system]]. In this
-   *     case it is assumed that the implicit username is ''default''.
+   * Authenticates the current connection to the server using username and password.
    *
-   * @param password
-   *   the password used to authenticate the connection
    * @param username
    *   the username used to authenticate the connection
+   * @param password
+   *   the password used to authenticate the connection
    * @return
    *   if the password provided via AUTH matches the password in the configuration file, the Unit value is returned and
    *   the server starts accepting commands. Otherwise, an error is returned and the client needs to try a new password.

--- a/redis/src/main/scala/zio/redis/api/Connection.scala
+++ b/redis/src/main/scala/zio/redis/api/Connection.scala
@@ -37,9 +37,9 @@ trait Connection extends RedisEnvironment {
    *   the server starts accepting commands. Otherwise, an error is returned and the client needs to try a new password.
    */
   final def auth(password: String): IO[RedisError, Unit] = {
-    val command = RedisCommand(Auth, Tuple2(StringInput, OptionalInput(StringInput)), UnitOutput, codec, executor)
+    val command = RedisCommand(Auth, Tuple2(OptionalInput(StringInput), StringInput), UnitOutput, codec, executor)
 
-    command.run((password, None))
+    command.run((None, password))
   }
 
   /**
@@ -54,9 +54,9 @@ trait Connection extends RedisEnvironment {
    *   the server starts accepting commands. Otherwise, an error is returned and the client needs to try a new password.
    */
   final def auth(password: String, username: String): IO[RedisError, Unit] = {
-    val command = RedisCommand(Auth, Tuple2(StringInput, OptionalInput(StringInput)), UnitOutput, codec, executor)
+    val command = RedisCommand(Auth, Tuple2(OptionalInput(StringInput), StringInput), UnitOutput, codec, executor)
 
-    command.run((password, Some(username)))
+    command.run((Some(username), password))
   }
 
   /**

--- a/redis/src/main/scala/zio/redis/api/Connection.scala
+++ b/redis/src/main/scala/zio/redis/api/Connection.scala
@@ -37,9 +37,29 @@ trait Connection extends RedisEnvironment {
    *   the server starts accepting commands. Otherwise, an error is returned and the client needs to try a new password.
    */
   final def auth(password: String): IO[RedisError, Unit] = {
-    val command = RedisCommand(Auth, StringInput, UnitOutput, codec, executor)
+    val command = RedisCommand(Auth, Tuple2(StringInput, OptionalInput(StringInput)), UnitOutput, codec, executor)
 
-    command.run(password)
+    command.run((password, None))
+  }
+
+  /**
+   * Authenticates the current connection to the server in two cases:
+   *   - If the Redis server is password protected via the the ''requirepass'' option
+   *   - If a Redis 6.0 instance, or greater, is using the [[https://redis.io/topics/acl Redis ACL system]]. In this
+   *     case it is assumed that the implicit username is ''default''.
+   *
+   * @param password
+   *   the password used to authenticate the connection
+   * @param username
+   *   the username used to authenticate the connection
+   * @return
+   *   if the password provided via AUTH matches the password in the configuration file, the Unit value is returned and
+   *   the server starts accepting commands. Otherwise, an error is returned and the client needs to try a new password.
+   */
+  final def auth(password: String, username: String): IO[RedisError, Unit] = {
+    val command = RedisCommand(Auth, Tuple2(StringInput, OptionalInput(StringInput)), UnitOutput, codec, executor)
+
+    command.run((password, Some(username)))
   }
 
   /**

--- a/redis/src/main/scala/zio/redis/api/Connection.scala
+++ b/redis/src/main/scala/zio/redis/api/Connection.scala
@@ -22,7 +22,7 @@ import zio.redis.Output._
 import zio.redis._
 
 trait Connection extends RedisEnvironment {
-  import Connection._
+  import Connection.{Auth => _, _}
 
   /**
    * Authenticates the current connection to the server in two cases:
@@ -37,9 +37,9 @@ trait Connection extends RedisEnvironment {
    *   the server starts accepting commands. Otherwise, an error is returned and the client needs to try a new password.
    */
   final def auth(password: String): IO[RedisError, Unit] = {
-    val command = RedisCommand(Auth, Tuple2(OptionalInput(StringInput), StringInput), UnitOutput, codec, executor)
+    val command = RedisCommand(Connection.Auth, AuthInput, UnitOutput, codec, executor)
 
-    command.run((None, password))
+    command.run(Auth(None, password))
   }
 
   /**
@@ -53,10 +53,10 @@ trait Connection extends RedisEnvironment {
    *   if the password provided via AUTH matches the password in the configuration file, the Unit value is returned and
    *   the server starts accepting commands. Otherwise, an error is returned and the client needs to try a new password.
    */
-  final def auth(password: String, username: String): IO[RedisError, Unit] = {
-    val command = RedisCommand(Auth, Tuple2(OptionalInput(StringInput), StringInput), UnitOutput, codec, executor)
+  final def auth(username: String, password: String): IO[RedisError, Unit] = {
+    val command = RedisCommand(Connection.Auth, AuthInput, UnitOutput, codec, executor)
 
-    command.run((Some(username), password))
+    command.run(Auth(Some(username), password))
   }
 
   /**

--- a/redis/src/main/scala/zio/redis/options/Keys.scala
+++ b/redis/src/main/scala/zio/redis/options/Keys.scala
@@ -30,7 +30,7 @@ trait Keys {
 
   type Alpha = Alpha.type
 
-  sealed case class Auth(password: String)
+  sealed case class Auth(password: String, username: Option[String])
 
   sealed case class By(pattern: String)
 

--- a/redis/src/main/scala/zio/redis/options/Keys.scala
+++ b/redis/src/main/scala/zio/redis/options/Keys.scala
@@ -30,7 +30,7 @@ trait Keys {
 
   type Alpha = Alpha.type
 
-  sealed case class Auth(password: String, username: Option[String])
+  sealed case class Auth(username: Option[String], password: String)
 
   sealed case class By(pattern: String)
 

--- a/redis/src/main/scala/zio/redis/options/Keys.scala
+++ b/redis/src/main/scala/zio/redis/options/Keys.scala
@@ -32,8 +32,6 @@ trait Keys {
 
   sealed case class Auth(username: Option[String], password: String)
 
-  sealed case class By(pattern: String)
-
   case object Copy {
     private[redis] def stringify: String = "COPY"
   }

--- a/redis/src/test/scala/zio/redis/ConnectionSpec.scala
+++ b/redis/src/test/scala/zio/redis/ConnectionSpec.scala
@@ -10,6 +10,14 @@ import java.net.InetAddress
 trait ConnectionSpec extends BaseSpec {
   def connectionSuite: Spec[Redis, RedisError] =
     suite("connection")(
+      suite("authenticating")(
+        test("auth with 'default' username") {
+          for {
+            redis <- ZIO.service[Redis]
+            res   <- redis.auth("default", "password")
+          } yield assert(res)(isUnit)
+        }
+      ),
       suite("clientCaching")(
         test("track keys") {
           for {

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -63,17 +63,17 @@ object InputSpec extends BaseSpec {
         test("with empty password") {
           for {
             result <- ZIO.attempt(AuthInput.encode(Auth(None, "")))
-          } yield assert(result)(equalTo(RespCommand(Literal("AUTH"), Value(""))))
+          } yield assert(result)(equalTo(RespCommand(Value(""))))
         },
         test("with non-empty password") {
           for {
             result <- ZIO.attempt(AuthInput.encode(Auth(None, "pass")))
-          } yield assert(result)(equalTo(RespCommand(Literal("AUTH"), Value("pass"))))
+          } yield assert(result)(equalTo(RespCommand(Value("pass"))))
         },
         test("with both username and password") {
           for {
             result <- ZIO.attempt(AuthInput.encode(Auth(Some("user"), "pass")))
-          } yield assert(result)(equalTo(RespCommand(Literal("AUTH"), Value("user"), Value("pass"))))
+          } yield assert(result)(equalTo(RespCommand(Value("user"), Value("pass"))))
         }
       ),
       suite("Bool")(

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -62,17 +62,17 @@ object InputSpec extends BaseSpec {
       suite("Auth")(
         test("with empty password") {
           for {
-            result <- ZIO.attempt(AuthInput.encode(Auth("", None)))
+            result <- ZIO.attempt(AuthInput.encode(Auth(None, "")))
           } yield assert(result)(equalTo(RespCommand(Literal("AUTH"), Value(""))))
         },
         test("with non-empty password") {
           for {
-            result <- ZIO.attempt(AuthInput.encode(Auth("pass", None)))
+            result <- ZIO.attempt(AuthInput.encode(Auth(None, "pass")))
           } yield assert(result)(equalTo(RespCommand(Literal("AUTH"), Value("pass"))))
         },
         test("with both username and password") {
           for {
-            result <- ZIO.attempt(AuthInput.encode(Auth("pass", Some("user"))))
+            result <- ZIO.attempt(AuthInput.encode(Auth(Some("user"), "pass")))
           } yield assert(result)(equalTo(RespCommand(Literal("AUTH"), Value("user"), Value("pass"))))
         }
       ),

--- a/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -62,13 +62,18 @@ object InputSpec extends BaseSpec {
       suite("Auth")(
         test("with empty password") {
           for {
-            result <- ZIO.attempt(AuthInput.encode(Auth("")))
+            result <- ZIO.attempt(AuthInput.encode(Auth("", None)))
           } yield assert(result)(equalTo(RespCommand(Literal("AUTH"), Value(""))))
         },
         test("with non-empty password") {
           for {
-            result <- ZIO.attempt(AuthInput.encode(Auth("pass")))
+            result <- ZIO.attempt(AuthInput.encode(Auth("pass", None)))
           } yield assert(result)(equalTo(RespCommand(Literal("AUTH"), Value("pass"))))
+        },
+        test("with both username and password") {
+          for {
+            result <- ZIO.attempt(AuthInput.encode(Auth("pass", Some("user"))))
+          } yield assert(result)(equalTo(RespCommand(Literal("AUTH"), Value("user"), Value("pass"))))
         }
       ),
       suite("Bool")(


### PR DESCRIPTION
### Description:

- Supported "username" argument in `AUTH` command.
- Extended API with `auth(username, password)` method.

Closes #771.