### PR TITLE
Support 'CLIENT INFO' and 'CLIENT LIST' commands

### DIFF
--- a/modules/redis/src/main/scala/zio/redis/Input.scala
+++ b/modules/redis/src/main/scala/zio/redis/Input.scala
@@ -161,6 +161,11 @@ object Input {
     }
   }
 
+  case object ClientTypeInput extends Input[ClientType] {
+    def encode(data: ClientType): RespCommand =
+      RespCommand(RespCommandArgument.Literal("TYPE"), RespCommandArgument.Literal(data.asString))
+  }
+
   case object ClientPauseModeInput extends Input[ClientPauseMode] {
     def encode(data: ClientPauseMode): RespCommand =
       RespCommand(RespCommandArgument.Literal(data.asString))
@@ -650,6 +655,15 @@ object Input {
   case object IdInput extends Input[Long] {
     def encode(data: Long): RespCommand =
       RespCommand(RespCommandArgument.Literal("ID"), RespCommandArgument.Unknown(data.toString))
+  }
+
+  case object IdsInput extends Input[(Long, List[Long])] {
+    def encode(data: (Long, List[Long])): RespCommand =
+      RespCommand(
+        Chunk.fromIterable(
+          RespCommandArgument.Literal("ID") +: (data._1 :: data._2).map(id => RespCommandArgument.Unknown(id.toString))
+        )
+      )
   }
 
   case object UnblockBehaviorInput extends Input[UnblockBehavior] {

--- a/modules/redis/src/main/scala/zio/redis/api/Connection.scala
+++ b/modules/redis/src/main/scala/zio/redis/api/Connection.scala
@@ -92,6 +92,19 @@ trait Connection extends RedisEnvironment {
   }
 
   /**
+   * The command returns information and statistics about the current client connection in a mostly human readable
+   * format.
+   *
+   * @return
+   *   a unique string composed of 'property=value' fields separated by a space character.
+   */
+  final def clientInfo: IO[RedisError, String] = {
+    val command = RedisCommand(ClientInfo, NoInput, MultiStringOutput, executor)
+
+    command.run(())
+  }
+
+  /**
    * Closes a given client connection with the specified address
    *
    * @param address
@@ -129,6 +142,32 @@ trait Connection extends RedisEnvironment {
     val command = RedisCommand(ClientKill, Varargs(ClientKillInput), LongOutput, executor)
 
     command.run(filters)
+  }
+
+  /**
+   * The command returns information and statistics about the client connections server in a mostly human readable
+   * format.
+   *
+   * @param clientType
+   *   filters the list by client's type
+   * @param clientIds
+   *   filters the list by client IDs
+   * @return
+   *   a unique string composed of 'property=value' fields separated by a space character
+   */
+  final def clientList(
+    clientType: Option[ClientType] = None,
+    clientIds: Option[(Long, List[Long])] = None
+  ): IO[RedisError, String] = {
+    val command =
+      RedisCommand(
+        ClientList,
+        Tuple2(OptionalInput(ClientTypeInput), OptionalInput(IdsInput)),
+        MultiStringOutput,
+        executor
+      )
+
+    command.run((clientType, clientIds))
   }
 
   /**
@@ -351,7 +390,9 @@ private[redis] object Connection {
   final val Auth               = "AUTH"
   final val ClientCaching      = "CLIENT CACHING"
   final val ClientId           = "CLIENT ID"
+  final val ClientInfo         = "CLIENT INFO"
   final val ClientKill         = "CLIENT KILL"
+  final val ClientList         = "CLIENT LIST"
   final val ClientGetName      = "CLIENT GETNAME"
   final val ClientGetRedir     = "CLIENT GETREDIR"
   final val ClientUnpause      = "CLIENT UNPAUSE"

--- a/modules/redis/src/main/scala/zio/redis/options/Connection.scala
+++ b/modules/redis/src/main/scala/zio/redis/options/Connection.scala
@@ -156,10 +156,10 @@ trait Connection {
   sealed trait ClientType { self =>
     private[redis] final def asString: String =
       self match {
-        case ClientType.Normal  => "normal"
-        case ClientType.Master  => "master"
-        case ClientType.Replica => "replica"
-        case ClientType.PubSub  => "pubsub"
+        case ClientType.Normal  => "NORMAL"
+        case ClientType.Master  => "MASTER"
+        case ClientType.Replica => "REPLICA"
+        case ClientType.PubSub  => "PUBSUB"
       }
   }
 

--- a/modules/redis/src/test/scala/zio/redis/ApiSpec.scala
+++ b/modules/redis/src/test/scala/zio/redis/ApiSpec.scala
@@ -19,46 +19,46 @@ object ApiSpec
     with ClusterSpec {
 
   def spec: Spec[TestEnvironment, Any] =
-    suite("Redis commands")(clusterSuite, singleNodeSuite) @@ sequential @@ withLiveEnvironment
+    suite("Redis commands")(singleNodeSuite) @@ sequential @@ withLiveEnvironment
 
   private val singleNodeSuite =
     suite("Single node executor")(
-      connectionSuite,
-      keysSuite,
-      listSuite,
-      setsSuite,
-      sortedSetsSuite,
-      stringsSuite,
-      geoSuite,
-      hyperLogLogSuite,
-      hashSuite,
-      streamsSuite,
-      scriptingSpec
+      connectionSuite
+//      keysSuite,
+//      listSuite,
+//      setsSuite,
+//      sortedSetsSuite,
+//      stringsSuite,
+//      geoSuite,
+//      hyperLogLogSuite,
+//      hashSuite,
+//      streamsSuite,
+//      scriptingSpec
     ).provideShared(
       SingleNodeExecutor.local,
       Redis.layer,
       ZLayer.succeed(ProtobufCodecSupplier)
     )
 
-  private val clusterSuite =
-    suite("Cluster executor")(
-      connectionSuite,
-      keysSuite,
-      listSuite,
-      stringsSuite,
-      hashSuite,
-      setsSuite,
-      sortedSetsSuite,
-      hyperLogLogSuite,
-      geoSuite,
-      streamsSuite,
-      scriptingSpec,
-      clusterSpec
-    ).provideShared(
-      ClusterExecutor.layer,
-      Redis.layer,
-      ZLayer.succeed(ProtobufCodecSupplier),
-      ZLayer.succeed(RedisClusterConfig(Chunk(RedisUri("localhost", 5000))))
-    ).filterNotTags(_.contains(BaseSpec.ClusterExecutorUnsupported))
-      .getOrElse(Spec.empty)
+//  private val clusterSuite =
+//    suite("Cluster executor")(
+//      connectionSuite,
+//      keysSuite,
+//      listSuite,
+//      stringsSuite,
+//      hashSuite,
+//      setsSuite,
+//      sortedSetsSuite,
+//      hyperLogLogSuite,
+//      geoSuite,
+//      streamsSuite,
+//      scriptingSpec,
+//      clusterSpec
+//    ).provideShared(
+//      ClusterExecutor.layer,
+//      Redis.layer,
+//      ZLayer.succeed(ProtobufCodecSupplier),
+//      ZLayer.succeed(RedisClusterConfig(Chunk(RedisUri("localhost", 5000))))
+//    ).filterNotTags(_.contains(BaseSpec.ClusterExecutorUnsupported))
+//      .getOrElse(Spec.empty)
 }

--- a/modules/redis/src/test/scala/zio/redis/ApiSpec.scala
+++ b/modules/redis/src/test/scala/zio/redis/ApiSpec.scala
@@ -19,46 +19,46 @@ object ApiSpec
     with ClusterSpec {
 
   def spec: Spec[TestEnvironment, Any] =
-    suite("Redis commands")(singleNodeSuite) @@ sequential @@ withLiveEnvironment
+    suite("Redis commands")(clusterSuite, singleNodeSuite) @@ sequential @@ withLiveEnvironment
 
   private val singleNodeSuite =
     suite("Single node executor")(
-      connectionSuite
-//      keysSuite,
-//      listSuite,
-//      setsSuite,
-//      sortedSetsSuite,
-//      stringsSuite,
-//      geoSuite,
-//      hyperLogLogSuite,
-//      hashSuite,
-//      streamsSuite,
-//      scriptingSpec
+      connectionSuite,
+      keysSuite,
+      listSuite,
+      setsSuite,
+      sortedSetsSuite,
+      stringsSuite,
+      geoSuite,
+      hyperLogLogSuite,
+      hashSuite,
+      streamsSuite,
+      scriptingSpec
     ).provideShared(
       SingleNodeExecutor.local,
       Redis.layer,
       ZLayer.succeed(ProtobufCodecSupplier)
     )
 
-//  private val clusterSuite =
-//    suite("Cluster executor")(
-//      connectionSuite,
-//      keysSuite,
-//      listSuite,
-//      stringsSuite,
-//      hashSuite,
-//      setsSuite,
-//      sortedSetsSuite,
-//      hyperLogLogSuite,
-//      geoSuite,
-//      streamsSuite,
-//      scriptingSpec,
-//      clusterSpec
-//    ).provideShared(
-//      ClusterExecutor.layer,
-//      Redis.layer,
-//      ZLayer.succeed(ProtobufCodecSupplier),
-//      ZLayer.succeed(RedisClusterConfig(Chunk(RedisUri("localhost", 5000))))
-//    ).filterNotTags(_.contains(BaseSpec.ClusterExecutorUnsupported))
-//      .getOrElse(Spec.empty)
+  private val clusterSuite =
+    suite("Cluster executor")(
+      connectionSuite,
+      keysSuite,
+      listSuite,
+      stringsSuite,
+      hashSuite,
+      setsSuite,
+      sortedSetsSuite,
+      hyperLogLogSuite,
+      geoSuite,
+      streamsSuite,
+      scriptingSpec,
+      clusterSpec
+    ).provideShared(
+      ClusterExecutor.layer,
+      Redis.layer,
+      ZLayer.succeed(ProtobufCodecSupplier),
+      ZLayer.succeed(RedisClusterConfig(Chunk(RedisUri("localhost", 5000))))
+    ).filterNotTags(_.contains(BaseSpec.ClusterExecutorUnsupported))
+      .getOrElse(Spec.empty)
 }

--- a/modules/redis/src/test/scala/zio/redis/ConnectionSpec.scala
+++ b/modules/redis/src/test/scala/zio/redis/ConnectionSpec.scala
@@ -80,10 +80,10 @@ trait ConnectionSpec extends BaseSpec {
         },
         test("get clients' info filtered by type") {
           for {
-            redis       <- ZIO.service[Redis]
-            infoNormal  <- redis.clientList(Some(ClientType.Normal))
-            infoReplica <- redis.clientList(Some(ClientType.Replica))
-          } yield assert(infoNormal)(isNonEmptyString) && assert(infoReplica)(isEmptyString)
+            redis      <- ZIO.service[Redis]
+            infoNormal <- redis.clientList(Some(ClientType.Normal))
+            infoPubSub <- redis.clientList(Some(ClientType.PubSub))
+          } yield assert(infoNormal)(isNonEmptyString) && assert(infoPubSub)(isEmptyString)
         },
         test("get clients' info filtered by client IDs") {
           for {

--- a/modules/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/modules/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -251,7 +251,7 @@ object InputSpec extends BaseSpec {
           for {
             clientType <- ZIO.succeed(ClientType.PubSub)
             result     <- ZIO.attempt(ClientKillInput.encode(ClientKillFilter.Type(clientType)))
-          } yield assert(result)(equalTo(RespCommand(Literal("TYPE"), Literal("pubsub"))))
+          } yield assert(result)(equalTo(RespCommand(Literal("TYPE"), Literal("PUBSUB"))))
         },
         test("user") {
           for {
@@ -1061,6 +1061,20 @@ object InputSpec extends BaseSpec {
           for {
             result <- ZIO.attempt(IdInput.encode(10))
           } yield assert(result)(equalTo(RespCommand(Literal("ID"), Unknown("10"))))
+        }
+      ),
+      suite("IDs")(
+        test("with a single element") {
+          for {
+            result <- ZIO.attempt(IdsInput.encode((1, Nil)))
+          } yield assert(result)(equalTo(RespCommand(Literal("ID"), Unknown("1"))))
+        },
+        test("with multiple elements") {
+          for {
+            result <- ZIO.attempt(IdsInput.encode((1, List(2, 3, 4))))
+          } yield assert(result)(
+            equalTo(RespCommand(Literal("ID"), Unknown("1"), Unknown("2"), Unknown("3"), Unknown("4")))
+          )
         }
       ),
       suite("UnblockBehavior")(

--- a/modules/redis/src/test/scala/zio/redis/SortedSetsSpec.scala
+++ b/modules/redis/src/test/scala/zio/redis/SortedSetsSpec.scala
@@ -795,7 +795,7 @@ trait SortedSetsSpec extends BaseSpec {
           redis  <- ZIO.service[Redis]
           key    <- uuid
           result <- redis.zPopMax(key).returning[String]
-        } yield assert(result.toList)(equalTo(Nil)))
+        } yield assert(result.toList)(isEmpty))
       ),
       suite("zPopMin")(
         test("non-empty set")(
@@ -828,7 +828,7 @@ trait SortedSetsSpec extends BaseSpec {
           redis  <- ZIO.service[Redis]
           key    <- uuid
           result <- redis.zPopMin(key).returning[String]
-        } yield assert(result.toList)(equalTo(Nil)))
+        } yield assert(result.toList)(isEmpty))
       ),
       suite("zRange")(
         test("non-empty set") {


### PR DESCRIPTION
### Description:

- Supported the `CLIENT INFO` command
- Supported the `CLIENT LIST` command
- Changed `ClientTypo` keywords to uppercase
- Fixed minor typos in tests
- Use `isEmpty` instead of `equalTo(Nil)`

Closes #460 