### PR TITLE
Fix compilation when using Scala 3.3.x

### DIFF
--- a/modules/embedded/src/test/scala/zio/redis/embedded/EmbeddedRedisSpec.scala
+++ b/modules/embedded/src/test/scala/zio/redis/embedded/EmbeddedRedisSpec.scala
@@ -27,7 +27,7 @@ import java.util.UUID
 
 object EmbeddedRedisSpec extends ZIOSpecDefault {
 
-  final case class Item (id: UUID, name: String, quantity: Int)
+  final case class Item(id: UUID, name: String, quantity: Int)
   object Item {
     implicit val itemSchema: Schema[Item] = DeriveSchema.gen[Item]
   }

--- a/modules/embedded/src/test/scala/zio/redis/embedded/EmbeddedRedisSpec.scala
+++ b/modules/embedded/src/test/scala/zio/redis/embedded/EmbeddedRedisSpec.scala
@@ -27,7 +27,7 @@ import java.util.UUID
 
 object EmbeddedRedisSpec extends ZIOSpecDefault {
 
-  final case class Item private (id: UUID, name: String, quantity: Int)
+  final case class Item (id: UUID, name: String, quantity: Int)
   object Item {
     implicit val itemSchema: Schema[Item] = DeriveSchema.gen[Item]
   }


### PR DESCRIPTION
Class Item was defining a single private constructor, which is unavailable outside the Item companion object. This should never compile, and apparently, it was fixed in Scala 3.3.x.

Another workaround to this error is defining Item as `private[EmbeddedRedisSpec]` to make it a private within outer object, which probably was done in previous versions of Scala

Based on Open Community Build failure: https://github.com/VirtusLab/community-build3/actions/runs/4650721329/jobs/8232633193