### PR TITLE
Handle empty bulk string (#808)

### DIFF
--- a/modules/redis/src/main/scala/zio/redis/Output.scala
+++ b/modules/redis/src/main/scala/zio/redis/Output.scala
@@ -251,7 +251,6 @@ object Output {
     protected def tryDecode(respValue: RespValue): Option[A] =
       respValue match {
         case RespValue.NullBulkString | RespValue.NullArray => None
-        case RespValue.BulkString(value) if value.isEmpty   => None
         case other                                          => Some(output.tryDecode(other))
       }
   }

--- a/modules/redis/src/test/scala/zio/redis/OutputSpec.scala
+++ b/modules/redis/src/test/scala/zio/redis/OutputSpec.scala
@@ -149,9 +149,10 @@ object OutputSpec extends BaseSpec {
             res <- ZIO.attempt(OptionalOutput(UnitOutput).unsafeDecode(RespValue.SimpleString("OK")))
           } yield assert(res)(isSome(isUnit))
         },
-          test ("extract empty bulk string") {
+        test("extract empty bulk string") {
           for {
-            res <- ZIO.attempt(OptionalOutput(ArbitraryOutput[String]()).unsafeDecode(RespValue.BulkString(Chunk.empty)))
+            res <-
+              ZIO.attempt(OptionalOutput(ArbitraryOutput[String]()).unsafeDecode(RespValue.BulkString(Chunk.empty)))
           } yield assert(res)(isSome(equalTo("")))
         }
       ),

--- a/modules/redis/src/test/scala/zio/redis/OutputSpec.scala
+++ b/modules/redis/src/test/scala/zio/redis/OutputSpec.scala
@@ -134,15 +134,25 @@ object OutputSpec extends BaseSpec {
         }
       ),
       suite("optional")(
-        test("extract None") {
+        test("extract null bulk string") {
           for {
             res <- ZIO.attempt(OptionalOutput(UnitOutput).unsafeDecode(RespValue.NullBulkString))
+          } yield assert(res)(isNone)
+        },
+        test("extract null array") {
+          for {
+            res <- ZIO.attempt(OptionalOutput(ArbitraryOutput[String]()).unsafeDecode(RespValue.NullArray))
           } yield assert(res)(isNone)
         },
         test("extract some") {
           for {
             res <- ZIO.attempt(OptionalOutput(UnitOutput).unsafeDecode(RespValue.SimpleString("OK")))
           } yield assert(res)(isSome(isUnit))
+        },
+          test ("extract empty bulk string") {
+          for {
+            res <- ZIO.attempt(OptionalOutput(ArbitraryOutput[String]()).unsafeDecode(RespValue.BulkString(Chunk.empty)))
+          } yield assert(res)(isSome(equalTo("")))
         }
       ),
       suite("scan")(

--- a/modules/redis/src/test/scala/zio/redis/StringsSpec.scala
+++ b/modules/redis/src/test/scala/zio/redis/StringsSpec.scala
@@ -989,7 +989,7 @@ trait StringsSpec extends BaseSpec {
             result <- redis.get(key).returning[String]
           } yield assert(result)(isNone)
         },
-        test("emtpy string") {
+        test("empty string") {
           for {
             redis  <- ZIO.service[Redis]
             key    <- uuid

--- a/modules/redis/src/test/scala/zio/redis/StringsSpec.scala
+++ b/modules/redis/src/test/scala/zio/redis/StringsSpec.scala
@@ -982,12 +982,20 @@ trait StringsSpec extends BaseSpec {
             result <- redis.get(key).returning[String]
           } yield assert(result)(isSome(equalTo("value")))
         },
-        test("emtpy string") {
+        test("non existent string") {
           for {
             redis  <- ZIO.service[Redis]
             key    <- uuid
             result <- redis.get(key).returning[String]
           } yield assert(result)(isNone)
+        },
+        test("emtpy string") {
+          for {
+            redis <- ZIO.service[Redis]
+            key <- uuid
+            _ <- redis.set(key, "")
+            result <- redis.get(key).returning[String]
+          } yield assert(result)(isSome(equalTo("")))
         },
         test("error when not string") {
           for {
@@ -1061,7 +1069,7 @@ trait StringsSpec extends BaseSpec {
             key    <- uuid
             _      <- redis.set(key, "value")
             substr <- redis.getRange(key, 10 to 15).returning[String]
-          } yield assert(substr)(isNone)
+          } yield assert(substr)(isSome(equalTo("")))
         },
         test("with inverse range of non-empty string") {
           for {
@@ -1069,7 +1077,7 @@ trait StringsSpec extends BaseSpec {
             key    <- uuid
             _      <- redis.set(key, "value")
             substr <- redis.getRange(key, 15 to 3).returning[String]
-          } yield assert(substr)(isNone)
+          } yield assert(substr)(isSome(equalTo("")))
         },
         test("with negative range end from non-empty string") {
           for {
@@ -1092,7 +1100,7 @@ trait StringsSpec extends BaseSpec {
             redis  <- ZIO.service[Redis]
             key    <- uuid
             substr <- redis.getRange(key, 1 to 3).returning[String]
-          } yield assert(substr)(isNone)
+          } yield assert(substr)(isSome(equalTo("")))
         },
         test("error when not string") {
           for {

--- a/modules/redis/src/test/scala/zio/redis/StringsSpec.scala
+++ b/modules/redis/src/test/scala/zio/redis/StringsSpec.scala
@@ -991,9 +991,9 @@ trait StringsSpec extends BaseSpec {
         },
         test("emtpy string") {
           for {
-            redis <- ZIO.service[Redis]
-            key <- uuid
-            _ <- redis.set(key, "")
+            redis  <- ZIO.service[Redis]
+            key    <- uuid
+            _      <- redis.set(key, "")
             result <- redis.get(key).returning[String]
           } yield assert(result)(isSome(equalTo("")))
         },


### PR DESCRIPTION
Resolves #808 

This did change how `getRange` works, as it now returns empty quotes even when the sought range exceed the length of the string, but to my knowledge (tweaking around with redis-cli) `getRange` returning empty quotes in such scenarios is standard redis behaviour. 

Hope that helps! I'm ready to tinker with this some more in case you think this solution could be improved.