### PR TITLE
Update code of conduct and contributor's guide links

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,11 +126,11 @@ Learn more on the [ZIO Redis homepage](https://zio.dev/zio-redis/)!
 
 ## Contributing
 
-For the general guidelines, see ZIO [contributor's guide](https://zio.dev/about/contributing).
+For the general guidelines, see ZIO [contributor's guide](https://zio.dev/zio-insight/how-to-contribute/).
 
 ## Code of Conduct
 
-See the [Code of Conduct](https://zio.dev/about/code-of-conduct)
+See the [Code of Conduct](https://zio.dev/code-of-conduct/)
 
 ## Support
 


### PR DESCRIPTION
In the README, links to "code of conduct" and "contributor's guide" are currently outdated and lead nowhere. This commit updates them.