### PR TITLE
Support async command evaluation

### DIFF
--- a/modules/redis/src/main/scala/zio/redis/GenRedis.scala
+++ b/modules/redis/src/main/scala/zio/redis/GenRedis.scala
@@ -1,0 +1,16 @@
+package zio.redis
+
+trait GenRedis[G[+_]]
+    extends api.Connection[G]
+    with api.Geo[G]
+    with api.Hashes[G]
+    with api.HyperLogLog[G]
+    with api.Keys[G]
+    with api.Lists[G]
+    with api.Sets[G]
+    with api.Strings[G]
+    with api.SortedSets[G]
+    with api.Streams[G]
+    with api.Scripting[G]
+    with api.Cluster[G]
+    with api.Publishing[G]

--- a/modules/redis/src/main/scala/zio/redis/GenRedis.scala
+++ b/modules/redis/src/main/scala/zio/redis/GenRedis.scala
@@ -1,7 +1,7 @@
 package zio.redis
 import zio.{IO, UIO}
 
-private trait GenRedis[G[+_]]
+private[redis] trait GenRedis[G[+_]]
     extends api.Connection[G]
     with api.Geo[G]
     with api.Hashes[G]
@@ -16,8 +16,8 @@ private trait GenRedis[G[+_]]
     with api.Cluster[G]
     with api.Publishing[G]
 
-private object GenRedis {
-  type Async[+A] = IO[RedisError, IO[RedisError, A]]
+private[redis] object GenRedis {
+  type Async[+A] = UIO[IO[RedisError, A]]
   type Sync[+A]  = IO[RedisError, A]
 
   def async[A](io: UIO[IO[RedisError, A]]) = io

--- a/modules/redis/src/main/scala/zio/redis/GenRedis.scala
+++ b/modules/redis/src/main/scala/zio/redis/GenRedis.scala
@@ -1,7 +1,7 @@
 package zio.redis
 import zio.{IO, UIO}
 
-trait GenRedis[G[+_]]
+private trait GenRedis[G[+_]]
     extends api.Connection[G]
     with api.Geo[G]
     with api.Hashes[G]
@@ -16,10 +16,10 @@ trait GenRedis[G[+_]]
     with api.Cluster[G]
     with api.Publishing[G]
 
-object GenRedis {
+private object GenRedis {
   type Async[+A] = IO[RedisError, IO[RedisError, A]]
   type Sync[+A]  = IO[RedisError, A]
-  
-  private[redis] def async[A](io: UIO[IO[RedisError, A]]) = io
-  private[redis] def sync[A](io: UIO[IO[RedisError, A]])  = io.flatten
+
+  def async[A](io: UIO[IO[RedisError, A]]) = io
+  def sync[A](io: UIO[IO[RedisError, A]])  = io.flatten
 }

--- a/modules/redis/src/main/scala/zio/redis/GenRedis.scala
+++ b/modules/redis/src/main/scala/zio/redis/GenRedis.scala
@@ -18,7 +18,8 @@ trait GenRedis[G[+_]]
 
 object GenRedis {
   type Async[+A] = IO[RedisError, IO[RedisError, A]]
+  type Sync[+A]  = IO[RedisError, A]
+  
   private[redis] def async[A](io: UIO[IO[RedisError, A]]) = io
-  type Sync[+A] = IO[RedisError, A]
-  private[redis] def sync[A](io: UIO[IO[RedisError, A]]) = io.flatten
+  private[redis] def sync[A](io: UIO[IO[RedisError, A]])  = io.flatten
 }

--- a/modules/redis/src/main/scala/zio/redis/GenRedis.scala
+++ b/modules/redis/src/main/scala/zio/redis/GenRedis.scala
@@ -1,4 +1,5 @@
 package zio.redis
+import zio.{IO, UIO}
 
 trait GenRedis[G[+_]]
     extends api.Connection[G]
@@ -14,3 +15,10 @@ trait GenRedis[G[+_]]
     with api.Scripting[G]
     with api.Cluster[G]
     with api.Publishing[G]
+
+object GenRedis {
+  type Async[+A] = IO[RedisError, IO[RedisError, A]]
+  private[redis] def async[A](io: UIO[IO[RedisError, A]]) = io
+  type Sync[+A] = IO[RedisError, A]
+  private[redis] def sync[A](io: UIO[IO[RedisError, A]]) = io.flatten
+}

--- a/modules/redis/src/main/scala/zio/redis/Redis.scala
+++ b/modules/redis/src/main/scala/zio/redis/Redis.scala
@@ -29,30 +29,29 @@ object Redis {
       makeLayer
     )
 
-  lazy val singleNode: ZLayer[CodecSupplier & RedisConfig, RedisError.IOError, Redis & AsyncRedis] =
+  lazy val singleNode: ZLayer[CodecSupplier & RedisConfig, RedisError.IOError, Redis & AsyncRedis]                  =
     ZLayer.makeSome[CodecSupplier & RedisConfig, Redis & AsyncRedis](
       SingleNodeExecutor.layer,
       makeLayer
     )
-  private def makeLayer
-    : URLayer[CodecSupplier & RedisExecutor, GenRedis[RedisExecutor.Async] & GenRedis[RedisExecutor.Sync]] =
+  private def makeLayer: URLayer[CodecSupplier & RedisExecutor, GenRedis[GenRedis.Async] & GenRedis[GenRedis.Sync]] =
     ZLayer.fromZIOEnvironment {
       for {
         codecSupplier <- ZIO.service[CodecSupplier]
         executor      <- ZIO.service[RedisExecutor]
-      } yield ZEnvironment[GenRedis[RedisExecutor.Async], GenRedis[RedisExecutor.Sync]](
+      } yield ZEnvironment[GenRedis[GenRedis.Async], GenRedis[GenRedis.Sync]](
         new AsyncLive(codecSupplier, executor),
         new SyncLive(codecSupplier, executor)
       )
     }
 
   private final class SyncLive(val codecSupplier: CodecSupplier, val executor: RedisExecutor)
-      extends GenRedis[RedisExecutor.Sync] {
-    def toG[A](in: UIO[IO[RedisError, A]]): RedisExecutor.Sync[A] = RedisExecutor.sync(in)
+      extends GenRedis[GenRedis.Sync] {
+    def toG[A](in: UIO[IO[RedisError, A]]): GenRedis.Sync[A] = GenRedis.sync(in)
   }
 
   private final class AsyncLive(val codecSupplier: CodecSupplier, val executor: RedisExecutor)
-      extends GenRedis[RedisExecutor.Async] {
-    def toG[A](in: UIO[IO[RedisError, A]]): RedisExecutor.Async[A] = RedisExecutor.async(in)
+      extends GenRedis[GenRedis.Async] {
+    def toG[A](in: UIO[IO[RedisError, A]]): GenRedis.Async[A] = GenRedis.async(in)
   }
 }

--- a/modules/redis/src/main/scala/zio/redis/Redis.scala
+++ b/modules/redis/src/main/scala/zio/redis/Redis.scala
@@ -16,9 +16,8 @@
 
 package zio.redis
 
-import zio._
 import zio.redis.internal._
-import zio.Tag
+import zio.{Tag, _}
 
 trait GenRedis[G[+_]]
     extends api.Connection[G]

--- a/modules/redis/src/main/scala/zio/redis/Redis.scala
+++ b/modules/redis/src/main/scala/zio/redis/Redis.scala
@@ -24,10 +24,7 @@ object Redis {
     ZLayer.makeSome[CodecSupplier & RedisClusterConfig, Redis](ClusterExecutor.layer, makeLayer)
 
   lazy val local: ZLayer[CodecSupplier, RedisError.IOError, Redis & AsyncRedis] =
-    ZLayer.makeSome[CodecSupplier, Redis & AsyncRedis](
-      SingleNodeExecutor.local,
-      makeLayer
-    )
+    SingleNodeExecutor.local >>> makeLayer
 
   lazy val singleNode: ZLayer[CodecSupplier & RedisConfig, RedisError.IOError, Redis & AsyncRedis] =
     SingleNodeExecutor.layer >>> makeLayer

--- a/modules/redis/src/main/scala/zio/redis/Redis.scala
+++ b/modules/redis/src/main/scala/zio/redis/Redis.scala
@@ -41,7 +41,7 @@ object Redis {
   lazy val local: ZLayer[CodecSupplier, RedisError.IOError, Redis & AsyncRedis] =
     SingleNodeExecutor.local >>> (makeLayer[RedisExecutor.Sync] ++ makeLayer[RedisExecutor.Async])
 
-  lazy val singleNode: ZLayer[CodecSupplier & RedisConfig, RedisError.IOError, Redis with AsyncRedis] =
+  lazy val singleNode: ZLayer[CodecSupplier & RedisConfig, RedisError.IOError, Redis & AsyncRedis] =
     SingleNodeExecutor.layer >>> (makeLayer[RedisExecutor.Sync] ++ makeLayer[RedisExecutor.Async])
 
   private def makeLayer[G[+_]](implicit

--- a/modules/redis/src/main/scala/zio/redis/Redis.scala
+++ b/modules/redis/src/main/scala/zio/redis/Redis.scala
@@ -40,10 +40,10 @@ object Redis {
     }
 
   private final class SyncLive(val codecSupplier: CodecSupplier, val executor: RedisExecutor) extends Redis {
-    def toG[A](in: UIO[IO[RedisError, A]]): GenRedis.Sync[A] = GenRedis.sync(in)
+    def lift[A](in: UIO[IO[RedisError, A]]): GenRedis.Sync[A] = GenRedis.sync(in)
   }
 
   private final class AsyncLive(val codecSupplier: CodecSupplier, val executor: RedisExecutor) extends AsyncRedis {
-    def toG[A](in: UIO[IO[RedisError, A]]): GenRedis.Async[A] = GenRedis.async(in)
+    def lift[A](in: UIO[IO[RedisError, A]]): GenRedis.Async[A] = GenRedis.async(in)
   }
 }

--- a/modules/redis/src/main/scala/zio/redis/Redis.scala
+++ b/modules/redis/src/main/scala/zio/redis/Redis.scala
@@ -29,9 +29,9 @@ object Redis {
       makeLayer
     )
 
-  lazy val singleNode: ZLayer[CodecSupplier & RedisConfig, RedisError.IOError, Redis & AsyncRedis]                  =
-      SingleNodeExecutor.layer >>> makeLayer
-  private def makeLayer: URLayer[CodecSupplier & RedisExecutor, AsyncRedis & Redis] =
+  lazy val singleNode: ZLayer[CodecSupplier & RedisConfig, RedisError.IOError, Redis & AsyncRedis] =
+    SingleNodeExecutor.layer >>> makeLayer
+  private def makeLayer: URLayer[CodecSupplier & RedisExecutor, AsyncRedis & Redis]                =
     ZLayer.fromZIOEnvironment {
       for {
         codecSupplier <- ZIO.service[CodecSupplier]
@@ -42,13 +42,11 @@ object Redis {
       )
     }
 
-  private final class SyncLive(val codecSupplier: CodecSupplier, val executor: RedisExecutor)
-      extends Redis {
+  private final class SyncLive(val codecSupplier: CodecSupplier, val executor: RedisExecutor) extends Redis {
     def toG[A](in: UIO[IO[RedisError, A]]): GenRedis.Sync[A] = GenRedis.sync(in)
   }
 
-  private final class AsyncLive(val codecSupplier: CodecSupplier, val executor: RedisExecutor)
-      extends AsyncRedis {
+  private final class AsyncLive(val codecSupplier: CodecSupplier, val executor: RedisExecutor) extends AsyncRedis {
     def toG[A](in: UIO[IO[RedisError, A]]): GenRedis.Async[A] = GenRedis.async(in)
   }
 }

--- a/modules/redis/src/main/scala/zio/redis/Redis.scala
+++ b/modules/redis/src/main/scala/zio/redis/Redis.scala
@@ -39,8 +39,8 @@ object Redis {
   lazy val cluster: ZLayer[CodecSupplier & RedisClusterConfig, RedisError, Redis] =
     ClusterExecutor.layer >>> makeLayer[RedisExecutor.Sync]
 
-  lazy val local: ZLayer[CodecSupplier, RedisError.IOError, Redis] =
-    SingleNodeExecutor.local >>> makeLayer[RedisExecutor.Sync]
+  lazy val local: ZLayer[CodecSupplier, RedisError.IOError, Redis & AsyncRedis] =
+    SingleNodeExecutor.local >>> (makeLayer[RedisExecutor.Sync] ++ makeLayer[RedisExecutor.Async])
 
   lazy val singleNode: ZLayer[CodecSupplier & RedisConfig, RedisError.IOError, Redis with AsyncRedis] =
     SingleNodeExecutor.layer >>> (makeLayer[RedisExecutor.Sync] ++ makeLayer[RedisExecutor.Async])

--- a/modules/redis/src/main/scala/zio/redis/Redis.scala
+++ b/modules/redis/src/main/scala/zio/redis/Redis.scala
@@ -40,10 +40,10 @@ object Redis {
     }
 
   private final class SyncLive(val codecSupplier: CodecSupplier, val executor: RedisExecutor) extends Redis {
-    def lift[A](in: UIO[IO[RedisError, A]]): GenRedis.Sync[A] = GenRedis.sync(in)
+    protected def lift[A](in: UIO[IO[RedisError, A]]): GenRedis.Sync[A] = GenRedis.sync(in)
   }
 
   private final class AsyncLive(val codecSupplier: CodecSupplier, val executor: RedisExecutor) extends AsyncRedis {
-    def lift[A](in: UIO[IO[RedisError, A]]): GenRedis.Async[A] = GenRedis.async(in)
+    protected def lift[A](in: UIO[IO[RedisError, A]]): GenRedis.Async[A] = GenRedis.async(in)
   }
 }

--- a/modules/redis/src/main/scala/zio/redis/Redis.scala
+++ b/modules/redis/src/main/scala/zio/redis/Redis.scala
@@ -16,8 +16,8 @@
 
 package zio.redis
 
-import zio.redis.internal._
 import zio._
+import zio.redis.internal._
 
 object Redis {
   lazy val cluster: ZLayer[CodecSupplier & RedisClusterConfig, RedisError, Redis] =

--- a/modules/redis/src/main/scala/zio/redis/ResultBuilder.scala
+++ b/modules/redis/src/main/scala/zio/redis/ResultBuilder.scala
@@ -31,20 +31,20 @@ object ResultBuilder {
   @annotation.implicitNotFound("Use `returning[A]` to specify method's return type")
   final abstract class NeedsReturnType
 
-  trait ResultBuilder1[+F[_]] extends ResultBuilder {
-    def returning[R: Schema]: IO[RedisError, F[R]]
+  trait ResultBuilder1[+F[_], G[+_]] extends ResultBuilder {
+    def returning[R: Schema]: G[F[R]]
   }
 
-  trait ResultBuilder2[+F[_, _]] extends ResultBuilder {
-    def returning[R1: Schema, R2: Schema]: IO[RedisError, F[R1, R2]]
+  trait ResultBuilder2[+F[_, _], G[+_]] extends ResultBuilder {
+    def returning[R1: Schema, R2: Schema]: G[F[R1, R2]]
   }
 
-  trait ResultBuilder3[+F[_, _, _]] extends ResultBuilder {
-    def returning[R1: Schema, R2: Schema, R3: Schema]: IO[RedisError, F[R1, R2, R3]]
+  trait ResultBuilder3[+F[_, _, _], G[+_]] extends ResultBuilder {
+    def returning[R1: Schema, R2: Schema, R3: Schema]: G[F[R1, R2, R3]]
   }
 
-  trait ResultOutputBuilder extends ResultBuilder {
-    def returning[R: Output]: IO[RedisError, R]
+  trait ResultOutputBuilder[G[+_]] extends ResultBuilder {
+    def returning[R: Output]: G[R]
   }
 
   trait ResultStreamBuilder1[+F[_]] extends ResultBuilder {

--- a/modules/redis/src/main/scala/zio/redis/api/Cluster.scala
+++ b/modules/redis/src/main/scala/zio/redis/api/Cluster.scala
@@ -16,13 +16,13 @@
 
 package zio.redis.api
 
+import zio.Chunk
 import zio.redis.Input._
 import zio.redis.Output.{ChunkOutput, ClusterPartitionOutput, UnitOutput}
 import zio.redis.api.Cluster.{AskingCommand, ClusterSetSlots, ClusterSlots}
 import zio.redis.internal.{RedisCommand, RedisEnvironment, RedisExecutor}
 import zio.redis.options.Cluster.SetSlotSubCommand._
 import zio.redis.options.Cluster.{Partition, Slot}
-import zio.Chunk
 
 trait Cluster[G[+_]] extends RedisEnvironment[G] {
 

--- a/modules/redis/src/main/scala/zio/redis/api/Cluster.scala
+++ b/modules/redis/src/main/scala/zio/redis/api/Cluster.scala
@@ -19,7 +19,7 @@ package zio.redis.api
 import zio.Chunk
 import zio.redis.Input._
 import zio.redis.Output.{ChunkOutput, ClusterPartitionOutput, UnitOutput}
-import zio.redis.api.Cluster.{askingCommand, ClusterSetSlots, ClusterSlots}
+import zio.redis.api.Cluster.{ClusterSetSlots, ClusterSlots, askingCommand}
 import zio.redis.internal.{RedisCommand, RedisEnvironment}
 import zio.redis.options.Cluster.SetSlotSubCommand._
 import zio.redis.options.Cluster.{Partition, Slot}

--- a/modules/redis/src/main/scala/zio/redis/api/Cluster.scala
+++ b/modules/redis/src/main/scala/zio/redis/api/Cluster.scala
@@ -19,7 +19,7 @@ package zio.redis.api
 import zio.Chunk
 import zio.redis.Input._
 import zio.redis.Output.{ChunkOutput, ClusterPartitionOutput, UnitOutput}
-import zio.redis.api.Cluster.{AskingCommand, ClusterSetSlots, ClusterSlots}
+import zio.redis.api.Cluster.{askingCommand, ClusterSetSlots, ClusterSlots}
 import zio.redis.internal.{RedisCommand, RedisEnvironment, RedisExecutor}
 import zio.redis.options.Cluster.SetSlotSubCommand._
 import zio.redis.options.Cluster.{Partition, Slot}
@@ -34,7 +34,7 @@ trait Cluster[G[+_]] extends RedisEnvironment[G] {
    *   the Unit value.
    */
   final def asking: G[Unit] =
-    AskingCommand(executor).run(())
+    askingCommand(executor).run(())
 
   /**
    * Set a hash slot in importing state. Command should be executed on the node where hash slot will be migrated
@@ -130,6 +130,6 @@ private[redis] object Cluster {
   final val ClusterSetSlots = "CLUSTER SETSLOT"
   final val ClusterSlots    = "CLUSTER SLOTS"
 
-  final def AskingCommand[G[+_]](executor: RedisExecutor[G]): RedisCommand[Unit, Unit, G] =
+  final def askingCommand[G[+_]](executor: RedisExecutor[G]): RedisCommand[Unit, Unit, G] =
     RedisCommand(Asking, NoInput, UnitOutput, executor)
 }

--- a/modules/redis/src/main/scala/zio/redis/api/Cluster.scala
+++ b/modules/redis/src/main/scala/zio/redis/api/Cluster.scala
@@ -34,7 +34,7 @@ trait Cluster[G[+_]] extends RedisEnvironment[G] {
    *   the Unit value.
    */
   final def asking: G[Unit] =
-    runCommand(askingCommand, ())
+    askingCommand.run(())
 
   /**
    * Set a hash slot in importing state. Command should be executed on the node where hash slot will be migrated
@@ -53,7 +53,7 @@ trait Cluster[G[+_]] extends RedisEnvironment[G] {
       Tuple3(LongInput, ArbitraryValueInput[String](), ArbitraryValueInput[String]()),
       UnitOutput
     )
-    this.runCommand(command, (slot.number, Importing.asString, nodeId))
+    command.run((slot.number, Importing.asString, nodeId))
   }
 
   /**
@@ -73,7 +73,7 @@ trait Cluster[G[+_]] extends RedisEnvironment[G] {
       Tuple3(LongInput, ArbitraryValueInput[String](), ArbitraryValueInput[String]()),
       UnitOutput
     )
-    runCommand(command, (slot.number, Migrating.asString, nodeId))
+    command.run((slot.number, Migrating.asString, nodeId))
   }
 
   /**
@@ -93,7 +93,7 @@ trait Cluster[G[+_]] extends RedisEnvironment[G] {
       Tuple3(LongInput, ArbitraryValueInput[String](), ArbitraryValueInput[String]()),
       UnitOutput
     )
-    runCommand(command, (slot.number, Node.asString, nodeId))
+    command.run((slot.number, Node.asString, nodeId))
   }
 
   /**
@@ -107,7 +107,7 @@ trait Cluster[G[+_]] extends RedisEnvironment[G] {
   final def setSlotStable(slot: Slot): G[Unit] = {
     val command =
       RedisCommand(ClusterSetSlots, Tuple2(LongInput, ArbitraryValueInput[String]()), UnitOutput)
-    runCommand(command, (slot.number, Stable.asString))
+    command.run((slot.number, Stable.asString))
   }
 
   /**
@@ -118,7 +118,7 @@ trait Cluster[G[+_]] extends RedisEnvironment[G] {
    */
   final def slots: G[Chunk[Partition]] = {
     val command = RedisCommand(ClusterSlots, NoInput, ChunkOutput(ClusterPartitionOutput))
-    runCommand(command, ())
+    command.run(())
   }
 }
 

--- a/modules/redis/src/main/scala/zio/redis/api/Connection.scala
+++ b/modules/redis/src/main/scala/zio/redis/api/Connection.scala
@@ -16,13 +16,12 @@
 
 package zio.redis.api
 
-import zio._
 import zio.redis.Input._
 import zio.redis.Output._
 import zio.redis._
 import zio.redis.internal.{RedisCommand, RedisEnvironment}
 
-trait Connection extends RedisEnvironment {
+trait Connection[G[+_]] extends RedisEnvironment[G] {
   import Connection.{Auth => _, _}
 
   /**
@@ -37,7 +36,7 @@ trait Connection extends RedisEnvironment {
    *   if the password provided via AUTH matches the password in the configuration file, the Unit value is returned and
    *   the server starts accepting commands. Otherwise, an error is returned and the client needs to try a new password.
    */
-  final def auth(password: String): IO[RedisError, Unit] = {
+  final def auth(password: String): G[Unit] = {
     val command = RedisCommand(Connection.Auth, AuthInput, UnitOutput, executor)
 
     command.run(Auth(None, password))
@@ -54,7 +53,7 @@ trait Connection extends RedisEnvironment {
    *   if the password provided via AUTH matches the password in the configuration file, the Unit value is returned and
    *   the server starts accepting commands. Otherwise, an error is returned and the client needs to try a new password.
    */
-  final def auth(username: String, password: String): IO[RedisError, Unit] = {
+  final def auth(username: String, password: String): G[Unit] = {
     val command = RedisCommand(Connection.Auth, AuthInput, UnitOutput, executor)
 
     command.run(Auth(Some(username), password))
@@ -66,7 +65,7 @@ trait Connection extends RedisEnvironment {
    * @return
    *   the connection name, or None if a name wasn't set.
    */
-  final def clientGetName: IO[RedisError, Option[String]] = {
+  final def clientGetName: G[Option[String]] = {
     val command = RedisCommand(ClientGetName, NoInput, OptionalOutput(MultiStringOutput), executor)
 
     command.run(())
@@ -82,7 +81,7 @@ trait Connection extends RedisEnvironment {
    * @return
    *   the ID of the current connection.
    */
-  final def clientId: IO[RedisError, Long] = {
+  final def clientId: G[Long] = {
     val command = RedisCommand(ClientId, NoInput, LongOutput, executor)
 
     command.run(())
@@ -96,7 +95,7 @@ trait Connection extends RedisEnvironment {
    * @return
    *   the Unit value.
    */
-  final def clientSetName(name: String): IO[RedisError, Unit] = {
+  final def clientSetName(name: String): G[Unit] = {
     val command = RedisCommand(ClientSetName, StringInput, UnitOutput, executor)
 
     command.run(name)
@@ -112,7 +111,7 @@ trait Connection extends RedisEnvironment {
    * @return
    *   the Unit value.
    */
-  final def select(index: Long): IO[RedisError, Unit] = {
+  final def select(index: Long): G[Unit] = {
     val command = RedisCommand(Select, LongInput, UnitOutput, executor)
 
     command.run(index)

--- a/modules/redis/src/main/scala/zio/redis/api/Connection.scala
+++ b/modules/redis/src/main/scala/zio/redis/api/Connection.scala
@@ -37,9 +37,9 @@ trait Connection[G[+_]] extends RedisEnvironment[G] {
    *   the server starts accepting commands. Otherwise, an error is returned and the client needs to try a new password.
    */
   final def auth(password: String): G[Unit] = {
-    val command = RedisCommand(Connection.Auth, AuthInput, UnitOutput, executor)
+    val command = RedisCommand(Connection.Auth, AuthInput, UnitOutput)
 
-    command.run(Auth(None, password))
+    runCommand(command, Auth(None, password))
   }
 
   /**
@@ -54,9 +54,9 @@ trait Connection[G[+_]] extends RedisEnvironment[G] {
    *   the server starts accepting commands. Otherwise, an error is returned and the client needs to try a new password.
    */
   final def auth(username: String, password: String): G[Unit] = {
-    val command = RedisCommand(Connection.Auth, AuthInput, UnitOutput, executor)
+    val command = RedisCommand(Connection.Auth, AuthInput, UnitOutput)
 
-    command.run(Auth(Some(username), password))
+    runCommand(command, Auth(Some(username), password))
   }
 
   /**
@@ -66,9 +66,9 @@ trait Connection[G[+_]] extends RedisEnvironment[G] {
    *   the connection name, or None if a name wasn't set.
    */
   final def clientGetName: G[Option[String]] = {
-    val command = RedisCommand(ClientGetName, NoInput, OptionalOutput(MultiStringOutput), executor)
+    val command = RedisCommand(ClientGetName, NoInput, OptionalOutput(MultiStringOutput))
 
-    command.run(())
+    runCommand(command, ())
   }
 
   /**
@@ -82,9 +82,9 @@ trait Connection[G[+_]] extends RedisEnvironment[G] {
    *   the ID of the current connection.
    */
   final def clientId: G[Long] = {
-    val command = RedisCommand(ClientId, NoInput, LongOutput, executor)
+    val command = RedisCommand(ClientId, NoInput, LongOutput)
 
-    command.run(())
+    runCommand(command, ())
   }
 
   /**
@@ -96,9 +96,9 @@ trait Connection[G[+_]] extends RedisEnvironment[G] {
    *   the Unit value.
    */
   final def clientSetName(name: String): G[Unit] = {
-    val command = RedisCommand(ClientSetName, StringInput, UnitOutput, executor)
+    val command = RedisCommand(ClientSetName, StringInput, UnitOutput)
 
-    command.run(name)
+    runCommand(command, name)
   }
 
   /**
@@ -112,9 +112,9 @@ trait Connection[G[+_]] extends RedisEnvironment[G] {
    *   the Unit value.
    */
   final def select(index: Long): G[Unit] = {
-    val command = RedisCommand(Select, LongInput, UnitOutput, executor)
+    val command = RedisCommand(Select, LongInput, UnitOutput)
 
-    command.run(index)
+    runCommand(command, index)
   }
 }
 

--- a/modules/redis/src/main/scala/zio/redis/api/Connection.scala
+++ b/modules/redis/src/main/scala/zio/redis/api/Connection.scala
@@ -39,7 +39,7 @@ trait Connection[G[+_]] extends RedisEnvironment[G] {
   final def auth(password: String): G[Unit] = {
     val command = RedisCommand(Connection.Auth, AuthInput, UnitOutput)
 
-    runCommand(command, Auth(None, password))
+    command.run(Auth(None, password))
   }
 
   /**
@@ -56,7 +56,7 @@ trait Connection[G[+_]] extends RedisEnvironment[G] {
   final def auth(username: String, password: String): G[Unit] = {
     val command = RedisCommand(Connection.Auth, AuthInput, UnitOutput)
 
-    runCommand(command, Auth(Some(username), password))
+    command.run(Auth(Some(username), password))
   }
 
   /**
@@ -68,7 +68,7 @@ trait Connection[G[+_]] extends RedisEnvironment[G] {
   final def clientGetName: G[Option[String]] = {
     val command = RedisCommand(ClientGetName, NoInput, OptionalOutput(MultiStringOutput))
 
-    runCommand(command, ())
+    command.run(())
   }
 
   /**
@@ -84,7 +84,7 @@ trait Connection[G[+_]] extends RedisEnvironment[G] {
   final def clientId: G[Long] = {
     val command = RedisCommand(ClientId, NoInput, LongOutput)
 
-    runCommand(command, ())
+    command.run(())
   }
 
   /**
@@ -98,7 +98,7 @@ trait Connection[G[+_]] extends RedisEnvironment[G] {
   final def clientSetName(name: String): G[Unit] = {
     val command = RedisCommand(ClientSetName, StringInput, UnitOutput)
 
-    runCommand(command, name)
+    command.run(name)
   }
 
   /**
@@ -114,7 +114,7 @@ trait Connection[G[+_]] extends RedisEnvironment[G] {
   final def select(index: Long): G[Unit] = {
     val command = RedisCommand(Select, LongInput, UnitOutput)
 
-    runCommand(command, index)
+    command.run(index)
   }
 }
 

--- a/modules/redis/src/main/scala/zio/redis/api/Geo.scala
+++ b/modules/redis/src/main/scala/zio/redis/api/Geo.scala
@@ -48,7 +48,7 @@ trait Geo[G[+_]] extends RedisEnvironment[G] {
       Tuple2(ArbitraryKeyInput[K](), NonEmptyList(Tuple2(LongLatInput, ArbitraryValueInput[M]()))),
       LongOutput
     )
-    runCommand(command, (key, (item, items.toList)))
+    command.run((key, (item, items.toList)))
   }
 
   /**
@@ -81,7 +81,7 @@ trait Geo[G[+_]] extends RedisEnvironment[G] {
       ),
       OptionalOutput(DoubleOutput)
     )
-    runCommand(command, (key, member1, member2, radiusUnit))
+    command.run((key, member1, member2, radiusUnit))
   }
 
   /**
@@ -107,7 +107,7 @@ trait Geo[G[+_]] extends RedisEnvironment[G] {
       Tuple2(ArbitraryKeyInput[K](), NonEmptyList(ArbitraryValueInput[M]())),
       ChunkOutput(OptionalOutput(MultiStringOutput))
     )
-    runCommand(command, (key, (member, members.toList)))
+    command.run((key, (member, members.toList)))
   }
 
   /**
@@ -130,7 +130,7 @@ trait Geo[G[+_]] extends RedisEnvironment[G] {
   ): G[Chunk[Option[LongLat]]] = {
     val command =
       RedisCommand(GeoPos, Tuple2(ArbitraryKeyInput[K](), NonEmptyList(ArbitraryValueInput[M]())), GeoOutput)
-    runCommand(command, (key, (member, members.toList)))
+    command.run((key, (member, members.toList)))
   }
 
   /**
@@ -184,7 +184,7 @@ trait Geo[G[+_]] extends RedisEnvironment[G] {
       ),
       GeoRadiusOutput
     )
-    runCommand(command, (key, center, radius, radiusUnit, withCoord, withDist, withHash, count, order))
+    command.run((key, center, radius, radiusUnit, withCoord, withDist, withHash, count, order))
   }
 
   /**
@@ -247,8 +247,7 @@ trait Geo[G[+_]] extends RedisEnvironment[G] {
       ),
       LongOutput
     )
-    runCommand(
-      command,
+    command.run(
       (key, center, radius, radiusUnit, withCoord, withDist, withHash, count, order, store.store, store.storeDist)
     )
   }
@@ -304,7 +303,7 @@ trait Geo[G[+_]] extends RedisEnvironment[G] {
       ),
       GeoRadiusOutput
     )
-    runCommand(command, (key, member, radius, radiusUnit, withCoord, withDist, withHash, count, order))
+    command.run((key, member, radius, radiusUnit, withCoord, withDist, withHash, count, order))
   }
 
   /**
@@ -367,8 +366,7 @@ trait Geo[G[+_]] extends RedisEnvironment[G] {
       ),
       LongOutput
     )
-    runCommand(
-      command,
+    command.run(
       (key, member, radius, radiusUnit, withCoord, withDist, withHash, count, order, store.store, store.storeDist)
     )
   }

--- a/modules/redis/src/main/scala/zio/redis/api/Geo.scala
+++ b/modules/redis/src/main/scala/zio/redis/api/Geo.scala
@@ -23,7 +23,7 @@ import zio.redis._
 import zio.redis.internal.{RedisCommand, RedisEnvironment}
 import zio.schema.Schema
 
-trait Geo extends RedisEnvironment {
+trait Geo[G[+_]] extends RedisEnvironment[G] {
   import Geo._
 
   /**
@@ -42,7 +42,7 @@ trait Geo extends RedisEnvironment {
     key: K,
     item: (LongLat, M),
     items: (LongLat, M)*
-  ): IO[RedisError, Long] = {
+  ): G[Long] = {
     val command = RedisCommand(
       GeoAdd,
       Tuple2(ArbitraryKeyInput[K](), NonEmptyList(Tuple2(LongLatInput, ArbitraryValueInput[M]()))),
@@ -71,7 +71,7 @@ trait Geo extends RedisEnvironment {
     member1: M,
     member2: M,
     radiusUnit: Option[RadiusUnit] = None
-  ): IO[RedisError, Option[Double]] = {
+  ): G[Option[Double]] = {
     val command = RedisCommand(
       GeoDist,
       Tuple4(
@@ -103,7 +103,7 @@ trait Geo extends RedisEnvironment {
     key: K,
     member: M,
     members: M*
-  ): IO[RedisError, Chunk[Option[String]]] = {
+  ): G[Chunk[Option[String]]] = {
     val command = RedisCommand(
       GeoHash,
       Tuple2(ArbitraryKeyInput[K](), NonEmptyList(ArbitraryValueInput[M]())),
@@ -130,7 +130,7 @@ trait Geo extends RedisEnvironment {
     key: K,
     member: M,
     members: M*
-  ): IO[RedisError, Chunk[Option[LongLat]]] = {
+  ): G[Chunk[Option[LongLat]]] = {
     val command =
       RedisCommand(GeoPos, Tuple2(ArbitraryKeyInput[K](), NonEmptyList(ArbitraryValueInput[M]())), GeoOutput, executor)
     command.run((key, (member, members.toList)))
@@ -171,7 +171,7 @@ trait Geo extends RedisEnvironment {
     withHash: Option[WithHash] = None,
     count: Option[Count] = None,
     order: Option[Order] = None
-  ): IO[RedisError, Chunk[GeoView]] = {
+  ): G[Chunk[GeoView]] = {
     val command = RedisCommand(
       GeoRadius,
       Tuple9(
@@ -233,7 +233,7 @@ trait Geo extends RedisEnvironment {
     withHash: Option[WithHash] = None,
     count: Option[Count] = None,
     order: Option[Order] = None
-  ): IO[RedisError, Long] = {
+  ): G[Long] = {
     val command = RedisCommand(
       GeoRadius,
       Tuple11(
@@ -292,7 +292,7 @@ trait Geo extends RedisEnvironment {
     withHash: Option[WithHash] = None,
     count: Option[Count] = None,
     order: Option[Order] = None
-  ): IO[RedisError, Chunk[GeoView]] = {
+  ): G[Chunk[GeoView]] = {
     val command = RedisCommand(
       GeoRadiusByMember,
       Tuple9(
@@ -354,7 +354,7 @@ trait Geo extends RedisEnvironment {
     withHash: Option[WithHash] = None,
     count: Option[Count] = None,
     order: Option[Order] = None
-  ): IO[RedisError, Long] = {
+  ): G[Long] = {
     val command = RedisCommand(
       GeoRadiusByMember,
       Tuple11(

--- a/modules/redis/src/main/scala/zio/redis/api/Geo.scala
+++ b/modules/redis/src/main/scala/zio/redis/api/Geo.scala
@@ -46,10 +46,9 @@ trait Geo[G[+_]] extends RedisEnvironment[G] {
     val command = RedisCommand(
       GeoAdd,
       Tuple2(ArbitraryKeyInput[K](), NonEmptyList(Tuple2(LongLatInput, ArbitraryValueInput[M]()))),
-      LongOutput,
-      executor
+      LongOutput
     )
-    command.run((key, (item, items.toList)))
+    runCommand(command, (key, (item, items.toList)))
   }
 
   /**
@@ -80,10 +79,9 @@ trait Geo[G[+_]] extends RedisEnvironment[G] {
         ArbitraryValueInput[M](),
         OptionalInput(RadiusUnitInput)
       ),
-      OptionalOutput(DoubleOutput),
-      executor
+      OptionalOutput(DoubleOutput)
     )
-    command.run((key, member1, member2, radiusUnit))
+    runCommand(command, (key, member1, member2, radiusUnit))
   }
 
   /**
@@ -107,10 +105,9 @@ trait Geo[G[+_]] extends RedisEnvironment[G] {
     val command = RedisCommand(
       GeoHash,
       Tuple2(ArbitraryKeyInput[K](), NonEmptyList(ArbitraryValueInput[M]())),
-      ChunkOutput(OptionalOutput(MultiStringOutput)),
-      executor
+      ChunkOutput(OptionalOutput(MultiStringOutput))
     )
-    command.run((key, (member, members.toList)))
+    runCommand(command, (key, (member, members.toList)))
   }
 
   /**
@@ -132,8 +129,8 @@ trait Geo[G[+_]] extends RedisEnvironment[G] {
     members: M*
   ): G[Chunk[Option[LongLat]]] = {
     val command =
-      RedisCommand(GeoPos, Tuple2(ArbitraryKeyInput[K](), NonEmptyList(ArbitraryValueInput[M]())), GeoOutput, executor)
-    command.run((key, (member, members.toList)))
+      RedisCommand(GeoPos, Tuple2(ArbitraryKeyInput[K](), NonEmptyList(ArbitraryValueInput[M]())), GeoOutput)
+    runCommand(command, (key, (member, members.toList)))
   }
 
   /**
@@ -185,10 +182,9 @@ trait Geo[G[+_]] extends RedisEnvironment[G] {
         OptionalInput(CountInput),
         OptionalInput(OrderInput)
       ),
-      GeoRadiusOutput,
-      executor
+      GeoRadiusOutput
     )
-    command.run((key, center, radius, radiusUnit, withCoord, withDist, withHash, count, order))
+    runCommand(command, (key, center, radius, radiusUnit, withCoord, withDist, withHash, count, order))
   }
 
   /**
@@ -249,10 +245,10 @@ trait Geo[G[+_]] extends RedisEnvironment[G] {
         OptionalInput(StoreInput),
         OptionalInput(StoreDistInput)
       ),
-      LongOutput,
-      executor
+      LongOutput
     )
-    command.run(
+    runCommand(
+      command,
       (key, center, radius, radiusUnit, withCoord, withDist, withHash, count, order, store.store, store.storeDist)
     )
   }
@@ -306,10 +302,9 @@ trait Geo[G[+_]] extends RedisEnvironment[G] {
         OptionalInput(CountInput),
         OptionalInput(OrderInput)
       ),
-      GeoRadiusOutput,
-      executor
+      GeoRadiusOutput
     )
-    command.run((key, member, radius, radiusUnit, withCoord, withDist, withHash, count, order))
+    runCommand(command, (key, member, radius, radiusUnit, withCoord, withDist, withHash, count, order))
   }
 
   /**
@@ -370,10 +365,10 @@ trait Geo[G[+_]] extends RedisEnvironment[G] {
         OptionalInput(StoreInput),
         OptionalInput(StoreDistInput)
       ),
-      LongOutput,
-      executor
+      LongOutput
     )
-    command.run(
+    runCommand(
+      command,
       (key, member, radius, radiusUnit, withCoord, withDist, withHash, count, order, store.store, store.storeDist)
     )
   }

--- a/modules/redis/src/main/scala/zio/redis/api/Hashes.scala
+++ b/modules/redis/src/main/scala/zio/redis/api/Hashes.scala
@@ -42,7 +42,7 @@ trait Hashes[G[+_]] extends RedisEnvironment[G] {
   final def hDel[K: Schema, F: Schema](key: K, field: F, fields: F*): G[Long] = {
     val command =
       RedisCommand(HDel, Tuple2(ArbitraryKeyInput[K](), NonEmptyList(ArbitraryValueInput[F]())), LongOutput)
-    runCommand(command, (key, (field, fields.toList)))
+    command.run((key, (field, fields.toList)))
   }
 
   /**
@@ -58,7 +58,7 @@ trait Hashes[G[+_]] extends RedisEnvironment[G] {
   final def hExists[K: Schema, F: Schema](key: K, field: F): G[Boolean] = {
     val command =
       RedisCommand(HExists, Tuple2(ArbitraryKeyInput[K](), ArbitraryValueInput[F]()), BoolOutput)
-    runCommand(command, (key, field))
+    command.run((key, field))
   }
 
   /**
@@ -74,14 +74,11 @@ trait Hashes[G[+_]] extends RedisEnvironment[G] {
   final def hGet[K: Schema, F: Schema](key: K, field: F): ResultBuilder1[Option, G] =
     new ResultBuilder1[Option, G] {
       def returning[V: Schema]: G[Option[V]] =
-        runCommand(
-          RedisCommand(
-            HGet,
-            Tuple2(ArbitraryKeyInput[K](), ArbitraryValueInput[F]()),
-            OptionalOutput(ArbitraryOutput[V]())
-          ),
-          (key, field)
-        )
+        RedisCommand(
+          HGet,
+          Tuple2(ArbitraryKeyInput[K](), ArbitraryValueInput[F]()),
+          OptionalOutput(ArbitraryOutput[V]())
+        ).run((key, field))
     }
 
   /**
@@ -100,7 +97,7 @@ trait Hashes[G[+_]] extends RedisEnvironment[G] {
           ArbitraryKeyInput[K](),
           KeyValueOutput(ArbitraryOutput[F](), ArbitraryOutput[V]())
         )
-      runCommand(command, key)
+      command.run(key)
     }
   }
 
@@ -120,7 +117,7 @@ trait Hashes[G[+_]] extends RedisEnvironment[G] {
   final def hIncrBy[K: Schema, F: Schema](key: K, field: F, increment: Long): G[Long] = {
     val command =
       RedisCommand(HIncrBy, Tuple3(ArbitraryKeyInput[K](), ArbitraryValueInput[F](), LongInput), LongOutput)
-    runCommand(command, (key, field, increment))
+    command.run((key, field, increment))
   }
 
   /**
@@ -147,7 +144,7 @@ trait Hashes[G[+_]] extends RedisEnvironment[G] {
         Tuple3(ArbitraryKeyInput[K](), ArbitraryValueInput[F](), DoubleInput),
         DoubleOutput
       )
-    runCommand(command, (key, field, increment))
+    command.run((key, field, increment))
   }
 
   /**
@@ -161,7 +158,7 @@ trait Hashes[G[+_]] extends RedisEnvironment[G] {
   final def hKeys[K: Schema](key: K): ResultBuilder1[Chunk, G] =
     new ResultBuilder1[Chunk, G] {
       def returning[F: Schema]: G[Chunk[F]] =
-        runCommand(RedisCommand(HKeys, ArbitraryKeyInput[K](), ChunkOutput(ArbitraryOutput[F]())), key)
+        RedisCommand(HKeys, ArbitraryKeyInput[K](), ChunkOutput(ArbitraryOutput[F]())).run(key)
     }
 
   /**
@@ -174,7 +171,7 @@ trait Hashes[G[+_]] extends RedisEnvironment[G] {
    */
   final def hLen[K: Schema](key: K): G[Long] = {
     val command = RedisCommand(HLen, ArbitraryKeyInput[K](), LongOutput)
-    runCommand(command, key)
+    command.run(key)
   }
 
   /**
@@ -201,7 +198,7 @@ trait Hashes[G[+_]] extends RedisEnvironment[G] {
           Tuple2(ArbitraryKeyInput[K](), NonEmptyList(ArbitraryValueInput[F]())),
           ChunkOutput(OptionalOutput(ArbitraryOutput[V]()))
         )
-        runCommand(command, (key, (field, fields.toList)))
+        command.run((key, (field, fields.toList)))
       }
     }
 
@@ -216,7 +213,7 @@ trait Hashes[G[+_]] extends RedisEnvironment[G] {
   final def hRandField[K: Schema](key: K): ResultBuilder1[Option, G] =
     new ResultBuilder1[Option, G] {
       def returning[V: Schema]: G[Option[V]] =
-        runCommand(RedisCommand(HRandField, ArbitraryKeyInput[K](), OptionalOutput(ArbitraryOutput[V]())), key)
+        RedisCommand(HRandField, ArbitraryKeyInput[K](), OptionalOutput(ArbitraryOutput[V]())).run(key)
     }
 
   /**
@@ -241,7 +238,7 @@ trait Hashes[G[+_]] extends RedisEnvironment[G] {
           Tuple3(ArbitraryKeyInput[K](), LongInput, OptionalInput(StringInput)),
           ChunkOutput(ArbitraryOutput[V]())
         )
-        runCommand(command, (key, count, if (withValues) Some("WITHVALUES") else None))
+        command.run((key, count, if (withValues) Some("WITHVALUES") else None))
       }
     }
 
@@ -268,7 +265,7 @@ trait Hashes[G[+_]] extends RedisEnvironment[G] {
       Tuple2(ArbitraryKeyInput[K](), NonEmptyList(Tuple2(ArbitraryValueInput[F](), ArbitraryValueInput[V]()))),
       UnitOutput
     )
-    runCommand(command, (key, (pair, pairs.toList)))
+    command.run((key, (pair, pairs.toList)))
   }
 
   /**
@@ -298,7 +295,7 @@ trait Hashes[G[+_]] extends RedisEnvironment[G] {
           Tuple4(ArbitraryKeyInput[K](), LongInput, OptionalInput(PatternInput), OptionalInput(CountInput)),
           Tuple2Output(ArbitraryOutput[Long](), ChunkTuple2Output(ArbitraryOutput[F](), ArbitraryOutput[V]()))
         )
-        runCommand(command, (key, cursor, pattern.map(Pattern(_)), count))
+        command.run((key, cursor, pattern.map(Pattern(_)), count))
       }
     }
 
@@ -324,7 +321,7 @@ trait Hashes[G[+_]] extends RedisEnvironment[G] {
       Tuple2(ArbitraryKeyInput[K](), NonEmptyList(Tuple2(ArbitraryValueInput[F](), ArbitraryValueInput[V]()))),
       LongOutput
     )
-    runCommand(command, (key, (pair, pairs.toList)))
+    command.run((key, (pair, pairs.toList)))
   }
 
   /**
@@ -350,7 +347,7 @@ trait Hashes[G[+_]] extends RedisEnvironment[G] {
         Tuple3(ArbitraryKeyInput[K](), ArbitraryValueInput[F](), ArbitraryValueInput[V]()),
         BoolOutput
       )
-    runCommand(command, (key, field, value))
+    command.run((key, field, value))
   }
 
   /**
@@ -366,7 +363,7 @@ trait Hashes[G[+_]] extends RedisEnvironment[G] {
   final def hStrLen[K: Schema, F: Schema](key: K, field: F): G[Long] = {
     val command =
       RedisCommand(HStrLen, Tuple2(ArbitraryKeyInput[K](), ArbitraryValueInput[F]()), LongOutput)
-    runCommand(command, (key, field))
+    command.run((key, field))
   }
 
   /**
@@ -380,7 +377,7 @@ trait Hashes[G[+_]] extends RedisEnvironment[G] {
   final def hVals[K: Schema](key: K): ResultBuilder1[Chunk, G] =
     new ResultBuilder1[Chunk, G] {
       def returning[V: Schema]: G[Chunk[V]] =
-        runCommand(RedisCommand(HVals, ArbitraryKeyInput[K](), ChunkOutput(ArbitraryOutput[V]())), key)
+        RedisCommand(HVals, ArbitraryKeyInput[K](), ChunkOutput(ArbitraryOutput[V]())).run(key)
     }
 }
 

--- a/modules/redis/src/main/scala/zio/redis/api/HyperLogLog.scala
+++ b/modules/redis/src/main/scala/zio/redis/api/HyperLogLog.scala
@@ -40,7 +40,7 @@ trait HyperLogLog[G[+_]] extends RedisEnvironment[G] {
   final def pfAdd[K: Schema, V: Schema](key: K, element: V, elements: V*): G[Boolean] = {
     val command =
       RedisCommand(PfAdd, Tuple2(ArbitraryKeyInput[K](), NonEmptyList(ArbitraryValueInput[V]())), BoolOutput)
-    runCommand(command, (key, (element, elements.toList)))
+    command.run((key, (element, elements.toList)))
   }
 
   /**
@@ -55,7 +55,7 @@ trait HyperLogLog[G[+_]] extends RedisEnvironment[G] {
    */
   final def pfCount[K: Schema](key: K, keys: K*): G[Long] = {
     val command = RedisCommand(PfCount, NonEmptyList(ArbitraryKeyInput[K]()), LongOutput)
-    runCommand(command, (key, keys.toList))
+    command.run((key, keys.toList))
   }
 
   /**
@@ -71,7 +71,7 @@ trait HyperLogLog[G[+_]] extends RedisEnvironment[G] {
   final def pfMerge[K: Schema](destKey: K, sourceKey: K, sourceKeys: K*): G[Unit] = {
     val command =
       RedisCommand(PfMerge, Tuple2(ArbitraryKeyInput[K](), NonEmptyList(ArbitraryKeyInput[K]())), UnitOutput)
-    runCommand(command, (destKey, (sourceKey, sourceKeys.toList)))
+    command.run((destKey, (sourceKey, sourceKeys.toList)))
   }
 }
 

--- a/modules/redis/src/main/scala/zio/redis/api/HyperLogLog.scala
+++ b/modules/redis/src/main/scala/zio/redis/api/HyperLogLog.scala
@@ -39,8 +39,8 @@ trait HyperLogLog[G[+_]] extends RedisEnvironment[G] {
    */
   final def pfAdd[K: Schema, V: Schema](key: K, element: V, elements: V*): G[Boolean] = {
     val command =
-      RedisCommand(PfAdd, Tuple2(ArbitraryKeyInput[K](), NonEmptyList(ArbitraryValueInput[V]())), BoolOutput, executor)
-    command.run((key, (element, elements.toList)))
+      RedisCommand(PfAdd, Tuple2(ArbitraryKeyInput[K](), NonEmptyList(ArbitraryValueInput[V]())), BoolOutput)
+    runCommand(command, (key, (element, elements.toList)))
   }
 
   /**
@@ -54,8 +54,8 @@ trait HyperLogLog[G[+_]] extends RedisEnvironment[G] {
    *   approximate number of unique elements observed via PFADD.
    */
   final def pfCount[K: Schema](key: K, keys: K*): G[Long] = {
-    val command = RedisCommand(PfCount, NonEmptyList(ArbitraryKeyInput[K]()), LongOutput, executor)
-    command.run((key, keys.toList))
+    val command = RedisCommand(PfCount, NonEmptyList(ArbitraryKeyInput[K]()), LongOutput)
+    runCommand(command, (key, keys.toList))
   }
 
   /**
@@ -70,8 +70,8 @@ trait HyperLogLog[G[+_]] extends RedisEnvironment[G] {
    */
   final def pfMerge[K: Schema](destKey: K, sourceKey: K, sourceKeys: K*): G[Unit] = {
     val command =
-      RedisCommand(PfMerge, Tuple2(ArbitraryKeyInput[K](), NonEmptyList(ArbitraryKeyInput[K]())), UnitOutput, executor)
-    command.run((destKey, (sourceKey, sourceKeys.toList)))
+      RedisCommand(PfMerge, Tuple2(ArbitraryKeyInput[K](), NonEmptyList(ArbitraryKeyInput[K]())), UnitOutput)
+    runCommand(command, (destKey, (sourceKey, sourceKeys.toList)))
   }
 }
 

--- a/modules/redis/src/main/scala/zio/redis/api/HyperLogLog.scala
+++ b/modules/redis/src/main/scala/zio/redis/api/HyperLogLog.scala
@@ -16,13 +16,12 @@
 
 package zio.redis.api
 
-import zio.IO
 import zio.redis.Output._
 import zio.redis._
 import zio.redis.internal.{RedisCommand, RedisEnvironment}
 import zio.schema.Schema
 
-trait HyperLogLog extends RedisEnvironment {
+trait HyperLogLog[G[+_]] extends RedisEnvironment[G] {
   import HyperLogLog._
   import Input._
 
@@ -38,7 +37,7 @@ trait HyperLogLog extends RedisEnvironment {
    * @return
    *   boolean indicating if at least 1 HyperLogLog register was altered.
    */
-  final def pfAdd[K: Schema, V: Schema](key: K, element: V, elements: V*): IO[RedisError, Boolean] = {
+  final def pfAdd[K: Schema, V: Schema](key: K, element: V, elements: V*): G[Boolean] = {
     val command =
       RedisCommand(PfAdd, Tuple2(ArbitraryKeyInput[K](), NonEmptyList(ArbitraryValueInput[V]())), BoolOutput, executor)
     command.run((key, (element, elements.toList)))
@@ -54,7 +53,7 @@ trait HyperLogLog extends RedisEnvironment {
    * @return
    *   approximate number of unique elements observed via PFADD.
    */
-  final def pfCount[K: Schema](key: K, keys: K*): IO[RedisError, Long] = {
+  final def pfCount[K: Schema](key: K, keys: K*): G[Long] = {
     val command = RedisCommand(PfCount, NonEmptyList(ArbitraryKeyInput[K]()), LongOutput, executor)
     command.run((key, keys.toList))
   }
@@ -69,7 +68,7 @@ trait HyperLogLog extends RedisEnvironment {
    * @param sourceKeys
    *   additional keys to merge
    */
-  final def pfMerge[K: Schema](destKey: K, sourceKey: K, sourceKeys: K*): IO[RedisError, Unit] = {
+  final def pfMerge[K: Schema](destKey: K, sourceKey: K, sourceKeys: K*): G[Unit] = {
     val command =
       RedisCommand(PfMerge, Tuple2(ArbitraryKeyInput[K](), NonEmptyList(ArbitraryKeyInput[K]())), UnitOutput, executor)
     command.run((destKey, (sourceKey, sourceKeys.toList)))

--- a/modules/redis/src/main/scala/zio/redis/api/Keys.scala
+++ b/modules/redis/src/main/scala/zio/redis/api/Keys.scala
@@ -55,7 +55,7 @@ trait Keys[G[+_]] extends RedisEnvironment[G] {
       Tuple4(ArbitraryKeyInput[S](), ArbitraryKeyInput[D](), OptionalInput(DbInput), OptionalInput(ReplaceInput)),
       BoolOutput
     )
-    runCommand(command, (source, destination, database, replace))
+    command.run((source, destination, database, replace))
   }
 
   /**
@@ -73,7 +73,7 @@ trait Keys[G[+_]] extends RedisEnvironment[G] {
    */
   final def del[K: Schema](key: K, keys: K*): G[Long] = {
     val command = RedisCommand(Del, NonEmptyList(ArbitraryKeyInput[K]()), LongOutput)
-    runCommand(command, (key, keys.toList))
+    command.run((key, keys.toList))
   }
 
   /**
@@ -86,7 +86,7 @@ trait Keys[G[+_]] extends RedisEnvironment[G] {
    */
   final def dump[K: Schema](key: K): G[Chunk[Byte]] = {
     val command = RedisCommand(Dump, ArbitraryKeyInput[K](), BulkStringOutput)
-    runCommand(command, key)
+    command.run(key)
   }
 
   /**
@@ -102,7 +102,7 @@ trait Keys[G[+_]] extends RedisEnvironment[G] {
    */
   final def exists[K: Schema](key: K, keys: K*): G[Long] = {
     val command = RedisCommand(Exists, NonEmptyList(ArbitraryKeyInput[K]()), LongOutput)
-    runCommand(command, (key, keys.toList))
+    command.run((key, keys.toList))
   }
 
   /**
@@ -121,7 +121,7 @@ trait Keys[G[+_]] extends RedisEnvironment[G] {
   final def expire[K: Schema](key: K, timeout: Duration): G[Boolean] = {
     val command =
       RedisCommand(Expire, Tuple2(ArbitraryKeyInput[K](), DurationSecondsInput), BoolOutput)
-    runCommand(command, (key, timeout))
+    command.run((key, timeout))
   }
 
   /**
@@ -139,7 +139,7 @@ trait Keys[G[+_]] extends RedisEnvironment[G] {
    */
   final def expireAt[K: Schema](key: K, timestamp: Instant): G[Boolean] = {
     val command = RedisCommand(ExpireAt, Tuple2(ArbitraryKeyInput[K](), TimeSecondsInput), BoolOutput)
-    runCommand(command, (key, timestamp))
+    command.run((key, timestamp))
   }
 
   /**
@@ -153,7 +153,7 @@ trait Keys[G[+_]] extends RedisEnvironment[G] {
   final def keys(pattern: String): ResultBuilder1[Chunk, G] =
     new ResultBuilder1[Chunk, G] {
       def returning[V: Schema]: G[Chunk[V]] =
-        runCommand(RedisCommand(Keys.Keys, StringInput, ChunkOutput(ArbitraryOutput[V]())), pattern)
+        RedisCommand(Keys.Keys, StringInput, ChunkOutput(ArbitraryOutput[V]())).run(pattern)
     }
 
   /**
@@ -207,7 +207,7 @@ trait Keys[G[+_]] extends RedisEnvironment[G] {
       ),
       StringOutput
     )
-    runCommand(command, (host, port, key, destinationDb, timeout.toMillis, copy, replace, auth, keys))
+    command.run((host, port, key, destinationDb, timeout.toMillis, copy, replace, auth, keys))
   }
 
   /**
@@ -223,7 +223,7 @@ trait Keys[G[+_]] extends RedisEnvironment[G] {
    */
   final def move[K: Schema](key: K, destinationDb: Long): G[Boolean] = {
     val command = RedisCommand(Move, Tuple2(ArbitraryKeyInput[K](), LongInput), BoolOutput)
-    runCommand(command, (key, destinationDb))
+    command.run((key, destinationDb))
   }
 
   /**
@@ -236,7 +236,7 @@ trait Keys[G[+_]] extends RedisEnvironment[G] {
    */
   final def persist[K: Schema](key: K): G[Boolean] = {
     val command = RedisCommand(Persist, ArbitraryKeyInput[K](), BoolOutput)
-    runCommand(command, key)
+    command.run(key)
   }
 
   /**
@@ -255,7 +255,7 @@ trait Keys[G[+_]] extends RedisEnvironment[G] {
   final def pExpire[K: Schema](key: K, timeout: Duration): G[Boolean] = {
     val command =
       RedisCommand(PExpire, Tuple2(ArbitraryKeyInput[K](), DurationMillisecondsInput), BoolOutput)
-    runCommand(command, (key, timeout))
+    command.run((key, timeout))
   }
 
   /**
@@ -274,7 +274,7 @@ trait Keys[G[+_]] extends RedisEnvironment[G] {
   final def pExpireAt[K: Schema](key: K, timestamp: Instant): G[Boolean] = {
     val command =
       RedisCommand(PExpireAt, Tuple2(ArbitraryKeyInput[K](), TimeMillisecondsInput), BoolOutput)
-    runCommand(command, (key, timestamp))
+    command.run((key, timestamp))
   }
 
   /**
@@ -287,7 +287,7 @@ trait Keys[G[+_]] extends RedisEnvironment[G] {
    */
   final def pTtl[K: Schema](key: K): G[Duration] = {
     val command = RedisCommand(PTtl, ArbitraryKeyInput[K](), DurationMillisecondsOutput)
-    runCommand(command, key)
+    command.run(key)
   }
 
   /**
@@ -299,7 +299,7 @@ trait Keys[G[+_]] extends RedisEnvironment[G] {
   final def randomKey: ResultBuilder1[Option, G] =
     new ResultBuilder1[Option, G] {
       def returning[V: Schema]: G[Option[V]] =
-        runCommand(RedisCommand(RandomKey, NoInput, OptionalOutput(ArbitraryOutput[V]())), ())
+        RedisCommand(RandomKey, NoInput, OptionalOutput(ArbitraryOutput[V]())).run(())
     }
 
   /**
@@ -315,7 +315,7 @@ trait Keys[G[+_]] extends RedisEnvironment[G] {
   final def rename[K: Schema](key: K, newKey: K): G[Unit] = {
     val command =
       RedisCommand(Rename, Tuple2(ArbitraryKeyInput[K](), ArbitraryKeyInput[K]()), UnitOutput)
-    runCommand(command, (key, newKey))
+    command.run((key, newKey))
   }
 
   /**
@@ -331,7 +331,7 @@ trait Keys[G[+_]] extends RedisEnvironment[G] {
   final def renameNx[K: Schema](key: K, newKey: K): G[Boolean] = {
     val command =
       RedisCommand(RenameNx, Tuple2(ArbitraryKeyInput[K](), ArbitraryKeyInput[K]()), BoolOutput)
-    runCommand(command, (key, newKey))
+    command.run((key, newKey))
   }
 
   /**
@@ -378,7 +378,7 @@ trait Keys[G[+_]] extends RedisEnvironment[G] {
       ),
       UnitOutput
     )
-    runCommand(command, (key, ttl, value, replace, absTtl, idleTime, freq))
+    command.run((key, ttl, value, replace, absTtl, idleTime, freq))
   }
 
   /**
@@ -410,7 +410,7 @@ trait Keys[G[+_]] extends RedisEnvironment[G] {
           Tuple4(LongInput, OptionalInput(PatternInput), OptionalInput(CountInput), OptionalInput(RedisTypeInput)),
           Tuple2Output(ArbitraryOutput[Long](), ChunkOutput(ArbitraryOutput[K]()))
         )
-        runCommand(command, (cursor, pattern.map(Pattern(_)), count, `type`))
+        command.run((cursor, pattern.map(Pattern(_)), count, `type`))
       }
     }
 
@@ -454,7 +454,7 @@ trait Keys[G[+_]] extends RedisEnvironment[G] {
           ),
           ChunkOutput(ArbitraryOutput[V]())
         )
-        runCommand(command, (key, by, limit, get, order, alpha))
+        command.run((key, by, limit, get, order, alpha))
       }
     }
 
@@ -504,7 +504,7 @@ trait Keys[G[+_]] extends RedisEnvironment[G] {
       ),
       LongOutput
     )
-    runCommand(command, (key, by, limit, get, order, alpha, storeAt))
+    command.run((key, by, limit, get, order, alpha, storeAt))
   }
 
   /**
@@ -519,7 +519,7 @@ trait Keys[G[+_]] extends RedisEnvironment[G] {
    */
   final def touch[K: Schema](key: K, keys: K*): G[Long] = {
     val command = RedisCommand(Touch, NonEmptyList(ArbitraryKeyInput[K]()), LongOutput)
-    runCommand(command, (key, keys.toList))
+    command.run((key, keys.toList))
   }
 
   /**
@@ -532,7 +532,7 @@ trait Keys[G[+_]] extends RedisEnvironment[G] {
    */
   final def ttl[K: Schema](key: K): G[Duration] = {
     val command = RedisCommand(Ttl, ArbitraryKeyInput[K](), DurationSecondsOutput)
-    runCommand(command, key)
+    command.run(key)
   }
 
   /**
@@ -545,7 +545,7 @@ trait Keys[G[+_]] extends RedisEnvironment[G] {
    */
   final def typeOf[K: Schema](key: K): G[RedisType] = {
     val command = RedisCommand(TypeOf, ArbitraryKeyInput[K](), TypeOutput)
-    runCommand(command, key)
+    command.run(key)
   }
 
   /**
@@ -564,7 +564,7 @@ trait Keys[G[+_]] extends RedisEnvironment[G] {
    */
   final def unlink[K: Schema](key: K, keys: K*): G[Long] = {
     val command = RedisCommand(Unlink, NonEmptyList(ArbitraryKeyInput[K]()), LongOutput)
-    runCommand(command, (key, keys.toList))
+    command.run((key, keys.toList))
   }
 
   /**
@@ -580,7 +580,7 @@ trait Keys[G[+_]] extends RedisEnvironment[G] {
    */
   final def wait_(replicas: Long, timeout: Duration): G[Long] = {
     val command = RedisCommand(Wait, Tuple2(LongInput, LongInput), LongOutput)
-    runCommand(command, (replicas, timeout.toMillis))
+    command.run((replicas, timeout.toMillis))
   }
 }
 

--- a/modules/redis/src/main/scala/zio/redis/api/Keys.scala
+++ b/modules/redis/src/main/scala/zio/redis/api/Keys.scala
@@ -53,10 +53,9 @@ trait Keys[G[+_]] extends RedisEnvironment[G] {
     val command = RedisCommand(
       Copy,
       Tuple4(ArbitraryKeyInput[S](), ArbitraryKeyInput[D](), OptionalInput(DbInput), OptionalInput(ReplaceInput)),
-      BoolOutput,
-      executor
+      BoolOutput
     )
-    command.run((source, destination, database, replace))
+    runCommand(command, (source, destination, database, replace))
   }
 
   /**
@@ -73,8 +72,8 @@ trait Keys[G[+_]] extends RedisEnvironment[G] {
    *   [[unlink]]
    */
   final def del[K: Schema](key: K, keys: K*): G[Long] = {
-    val command = RedisCommand(Del, NonEmptyList(ArbitraryKeyInput[K]()), LongOutput, executor)
-    command.run((key, keys.toList))
+    val command = RedisCommand(Del, NonEmptyList(ArbitraryKeyInput[K]()), LongOutput)
+    runCommand(command, (key, keys.toList))
   }
 
   /**
@@ -86,8 +85,8 @@ trait Keys[G[+_]] extends RedisEnvironment[G] {
    *   bytes for value stored at key.
    */
   final def dump[K: Schema](key: K): G[Chunk[Byte]] = {
-    val command = RedisCommand(Dump, ArbitraryKeyInput[K](), BulkStringOutput, executor)
-    command.run(key)
+    val command = RedisCommand(Dump, ArbitraryKeyInput[K](), BulkStringOutput)
+    runCommand(command, key)
   }
 
   /**
@@ -102,8 +101,8 @@ trait Keys[G[+_]] extends RedisEnvironment[G] {
    *   The number of keys existing.
    */
   final def exists[K: Schema](key: K, keys: K*): G[Long] = {
-    val command = RedisCommand(Exists, NonEmptyList(ArbitraryKeyInput[K]()), LongOutput, executor)
-    command.run((key, keys.toList))
+    val command = RedisCommand(Exists, NonEmptyList(ArbitraryKeyInput[K]()), LongOutput)
+    runCommand(command, (key, keys.toList))
   }
 
   /**
@@ -121,8 +120,8 @@ trait Keys[G[+_]] extends RedisEnvironment[G] {
    */
   final def expire[K: Schema](key: K, timeout: Duration): G[Boolean] = {
     val command =
-      RedisCommand(Expire, Tuple2(ArbitraryKeyInput[K](), DurationSecondsInput), BoolOutput, executor)
-    command.run((key, timeout))
+      RedisCommand(Expire, Tuple2(ArbitraryKeyInput[K](), DurationSecondsInput), BoolOutput)
+    runCommand(command, (key, timeout))
   }
 
   /**
@@ -139,8 +138,8 @@ trait Keys[G[+_]] extends RedisEnvironment[G] {
    *   [[expire]]
    */
   final def expireAt[K: Schema](key: K, timestamp: Instant): G[Boolean] = {
-    val command = RedisCommand(ExpireAt, Tuple2(ArbitraryKeyInput[K](), TimeSecondsInput), BoolOutput, executor)
-    command.run((key, timestamp))
+    val command = RedisCommand(ExpireAt, Tuple2(ArbitraryKeyInput[K](), TimeSecondsInput), BoolOutput)
+    runCommand(command, (key, timestamp))
   }
 
   /**
@@ -154,7 +153,7 @@ trait Keys[G[+_]] extends RedisEnvironment[G] {
   final def keys(pattern: String): ResultBuilder1[Chunk, G] =
     new ResultBuilder1[Chunk, G] {
       def returning[V: Schema]: G[Chunk[V]] =
-        RedisCommand(Keys.Keys, StringInput, ChunkOutput(ArbitraryOutput[V]()), executor).run(pattern)
+        runCommand(RedisCommand(Keys.Keys, StringInput, ChunkOutput(ArbitraryOutput[V]())), pattern)
     }
 
   /**
@@ -206,10 +205,9 @@ trait Keys[G[+_]] extends RedisEnvironment[G] {
         OptionalInput(AuthInput),
         OptionalInput(NonEmptyList(ArbitraryKeyInput[K]()))
       ),
-      StringOutput,
-      executor
+      StringOutput
     )
-    command.run((host, port, key, destinationDb, timeout.toMillis, copy, replace, auth, keys))
+    runCommand(command, (host, port, key, destinationDb, timeout.toMillis, copy, replace, auth, keys))
   }
 
   /**
@@ -224,8 +222,8 @@ trait Keys[G[+_]] extends RedisEnvironment[G] {
    *   true if the key was moved.
    */
   final def move[K: Schema](key: K, destinationDb: Long): G[Boolean] = {
-    val command = RedisCommand(Move, Tuple2(ArbitraryKeyInput[K](), LongInput), BoolOutput, executor)
-    command.run((key, destinationDb))
+    val command = RedisCommand(Move, Tuple2(ArbitraryKeyInput[K](), LongInput), BoolOutput)
+    runCommand(command, (key, destinationDb))
   }
 
   /**
@@ -237,8 +235,8 @@ trait Keys[G[+_]] extends RedisEnvironment[G] {
    *   true if timeout was removed, false if key does not exist or does not have an associated timeout.
    */
   final def persist[K: Schema](key: K): G[Boolean] = {
-    val command = RedisCommand(Persist, ArbitraryKeyInput[K](), BoolOutput, executor)
-    command.run(key)
+    val command = RedisCommand(Persist, ArbitraryKeyInput[K](), BoolOutput)
+    runCommand(command, key)
   }
 
   /**
@@ -256,8 +254,8 @@ trait Keys[G[+_]] extends RedisEnvironment[G] {
    */
   final def pExpire[K: Schema](key: K, timeout: Duration): G[Boolean] = {
     val command =
-      RedisCommand(PExpire, Tuple2(ArbitraryKeyInput[K](), DurationMillisecondsInput), BoolOutput, executor)
-    command.run((key, timeout))
+      RedisCommand(PExpire, Tuple2(ArbitraryKeyInput[K](), DurationMillisecondsInput), BoolOutput)
+    runCommand(command, (key, timeout))
   }
 
   /**
@@ -275,8 +273,8 @@ trait Keys[G[+_]] extends RedisEnvironment[G] {
    */
   final def pExpireAt[K: Schema](key: K, timestamp: Instant): G[Boolean] = {
     val command =
-      RedisCommand(PExpireAt, Tuple2(ArbitraryKeyInput[K](), TimeMillisecondsInput), BoolOutput, executor)
-    command.run((key, timestamp))
+      RedisCommand(PExpireAt, Tuple2(ArbitraryKeyInput[K](), TimeMillisecondsInput), BoolOutput)
+    runCommand(command, (key, timestamp))
   }
 
   /**
@@ -288,8 +286,8 @@ trait Keys[G[+_]] extends RedisEnvironment[G] {
    *   remaining time to live of a key that has a timeout, error otherwise.
    */
   final def pTtl[K: Schema](key: K): G[Duration] = {
-    val command = RedisCommand(PTtl, ArbitraryKeyInput[K](), DurationMillisecondsOutput, executor)
-    command.run(key)
+    val command = RedisCommand(PTtl, ArbitraryKeyInput[K](), DurationMillisecondsOutput)
+    runCommand(command, key)
   }
 
   /**
@@ -301,7 +299,7 @@ trait Keys[G[+_]] extends RedisEnvironment[G] {
   final def randomKey: ResultBuilder1[Option, G] =
     new ResultBuilder1[Option, G] {
       def returning[V: Schema]: G[Option[V]] =
-        RedisCommand(RandomKey, NoInput, OptionalOutput(ArbitraryOutput[V]()), executor).run(())
+        runCommand(RedisCommand(RandomKey, NoInput, OptionalOutput(ArbitraryOutput[V]())), ())
     }
 
   /**
@@ -316,8 +314,8 @@ trait Keys[G[+_]] extends RedisEnvironment[G] {
    */
   final def rename[K: Schema](key: K, newKey: K): G[Unit] = {
     val command =
-      RedisCommand(Rename, Tuple2(ArbitraryKeyInput[K](), ArbitraryKeyInput[K]()), UnitOutput, executor)
-    command.run((key, newKey))
+      RedisCommand(Rename, Tuple2(ArbitraryKeyInput[K](), ArbitraryKeyInput[K]()), UnitOutput)
+    runCommand(command, (key, newKey))
   }
 
   /**
@@ -332,8 +330,8 @@ trait Keys[G[+_]] extends RedisEnvironment[G] {
    */
   final def renameNx[K: Schema](key: K, newKey: K): G[Boolean] = {
     val command =
-      RedisCommand(RenameNx, Tuple2(ArbitraryKeyInput[K](), ArbitraryKeyInput[K]()), BoolOutput, executor)
-    command.run((key, newKey))
+      RedisCommand(RenameNx, Tuple2(ArbitraryKeyInput[K](), ArbitraryKeyInput[K]()), BoolOutput)
+    runCommand(command, (key, newKey))
   }
 
   /**
@@ -378,10 +376,9 @@ trait Keys[G[+_]] extends RedisEnvironment[G] {
         OptionalInput(IdleTimeInput),
         OptionalInput(FreqInput)
       ),
-      UnitOutput,
-      executor
+      UnitOutput
     )
-    command.run((key, ttl, value, replace, absTtl, idleTime, freq))
+    runCommand(command, (key, ttl, value, replace, absTtl, idleTime, freq))
   }
 
   /**
@@ -411,10 +408,9 @@ trait Keys[G[+_]] extends RedisEnvironment[G] {
         val command = RedisCommand(
           Scan,
           Tuple4(LongInput, OptionalInput(PatternInput), OptionalInput(CountInput), OptionalInput(RedisTypeInput)),
-          Tuple2Output(ArbitraryOutput[Long](), ChunkOutput(ArbitraryOutput[K]())),
-          executor
+          Tuple2Output(ArbitraryOutput[Long](), ChunkOutput(ArbitraryOutput[K]()))
         )
-        command.run((cursor, pattern.map(Pattern(_)), count, `type`))
+        runCommand(command, (cursor, pattern.map(Pattern(_)), count, `type`))
       }
     }
 
@@ -456,10 +452,9 @@ trait Keys[G[+_]] extends RedisEnvironment[G] {
             OrderInput,
             OptionalInput(AlphaInput)
           ),
-          ChunkOutput(ArbitraryOutput[V]()),
-          executor
+          ChunkOutput(ArbitraryOutput[V]())
         )
-        command.run((key, by, limit, get, order, alpha))
+        runCommand(command, (key, by, limit, get, order, alpha))
       }
     }
 
@@ -507,10 +502,9 @@ trait Keys[G[+_]] extends RedisEnvironment[G] {
         OptionalInput(AlphaInput),
         StoreInput
       ),
-      LongOutput,
-      executor
+      LongOutput
     )
-    command.run((key, by, limit, get, order, alpha, storeAt))
+    runCommand(command, (key, by, limit, get, order, alpha, storeAt))
   }
 
   /**
@@ -524,8 +518,8 @@ trait Keys[G[+_]] extends RedisEnvironment[G] {
    *   The number of keys that were touched.
    */
   final def touch[K: Schema](key: K, keys: K*): G[Long] = {
-    val command = RedisCommand(Touch, NonEmptyList(ArbitraryKeyInput[K]()), LongOutput, executor)
-    command.run((key, keys.toList))
+    val command = RedisCommand(Touch, NonEmptyList(ArbitraryKeyInput[K]()), LongOutput)
+    runCommand(command, (key, keys.toList))
   }
 
   /**
@@ -537,8 +531,8 @@ trait Keys[G[+_]] extends RedisEnvironment[G] {
    *   remaining time to live of a key that has a timeout, error otherwise.
    */
   final def ttl[K: Schema](key: K): G[Duration] = {
-    val command = RedisCommand(Ttl, ArbitraryKeyInput[K](), DurationSecondsOutput, executor)
-    command.run(key)
+    val command = RedisCommand(Ttl, ArbitraryKeyInput[K](), DurationSecondsOutput)
+    runCommand(command, key)
   }
 
   /**
@@ -550,8 +544,8 @@ trait Keys[G[+_]] extends RedisEnvironment[G] {
    *   type of the value stored at key.
    */
   final def typeOf[K: Schema](key: K): G[RedisType] = {
-    val command = RedisCommand(TypeOf, ArbitraryKeyInput[K](), TypeOutput, executor)
-    command.run(key)
+    val command = RedisCommand(TypeOf, ArbitraryKeyInput[K](), TypeOutput)
+    runCommand(command, key)
   }
 
   /**
@@ -569,8 +563,8 @@ trait Keys[G[+_]] extends RedisEnvironment[G] {
    *   [[del]]
    */
   final def unlink[K: Schema](key: K, keys: K*): G[Long] = {
-    val command = RedisCommand(Unlink, NonEmptyList(ArbitraryKeyInput[K]()), LongOutput, executor)
-    command.run((key, keys.toList))
+    val command = RedisCommand(Unlink, NonEmptyList(ArbitraryKeyInput[K]()), LongOutput)
+    runCommand(command, (key, keys.toList))
   }
 
   /**
@@ -585,8 +579,8 @@ trait Keys[G[+_]] extends RedisEnvironment[G] {
    *   the number of replicas reached both in case of failure and success.
    */
   final def wait_(replicas: Long, timeout: Duration): G[Long] = {
-    val command = RedisCommand(Wait, Tuple2(LongInput, LongInput), LongOutput, executor)
-    command.run((replicas, timeout.toMillis))
+    val command = RedisCommand(Wait, Tuple2(LongInput, LongInput), LongOutput)
+    runCommand(command, (replicas, timeout.toMillis))
   }
 }
 

--- a/modules/redis/src/main/scala/zio/redis/api/Lists.scala
+++ b/modules/redis/src/main/scala/zio/redis/api/Lists.scala
@@ -58,11 +58,10 @@ trait Lists[G[+_]] extends RedisEnvironment[G] {
         val command = RedisCommand(
           BlMove,
           Tuple5(ArbitraryValueInput[S](), ArbitraryValueInput[D](), SideInput, SideInput, DurationSecondsInput),
-          OptionalOutput(ArbitraryOutput[V]()),
-          executor
+          OptionalOutput(ArbitraryOutput[V]())
         )
 
-        command.run((source, destination, sourceSide, destinationSide, timeout))
+        runCommand(command, (source, destination, sourceSide, destinationSide, timeout))
       }
     }
 
@@ -89,10 +88,9 @@ trait Lists[G[+_]] extends RedisEnvironment[G] {
         val command = RedisCommand(
           BlPop,
           Tuple2(NonEmptyList(ArbitraryKeyInput[K]()), DurationSecondsInput),
-          OptionalOutput(Tuple2Output(ArbitraryOutput[K](), ArbitraryOutput[V]())),
-          executor
+          OptionalOutput(Tuple2Output(ArbitraryOutput[K](), ArbitraryOutput[V]()))
         )
-        command.run(((key, keys.toList), timeout))
+        runCommand(command, ((key, keys.toList), timeout))
       }
     }
 
@@ -119,10 +117,9 @@ trait Lists[G[+_]] extends RedisEnvironment[G] {
         val command = RedisCommand(
           BrPop,
           Tuple2(NonEmptyList(ArbitraryKeyInput[K]()), DurationSecondsInput),
-          OptionalOutput(Tuple2Output(ArbitraryOutput[K](), ArbitraryOutput[V]())),
-          executor
+          OptionalOutput(Tuple2Output(ArbitraryOutput[K](), ArbitraryOutput[V]()))
         )
-        command.run(((key, keys.toList), timeout))
+        runCommand(command, ((key, keys.toList), timeout))
       }
     }
 
@@ -150,11 +147,10 @@ trait Lists[G[+_]] extends RedisEnvironment[G] {
         val command = RedisCommand(
           BrPopLPush,
           Tuple3(ArbitraryValueInput[S](), ArbitraryValueInput[D](), DurationSecondsInput),
-          OptionalOutput(ArbitraryOutput[V]()),
-          executor
+          OptionalOutput(ArbitraryOutput[V]())
         )
 
-        command.run((source, destination, timeout))
+        runCommand(command, (source, destination, timeout))
       }
     }
 
@@ -172,8 +168,10 @@ trait Lists[G[+_]] extends RedisEnvironment[G] {
   final def lIndex[K: Schema](key: K, index: Long): ResultBuilder1[Option, G] =
     new ResultBuilder1[Option, G] {
       def returning[V: Schema]: G[Option[V]] =
-        RedisCommand(LIndex, Tuple2(ArbitraryKeyInput[K](), LongInput), OptionalOutput(ArbitraryOutput[V]()), executor)
-          .run((key, index))
+        runCommand(
+          RedisCommand(LIndex, Tuple2(ArbitraryKeyInput[K](), LongInput), OptionalOutput(ArbitraryOutput[V]())),
+          (key, index)
+        )
     }
 
   /**
@@ -199,10 +197,9 @@ trait Lists[G[+_]] extends RedisEnvironment[G] {
     val command = RedisCommand(
       LInsert,
       Tuple4(ArbitraryKeyInput[K](), PositionInput, ArbitraryValueInput[V](), ArbitraryValueInput[V]()),
-      LongOutput,
-      executor
+      LongOutput
     )
-    command.run((key, position, pivot, element))
+    runCommand(command, (key, position, pivot, element))
   }
 
   /**
@@ -214,8 +211,8 @@ trait Lists[G[+_]] extends RedisEnvironment[G] {
    *   the length of the list at key.
    */
   final def lLen[K: Schema](key: K): G[Long] = {
-    val command = RedisCommand(LLen, ArbitraryKeyInput[K](), LongOutput, executor)
-    command.run(key)
+    val command = RedisCommand(LLen, ArbitraryKeyInput[K](), LongOutput)
+    runCommand(command, key)
   }
 
   /**
@@ -245,10 +242,9 @@ trait Lists[G[+_]] extends RedisEnvironment[G] {
         val command = RedisCommand(
           LMove,
           Tuple4(ArbitraryValueInput[S](), ArbitraryValueInput[D](), SideInput, SideInput),
-          OptionalOutput(ArbitraryOutput[V]()),
-          executor
+          OptionalOutput(ArbitraryOutput[V]())
         )
-        command.run((source, destination, sourceSide, destinationSide))
+        runCommand(command, (source, destination, sourceSide, destinationSide))
       }
     }
 
@@ -263,7 +259,7 @@ trait Lists[G[+_]] extends RedisEnvironment[G] {
   final def lPop[K: Schema](key: K): ResultBuilder1[Option, G] =
     new ResultBuilder1[Option, G] {
       def returning[V: Schema]: G[Option[V]] =
-        RedisCommand(LPop, ArbitraryKeyInput[K](), OptionalOutput(ArbitraryOutput[V]()), executor).run(key)
+        runCommand(RedisCommand(LPop, ArbitraryKeyInput[K](), OptionalOutput(ArbitraryOutput[V]())), key)
     }
 
   /**
@@ -296,11 +292,10 @@ trait Lists[G[+_]] extends RedisEnvironment[G] {
         OptionalInput(RankInput),
         OptionalInput(ListMaxLenInput)
       ),
-      OptionalOutput(LongOutput),
-      executor
+      OptionalOutput(LongOutput)
     )
 
-    command.run((key, element, rank, maxLen))
+    runCommand(command, (key, element, rank, maxLen))
   }
 
   /**
@@ -337,11 +332,10 @@ trait Lists[G[+_]] extends RedisEnvironment[G] {
         OptionalInput(RankInput),
         OptionalInput(ListMaxLenInput)
       ),
-      ChunkOutput(LongOutput),
-      executor
+      ChunkOutput(LongOutput)
     )
 
-    command.run((key, element, count, rank, maxLen))
+    runCommand(command, (key, element, count, rank, maxLen))
   }
 
   /**
@@ -359,8 +353,8 @@ trait Lists[G[+_]] extends RedisEnvironment[G] {
    */
   final def lPush[K: Schema, V: Schema](key: K, element: V, elements: V*): G[Long] = {
     val command =
-      RedisCommand(LPush, Tuple2(ArbitraryKeyInput[K](), NonEmptyList(ArbitraryValueInput[V]())), LongOutput, executor)
-    command.run((key, (element, elements.toList)))
+      RedisCommand(LPush, Tuple2(ArbitraryKeyInput[K](), NonEmptyList(ArbitraryValueInput[V]())), LongOutput)
+    runCommand(command, (key, (element, elements.toList)))
   }
 
   /**
@@ -378,8 +372,8 @@ trait Lists[G[+_]] extends RedisEnvironment[G] {
    */
   final def lPushX[K: Schema, V: Schema](key: K, element: V, elements: V*): G[Long] = {
     val command =
-      RedisCommand(LPushX, Tuple2(ArbitraryKeyInput[K](), NonEmptyList(ArbitraryValueInput[V]())), LongOutput, executor)
-    command.run((key, (element, elements.toList)))
+      RedisCommand(LPushX, Tuple2(ArbitraryKeyInput[K](), NonEmptyList(ArbitraryValueInput[V]())), LongOutput)
+    runCommand(command, (key, (element, elements.toList)))
   }
 
   /**
@@ -396,8 +390,10 @@ trait Lists[G[+_]] extends RedisEnvironment[G] {
   final def lRange[K: Schema](key: K, range: Range): ResultBuilder1[Chunk, G] =
     new ResultBuilder1[Chunk, G] {
       def returning[V: Schema]: G[Chunk[V]] =
-        RedisCommand(LRange, Tuple2(ArbitraryKeyInput[K](), RangeInput), ChunkOutput(ArbitraryOutput[V]()), executor)
-          .run((key, range))
+        runCommand(
+          RedisCommand(LRange, Tuple2(ArbitraryKeyInput[K](), RangeInput), ChunkOutput(ArbitraryOutput[V]())),
+          (key, range)
+        )
     }
 
   /**
@@ -419,8 +415,8 @@ trait Lists[G[+_]] extends RedisEnvironment[G] {
    */
   final def lRem[K: Schema](key: K, count: Long, element: String): G[Long] = {
     val command =
-      RedisCommand(LRem, Tuple3(ArbitraryKeyInput[K](), LongInput, StringInput), LongOutput, executor)
-    command.run((key, count, element))
+      RedisCommand(LRem, Tuple3(ArbitraryKeyInput[K](), LongInput, StringInput), LongOutput)
+    runCommand(command, (key, count, element))
   }
 
   /**
@@ -437,8 +433,8 @@ trait Lists[G[+_]] extends RedisEnvironment[G] {
    */
   final def lSet[K: Schema, V: Schema](key: K, index: Long, element: V): G[Unit] = {
     val command =
-      RedisCommand(LSet, Tuple3(ArbitraryKeyInput[K](), LongInput, ArbitraryValueInput[V]()), UnitOutput, executor)
-    command.run((key, index, element))
+      RedisCommand(LSet, Tuple3(ArbitraryKeyInput[K](), LongInput, ArbitraryValueInput[V]()), UnitOutput)
+    runCommand(command, (key, index, element))
   }
 
   /**
@@ -453,8 +449,8 @@ trait Lists[G[+_]] extends RedisEnvironment[G] {
    *   the Unit value.
    */
   final def lTrim[K: Schema](key: K, range: Range): G[Unit] = {
-    val command = RedisCommand(LTrim, Tuple2(ArbitraryKeyInput[K](), RangeInput), UnitOutput, executor)
-    command.run((key, range))
+    val command = RedisCommand(LTrim, Tuple2(ArbitraryKeyInput[K](), RangeInput), UnitOutput)
+    runCommand(command, (key, range))
   }
 
   /**
@@ -468,7 +464,7 @@ trait Lists[G[+_]] extends RedisEnvironment[G] {
   final def rPop[K: Schema](key: K): ResultBuilder1[Option, G] =
     new ResultBuilder1[Option, G] {
       def returning[V: Schema]: G[Option[V]] =
-        RedisCommand(RPop, ArbitraryKeyInput[K](), OptionalOutput(ArbitraryOutput[V]()), executor).run(key)
+        runCommand(RedisCommand(RPop, ArbitraryKeyInput[K](), OptionalOutput(ArbitraryOutput[V]())), key)
     }
 
   /**
@@ -486,13 +482,14 @@ trait Lists[G[+_]] extends RedisEnvironment[G] {
   final def rPopLPush[S: Schema, D: Schema](source: S, destination: D): ResultBuilder1[Option, G] =
     new ResultBuilder1[Option, G] {
       def returning[V: Schema]: G[Option[V]] =
-        RedisCommand(
-          RPopLPush,
-          Tuple2(ArbitraryValueInput[S](), ArbitraryValueInput[D]()),
-          OptionalOutput(ArbitraryOutput[V]()),
-          executor
+        runCommand(
+          RedisCommand(
+            RPopLPush,
+            Tuple2(ArbitraryValueInput[S](), ArbitraryValueInput[D]()),
+            OptionalOutput(ArbitraryOutput[V]())
+          ),
+          (source, destination)
         )
-          .run((source, destination))
     }
 
   /**
@@ -510,8 +507,8 @@ trait Lists[G[+_]] extends RedisEnvironment[G] {
    */
   final def rPush[K: Schema, V: Schema](key: K, element: V, elements: V*): G[Long] = {
     val command =
-      RedisCommand(RPush, Tuple2(ArbitraryKeyInput[K](), NonEmptyList(ArbitraryValueInput[V]())), LongOutput, executor)
-    command.run((key, (element, elements.toList)))
+      RedisCommand(RPush, Tuple2(ArbitraryKeyInput[K](), NonEmptyList(ArbitraryValueInput[V]())), LongOutput)
+    runCommand(command, (key, (element, elements.toList)))
   }
 
   /**
@@ -529,8 +526,8 @@ trait Lists[G[+_]] extends RedisEnvironment[G] {
    */
   final def rPushX[K: Schema, V: Schema](key: K, element: V, elements: V*): G[Long] = {
     val command =
-      RedisCommand(RPushX, Tuple2(ArbitraryKeyInput[K](), NonEmptyList(ArbitraryValueInput[V]())), LongOutput, executor)
-    command.run((key, (element, elements.toList)))
+      RedisCommand(RPushX, Tuple2(ArbitraryKeyInput[K](), NonEmptyList(ArbitraryValueInput[V]())), LongOutput)
+    runCommand(command, (key, (element, elements.toList)))
   }
 }
 

--- a/modules/redis/src/main/scala/zio/redis/api/Lists.scala
+++ b/modules/redis/src/main/scala/zio/redis/api/Lists.scala
@@ -61,7 +61,7 @@ trait Lists[G[+_]] extends RedisEnvironment[G] {
           OptionalOutput(ArbitraryOutput[V]())
         )
 
-        runCommand(command, (source, destination, sourceSide, destinationSide, timeout))
+        command.run((source, destination, sourceSide, destinationSide, timeout))
       }
     }
 
@@ -90,7 +90,7 @@ trait Lists[G[+_]] extends RedisEnvironment[G] {
           Tuple2(NonEmptyList(ArbitraryKeyInput[K]()), DurationSecondsInput),
           OptionalOutput(Tuple2Output(ArbitraryOutput[K](), ArbitraryOutput[V]()))
         )
-        runCommand(command, ((key, keys.toList), timeout))
+        command.run(((key, keys.toList), timeout))
       }
     }
 
@@ -119,7 +119,7 @@ trait Lists[G[+_]] extends RedisEnvironment[G] {
           Tuple2(NonEmptyList(ArbitraryKeyInput[K]()), DurationSecondsInput),
           OptionalOutput(Tuple2Output(ArbitraryOutput[K](), ArbitraryOutput[V]()))
         )
-        runCommand(command, ((key, keys.toList), timeout))
+        command.run(((key, keys.toList), timeout))
       }
     }
 
@@ -150,7 +150,7 @@ trait Lists[G[+_]] extends RedisEnvironment[G] {
           OptionalOutput(ArbitraryOutput[V]())
         )
 
-        runCommand(command, (source, destination, timeout))
+        command.run((source, destination, timeout))
       }
     }
 
@@ -168,10 +168,8 @@ trait Lists[G[+_]] extends RedisEnvironment[G] {
   final def lIndex[K: Schema](key: K, index: Long): ResultBuilder1[Option, G] =
     new ResultBuilder1[Option, G] {
       def returning[V: Schema]: G[Option[V]] =
-        runCommand(
-          RedisCommand(LIndex, Tuple2(ArbitraryKeyInput[K](), LongInput), OptionalOutput(ArbitraryOutput[V]())),
-          (key, index)
-        )
+        RedisCommand(LIndex, Tuple2(ArbitraryKeyInput[K](), LongInput), OptionalOutput(ArbitraryOutput[V]()))
+          .run((key, index))
     }
 
   /**
@@ -199,7 +197,7 @@ trait Lists[G[+_]] extends RedisEnvironment[G] {
       Tuple4(ArbitraryKeyInput[K](), PositionInput, ArbitraryValueInput[V](), ArbitraryValueInput[V]()),
       LongOutput
     )
-    runCommand(command, (key, position, pivot, element))
+    command.run((key, position, pivot, element))
   }
 
   /**
@@ -212,7 +210,7 @@ trait Lists[G[+_]] extends RedisEnvironment[G] {
    */
   final def lLen[K: Schema](key: K): G[Long] = {
     val command = RedisCommand(LLen, ArbitraryKeyInput[K](), LongOutput)
-    runCommand(command, key)
+    command.run(key)
   }
 
   /**
@@ -244,7 +242,7 @@ trait Lists[G[+_]] extends RedisEnvironment[G] {
           Tuple4(ArbitraryValueInput[S](), ArbitraryValueInput[D](), SideInput, SideInput),
           OptionalOutput(ArbitraryOutput[V]())
         )
-        runCommand(command, (source, destination, sourceSide, destinationSide))
+        command.run((source, destination, sourceSide, destinationSide))
       }
     }
 
@@ -259,7 +257,7 @@ trait Lists[G[+_]] extends RedisEnvironment[G] {
   final def lPop[K: Schema](key: K): ResultBuilder1[Option, G] =
     new ResultBuilder1[Option, G] {
       def returning[V: Schema]: G[Option[V]] =
-        runCommand(RedisCommand(LPop, ArbitraryKeyInput[K](), OptionalOutput(ArbitraryOutput[V]())), key)
+        RedisCommand(LPop, ArbitraryKeyInput[K](), OptionalOutput(ArbitraryOutput[V]())).run(key)
     }
 
   /**
@@ -295,7 +293,7 @@ trait Lists[G[+_]] extends RedisEnvironment[G] {
       OptionalOutput(LongOutput)
     )
 
-    runCommand(command, (key, element, rank, maxLen))
+    command.run((key, element, rank, maxLen))
   }
 
   /**
@@ -335,7 +333,7 @@ trait Lists[G[+_]] extends RedisEnvironment[G] {
       ChunkOutput(LongOutput)
     )
 
-    runCommand(command, (key, element, count, rank, maxLen))
+    command.run((key, element, count, rank, maxLen))
   }
 
   /**
@@ -354,7 +352,7 @@ trait Lists[G[+_]] extends RedisEnvironment[G] {
   final def lPush[K: Schema, V: Schema](key: K, element: V, elements: V*): G[Long] = {
     val command =
       RedisCommand(LPush, Tuple2(ArbitraryKeyInput[K](), NonEmptyList(ArbitraryValueInput[V]())), LongOutput)
-    runCommand(command, (key, (element, elements.toList)))
+    command.run((key, (element, elements.toList)))
   }
 
   /**
@@ -373,7 +371,7 @@ trait Lists[G[+_]] extends RedisEnvironment[G] {
   final def lPushX[K: Schema, V: Schema](key: K, element: V, elements: V*): G[Long] = {
     val command =
       RedisCommand(LPushX, Tuple2(ArbitraryKeyInput[K](), NonEmptyList(ArbitraryValueInput[V]())), LongOutput)
-    runCommand(command, (key, (element, elements.toList)))
+    command.run((key, (element, elements.toList)))
   }
 
   /**
@@ -390,10 +388,8 @@ trait Lists[G[+_]] extends RedisEnvironment[G] {
   final def lRange[K: Schema](key: K, range: Range): ResultBuilder1[Chunk, G] =
     new ResultBuilder1[Chunk, G] {
       def returning[V: Schema]: G[Chunk[V]] =
-        runCommand(
-          RedisCommand(LRange, Tuple2(ArbitraryKeyInput[K](), RangeInput), ChunkOutput(ArbitraryOutput[V]())),
-          (key, range)
-        )
+        RedisCommand(LRange, Tuple2(ArbitraryKeyInput[K](), RangeInput), ChunkOutput(ArbitraryOutput[V]()))
+          .run((key, range))
     }
 
   /**
@@ -416,7 +412,7 @@ trait Lists[G[+_]] extends RedisEnvironment[G] {
   final def lRem[K: Schema](key: K, count: Long, element: String): G[Long] = {
     val command =
       RedisCommand(LRem, Tuple3(ArbitraryKeyInput[K](), LongInput, StringInput), LongOutput)
-    runCommand(command, (key, count, element))
+    command.run((key, count, element))
   }
 
   /**
@@ -434,7 +430,7 @@ trait Lists[G[+_]] extends RedisEnvironment[G] {
   final def lSet[K: Schema, V: Schema](key: K, index: Long, element: V): G[Unit] = {
     val command =
       RedisCommand(LSet, Tuple3(ArbitraryKeyInput[K](), LongInput, ArbitraryValueInput[V]()), UnitOutput)
-    runCommand(command, (key, index, element))
+    command.run((key, index, element))
   }
 
   /**
@@ -450,7 +446,7 @@ trait Lists[G[+_]] extends RedisEnvironment[G] {
    */
   final def lTrim[K: Schema](key: K, range: Range): G[Unit] = {
     val command = RedisCommand(LTrim, Tuple2(ArbitraryKeyInput[K](), RangeInput), UnitOutput)
-    runCommand(command, (key, range))
+    command.run((key, range))
   }
 
   /**
@@ -464,7 +460,7 @@ trait Lists[G[+_]] extends RedisEnvironment[G] {
   final def rPop[K: Schema](key: K): ResultBuilder1[Option, G] =
     new ResultBuilder1[Option, G] {
       def returning[V: Schema]: G[Option[V]] =
-        runCommand(RedisCommand(RPop, ArbitraryKeyInput[K](), OptionalOutput(ArbitraryOutput[V]())), key)
+        RedisCommand(RPop, ArbitraryKeyInput[K](), OptionalOutput(ArbitraryOutput[V]())).run(key)
     }
 
   /**
@@ -482,14 +478,11 @@ trait Lists[G[+_]] extends RedisEnvironment[G] {
   final def rPopLPush[S: Schema, D: Schema](source: S, destination: D): ResultBuilder1[Option, G] =
     new ResultBuilder1[Option, G] {
       def returning[V: Schema]: G[Option[V]] =
-        runCommand(
-          RedisCommand(
-            RPopLPush,
-            Tuple2(ArbitraryValueInput[S](), ArbitraryValueInput[D]()),
-            OptionalOutput(ArbitraryOutput[V]())
-          ),
-          (source, destination)
-        )
+        RedisCommand(
+          RPopLPush,
+          Tuple2(ArbitraryValueInput[S](), ArbitraryValueInput[D]()),
+          OptionalOutput(ArbitraryOutput[V]())
+        ).run((source, destination))
     }
 
   /**
@@ -508,7 +501,7 @@ trait Lists[G[+_]] extends RedisEnvironment[G] {
   final def rPush[K: Schema, V: Schema](key: K, element: V, elements: V*): G[Long] = {
     val command =
       RedisCommand(RPush, Tuple2(ArbitraryKeyInput[K](), NonEmptyList(ArbitraryValueInput[V]())), LongOutput)
-    runCommand(command, (key, (element, elements.toList)))
+    command.run((key, (element, elements.toList)))
   }
 
   /**
@@ -527,7 +520,7 @@ trait Lists[G[+_]] extends RedisEnvironment[G] {
   final def rPushX[K: Schema, V: Schema](key: K, element: V, elements: V*): G[Long] = {
     val command =
       RedisCommand(RPushX, Tuple2(ArbitraryKeyInput[K](), NonEmptyList(ArbitraryValueInput[V]())), LongOutput)
-    runCommand(command, (key, (element, elements.toList)))
+    command.run((key, (element, elements.toList)))
   }
 }
 

--- a/modules/redis/src/main/scala/zio/redis/api/Publishing.scala
+++ b/modules/redis/src/main/scala/zio/redis/api/Publishing.scala
@@ -18,12 +18,11 @@ package zio.redis.api
 
 import zio.redis.Input._
 import zio.redis.Output._
-import zio.redis._
 import zio.redis.internal.{RedisCommand, RedisEnvironment}
 import zio.schema.Schema
-import zio.{Chunk, IO}
+import zio.Chunk
 
-trait Publishing extends RedisEnvironment {
+trait Publishing[G[+_]] extends RedisEnvironment[G] {
   import Publishing._
 
   /**
@@ -36,7 +35,7 @@ trait Publishing extends RedisEnvironment {
    * @return
    *   Returns the number of clients that received the message.
    */
-  final def publish[A: Schema](channel: String, message: A): IO[RedisError, Long] = {
+  final def publish[A: Schema](channel: String, message: A): G[Long] = {
     val command = RedisCommand(Publish, Tuple2(StringInput, ArbitraryKeyInput[A]()), LongOutput, executor)
     command.run((channel, message))
   }
@@ -49,7 +48,7 @@ trait Publishing extends RedisEnvironment {
    * @return
    *   Returns a list of active channels matching the specified pattern.
    */
-  final def pubSubChannels(pattern: String): IO[RedisError, Chunk[String]] = {
+  final def pubSubChannels(pattern: String): G[Chunk[String]] = {
     val command = RedisCommand(PubSubChannels, StringInput, ChunkOutput(MultiStringOutput), executor)
     command.run(pattern)
   }
@@ -60,7 +59,7 @@ trait Publishing extends RedisEnvironment {
    * @return
    *   Returns the number of patterns all the clients are subscribed to.
    */
-  final def pubSubNumPat: IO[RedisError, Long] = {
+  final def pubSubNumPat: G[Long] = {
     val command = RedisCommand(PubSubNumPat, NoInput, LongOutput, executor)
     command.run(())
   }
@@ -75,7 +74,7 @@ trait Publishing extends RedisEnvironment {
    * @return
    *   Returns a map of channel and number of subscribers for channel.
    */
-  final def pubSubNumSub(channel: String, channels: String*): IO[RedisError, Map[String, Long]] = {
+  final def pubSubNumSub(channel: String, channels: String*): G[Map[String, Long]] = {
     val command = RedisCommand(PubSubNumSub, NonEmptyList(StringInput), NumSubResponseOutput, executor)
     command.run((channel, channels.toList))
   }

--- a/modules/redis/src/main/scala/zio/redis/api/Publishing.scala
+++ b/modules/redis/src/main/scala/zio/redis/api/Publishing.scala
@@ -37,7 +37,7 @@ trait Publishing[G[+_]] extends RedisEnvironment[G] {
    */
   final def publish[A: Schema](channel: String, message: A): G[Long] = {
     val command = RedisCommand(Publish, Tuple2(StringInput, ArbitraryKeyInput[A]()), LongOutput)
-    runCommand(command, (channel, message))
+    command.run((channel, message))
   }
 
   /**
@@ -50,7 +50,7 @@ trait Publishing[G[+_]] extends RedisEnvironment[G] {
    */
   final def pubSubChannels(pattern: String): G[Chunk[String]] = {
     val command = RedisCommand(PubSubChannels, StringInput, ChunkOutput(MultiStringOutput))
-    runCommand(command, pattern)
+    command.run(pattern)
   }
 
   /**
@@ -61,7 +61,7 @@ trait Publishing[G[+_]] extends RedisEnvironment[G] {
    */
   final def pubSubNumPat: G[Long] = {
     val command = RedisCommand(PubSubNumPat, NoInput, LongOutput)
-    runCommand(command, ())
+    command.run(())
   }
 
   /**
@@ -76,7 +76,7 @@ trait Publishing[G[+_]] extends RedisEnvironment[G] {
    */
   final def pubSubNumSub(channel: String, channels: String*): G[Map[String, Long]] = {
     val command = RedisCommand(PubSubNumSub, NonEmptyList(StringInput), NumSubResponseOutput)
-    runCommand(command, (channel, channels.toList))
+    command.run((channel, channels.toList))
   }
 }
 

--- a/modules/redis/src/main/scala/zio/redis/api/Publishing.scala
+++ b/modules/redis/src/main/scala/zio/redis/api/Publishing.scala
@@ -36,8 +36,8 @@ trait Publishing[G[+_]] extends RedisEnvironment[G] {
    *   Returns the number of clients that received the message.
    */
   final def publish[A: Schema](channel: String, message: A): G[Long] = {
-    val command = RedisCommand(Publish, Tuple2(StringInput, ArbitraryKeyInput[A]()), LongOutput, executor)
-    command.run((channel, message))
+    val command = RedisCommand(Publish, Tuple2(StringInput, ArbitraryKeyInput[A]()), LongOutput)
+    runCommand(command, (channel, message))
   }
 
   /**
@@ -49,8 +49,8 @@ trait Publishing[G[+_]] extends RedisEnvironment[G] {
    *   Returns a list of active channels matching the specified pattern.
    */
   final def pubSubChannels(pattern: String): G[Chunk[String]] = {
-    val command = RedisCommand(PubSubChannels, StringInput, ChunkOutput(MultiStringOutput), executor)
-    command.run(pattern)
+    val command = RedisCommand(PubSubChannels, StringInput, ChunkOutput(MultiStringOutput))
+    runCommand(command, pattern)
   }
 
   /**
@@ -60,8 +60,8 @@ trait Publishing[G[+_]] extends RedisEnvironment[G] {
    *   Returns the number of patterns all the clients are subscribed to.
    */
   final def pubSubNumPat: G[Long] = {
-    val command = RedisCommand(PubSubNumPat, NoInput, LongOutput, executor)
-    command.run(())
+    val command = RedisCommand(PubSubNumPat, NoInput, LongOutput)
+    runCommand(command, ())
   }
 
   /**
@@ -75,8 +75,8 @@ trait Publishing[G[+_]] extends RedisEnvironment[G] {
    *   Returns a map of channel and number of subscribers for channel.
    */
   final def pubSubNumSub(channel: String, channels: String*): G[Map[String, Long]] = {
-    val command = RedisCommand(PubSubNumSub, NonEmptyList(StringInput), NumSubResponseOutput, executor)
-    command.run((channel, channels.toList))
+    val command = RedisCommand(PubSubNumSub, NonEmptyList(StringInput), NumSubResponseOutput)
+    runCommand(command, (channel, channels.toList))
   }
 }
 

--- a/modules/redis/src/main/scala/zio/redis/api/Publishing.scala
+++ b/modules/redis/src/main/scala/zio/redis/api/Publishing.scala
@@ -16,11 +16,11 @@
 
 package zio.redis.api
 
+import zio.Chunk
 import zio.redis.Input._
 import zio.redis.Output._
 import zio.redis.internal.{RedisCommand, RedisEnvironment}
 import zio.schema.Schema
-import zio.Chunk
 
 trait Publishing[G[+_]] extends RedisEnvironment[G] {
   import Publishing._

--- a/modules/redis/src/main/scala/zio/redis/api/Scripting.scala
+++ b/modules/redis/src/main/scala/zio/redis/api/Scripting.scala
@@ -45,8 +45,8 @@ trait Scripting[G[+_]] extends RedisEnvironment[G] {
     args: Chunk[A]
   ): ResultOutputBuilder[G] = new ResultOutputBuilder[G] {
     def returning[R: Output]: G[R] = {
-      val command = RedisCommand(Eval, EvalInput(Input[K], Input[A]), Output[R], executor)
-      command.run((script, keys, args))
+      val command = RedisCommand(Eval, EvalInput(Input[K], Input[A]), Output[R])
+      runCommand(command, (script, keys, args))
     }
   }
 
@@ -70,8 +70,8 @@ trait Scripting[G[+_]] extends RedisEnvironment[G] {
     args: Chunk[A]
   ): ResultOutputBuilder[G] = new ResultOutputBuilder[G] {
     def returning[R: Output]: G[R] = {
-      val command = RedisCommand(EvalSha, EvalInput(Input[K], Input[A]), Output[R], executor)
-      command.run((sha1, keys, args))
+      val command = RedisCommand(EvalSha, EvalInput(Input[K], Input[A]), Output[R])
+      runCommand(command, (sha1, keys, args))
     }
   }
 
@@ -86,8 +86,8 @@ trait Scripting[G[+_]] extends RedisEnvironment[G] {
    *   the Unit value.
    */
   final def scriptDebug(mode: DebugMode): G[Unit] = {
-    val command = RedisCommand(ScriptDebug, ScriptDebugInput, UnitOutput, executor)
-    command.run(mode)
+    val command = RedisCommand(ScriptDebug, ScriptDebugInput, UnitOutput)
+    runCommand(command, mode)
   }
 
   /**
@@ -102,8 +102,8 @@ trait Scripting[G[+_]] extends RedisEnvironment[G] {
    *   otherwise false is returned.
    */
   final def scriptExists(sha1: String, sha1s: String*): G[Chunk[Boolean]] = {
-    val command = RedisCommand(ScriptExists, NonEmptyList(StringInput), ChunkOutput(BoolOutput), executor)
-    command.run((sha1, sha1s.toList))
+    val command = RedisCommand(ScriptExists, NonEmptyList(StringInput), ChunkOutput(BoolOutput))
+    runCommand(command, (sha1, sha1s.toList))
   }
 
   /**
@@ -120,8 +120,8 @@ trait Scripting[G[+_]] extends RedisEnvironment[G] {
    *   the Unit value.
    */
   final def scriptFlush(mode: Option[FlushMode] = None): G[Unit] = {
-    val command = RedisCommand(ScriptFlush, OptionalInput(ScriptFlushInput), UnitOutput, executor)
-    command.run(mode)
+    val command = RedisCommand(ScriptFlush, OptionalInput(ScriptFlushInput), UnitOutput)
+    runCommand(command, mode)
   }
 
   /**
@@ -132,8 +132,8 @@ trait Scripting[G[+_]] extends RedisEnvironment[G] {
    *   the Unit value.
    */
   final def scriptKill: G[Unit] = {
-    val command = RedisCommand(ScriptKill, NoInput, UnitOutput, executor)
-    command.run(())
+    val command = RedisCommand(ScriptKill, NoInput, UnitOutput)
+    runCommand(command, ())
   }
 
   /**
@@ -146,8 +146,8 @@ trait Scripting[G[+_]] extends RedisEnvironment[G] {
    *   the SHA1 digest of the script added into the script cache.
    */
   final def scriptLoad(script: String): G[String] = {
-    val command = RedisCommand(ScriptLoad, StringInput, MultiStringOutput, executor)
-    command.run(script)
+    val command = RedisCommand(ScriptLoad, StringInput, MultiStringOutput)
+    runCommand(command, script)
   }
 }
 

--- a/modules/redis/src/main/scala/zio/redis/api/Scripting.scala
+++ b/modules/redis/src/main/scala/zio/redis/api/Scripting.scala
@@ -46,7 +46,7 @@ trait Scripting[G[+_]] extends RedisEnvironment[G] {
   ): ResultOutputBuilder[G] = new ResultOutputBuilder[G] {
     def returning[R: Output]: G[R] = {
       val command = RedisCommand(Eval, EvalInput(Input[K], Input[A]), Output[R])
-      runCommand(command, (script, keys, args))
+      command.run((script, keys, args))
     }
   }
 
@@ -71,7 +71,7 @@ trait Scripting[G[+_]] extends RedisEnvironment[G] {
   ): ResultOutputBuilder[G] = new ResultOutputBuilder[G] {
     def returning[R: Output]: G[R] = {
       val command = RedisCommand(EvalSha, EvalInput(Input[K], Input[A]), Output[R])
-      runCommand(command, (sha1, keys, args))
+      command.run((sha1, keys, args))
     }
   }
 
@@ -87,7 +87,7 @@ trait Scripting[G[+_]] extends RedisEnvironment[G] {
    */
   final def scriptDebug(mode: DebugMode): G[Unit] = {
     val command = RedisCommand(ScriptDebug, ScriptDebugInput, UnitOutput)
-    runCommand(command, mode)
+    command.run(mode)
   }
 
   /**
@@ -103,7 +103,7 @@ trait Scripting[G[+_]] extends RedisEnvironment[G] {
    */
   final def scriptExists(sha1: String, sha1s: String*): G[Chunk[Boolean]] = {
     val command = RedisCommand(ScriptExists, NonEmptyList(StringInput), ChunkOutput(BoolOutput))
-    runCommand(command, (sha1, sha1s.toList))
+    command.run((sha1, sha1s.toList))
   }
 
   /**
@@ -121,7 +121,7 @@ trait Scripting[G[+_]] extends RedisEnvironment[G] {
    */
   final def scriptFlush(mode: Option[FlushMode] = None): G[Unit] = {
     val command = RedisCommand(ScriptFlush, OptionalInput(ScriptFlushInput), UnitOutput)
-    runCommand(command, mode)
+    command.run(mode)
   }
 
   /**
@@ -133,7 +133,7 @@ trait Scripting[G[+_]] extends RedisEnvironment[G] {
    */
   final def scriptKill: G[Unit] = {
     val command = RedisCommand(ScriptKill, NoInput, UnitOutput)
-    runCommand(command, ())
+    command.run(())
   }
 
   /**
@@ -147,7 +147,7 @@ trait Scripting[G[+_]] extends RedisEnvironment[G] {
    */
   final def scriptLoad(script: String): G[String] = {
     val command = RedisCommand(ScriptLoad, StringInput, MultiStringOutput)
-    runCommand(command, script)
+    command.run(script)
   }
 }
 

--- a/modules/redis/src/main/scala/zio/redis/api/Scripting.scala
+++ b/modules/redis/src/main/scala/zio/redis/api/Scripting.scala
@@ -22,7 +22,7 @@ import zio.redis.ResultBuilder.ResultOutputBuilder
 import zio.redis._
 import zio.redis.internal.{RedisCommand, RedisEnvironment}
 
-trait Scripting extends RedisEnvironment {
+trait Scripting[G[+_]] extends RedisEnvironment[G] {
   import Input._
   import Scripting._
 
@@ -43,8 +43,8 @@ trait Scripting extends RedisEnvironment {
     script: String,
     keys: Chunk[K],
     args: Chunk[A]
-  ): ResultOutputBuilder = new ResultOutputBuilder {
-    def returning[R: Output]: IO[RedisError, R] = {
+  ): ResultOutputBuilder[G] = new ResultOutputBuilder[G] {
+    def returning[R: Output]: G[R] = {
       val command = RedisCommand(Eval, EvalInput(Input[K], Input[A]), Output[R], executor)
       command.run((script, keys, args))
     }
@@ -68,8 +68,8 @@ trait Scripting extends RedisEnvironment {
     sha1: String,
     keys: Chunk[K],
     args: Chunk[A]
-  ): ResultOutputBuilder = new ResultOutputBuilder {
-    def returning[R: Output]: IO[RedisError, R] = {
+  ): ResultOutputBuilder[G] = new ResultOutputBuilder[G] {
+    def returning[R: Output]: G[R] = {
       val command = RedisCommand(EvalSha, EvalInput(Input[K], Input[A]), Output[R], executor)
       command.run((sha1, keys, args))
     }
@@ -85,7 +85,7 @@ trait Scripting extends RedisEnvironment {
    * @return
    *   the Unit value.
    */
-  final def scriptDebug(mode: DebugMode): IO[RedisError, Unit] = {
+  final def scriptDebug(mode: DebugMode): G[Unit] = {
     val command = RedisCommand(ScriptDebug, ScriptDebugInput, UnitOutput, executor)
     command.run(mode)
   }
@@ -101,7 +101,7 @@ trait Scripting extends RedisEnvironment {
    *   for every corresponding SHA1 digest of a script that actually exists in the script cache, an true is returned,
    *   otherwise false is returned.
    */
-  final def scriptExists(sha1: String, sha1s: String*): IO[RedisError, Chunk[Boolean]] = {
+  final def scriptExists(sha1: String, sha1s: String*): G[Chunk[Boolean]] = {
     val command = RedisCommand(ScriptExists, NonEmptyList(StringInput), ChunkOutput(BoolOutput), executor)
     command.run((sha1, sha1s.toList))
   }
@@ -119,7 +119,7 @@ trait Scripting extends RedisEnvironment {
    * @return
    *   the Unit value.
    */
-  final def scriptFlush(mode: Option[FlushMode] = None): IO[RedisError, Unit] = {
+  final def scriptFlush(mode: Option[FlushMode] = None): G[Unit] = {
     val command = RedisCommand(ScriptFlush, OptionalInput(ScriptFlushInput), UnitOutput, executor)
     command.run(mode)
   }
@@ -131,7 +131,7 @@ trait Scripting extends RedisEnvironment {
    * @return
    *   the Unit value.
    */
-  final def scriptKill: IO[RedisError, Unit] = {
+  final def scriptKill: G[Unit] = {
     val command = RedisCommand(ScriptKill, NoInput, UnitOutput, executor)
     command.run(())
   }
@@ -145,7 +145,7 @@ trait Scripting extends RedisEnvironment {
    * @return
    *   the SHA1 digest of the script added into the script cache.
    */
-  final def scriptLoad(script: String): IO[RedisError, String] = {
+  final def scriptLoad(script: String): G[String] = {
     val command = RedisCommand(ScriptLoad, StringInput, MultiStringOutput, executor)
     command.run(script)
   }

--- a/modules/redis/src/main/scala/zio/redis/api/Sets.scala
+++ b/modules/redis/src/main/scala/zio/redis/api/Sets.scala
@@ -43,7 +43,7 @@ trait Sets[G[+_]] extends RedisEnvironment[G] {
   final def sAdd[K: Schema, M: Schema](key: K, member: M, members: M*): G[Long] = {
     val command =
       RedisCommand(SAdd, Tuple2(ArbitraryKeyInput[K](), NonEmptyList(ArbitraryValueInput[M]())), LongOutput)
-    runCommand(command, (key, (member, members.toList)))
+    command.run((key, (member, members.toList)))
   }
 
   /**
@@ -56,7 +56,7 @@ trait Sets[G[+_]] extends RedisEnvironment[G] {
    */
   final def sCard[K: Schema](key: K): G[Long] = {
     val command = RedisCommand(SCard, ArbitraryKeyInput[K](), LongOutput)
-    runCommand(command, key)
+    command.run(key)
   }
 
   /**
@@ -72,10 +72,8 @@ trait Sets[G[+_]] extends RedisEnvironment[G] {
   final def sDiff[K: Schema](key: K, keys: K*): ResultBuilder1[Chunk, G] =
     new ResultBuilder1[Chunk, G] {
       def returning[R: Schema]: G[Chunk[R]] =
-        runCommand(
-          RedisCommand(SDiff, NonEmptyList(ArbitraryKeyInput[K]()), ChunkOutput(ArbitraryOutput[R]())),
-          (key, keys.toList)
-        )
+        RedisCommand(SDiff, NonEmptyList(ArbitraryKeyInput[K]()), ChunkOutput(ArbitraryOutput[R]()))
+          .run((key, keys.toList))
     }
 
   /**
@@ -96,7 +94,7 @@ trait Sets[G[+_]] extends RedisEnvironment[G] {
       Tuple2(ArbitraryValueInput[D](), NonEmptyList(ArbitraryKeyInput[K]())),
       LongOutput
     )
-    runCommand(command, (destination, (key, keys.toList)))
+    command.run((destination, (key, keys.toList)))
   }
 
   /**
@@ -112,10 +110,8 @@ trait Sets[G[+_]] extends RedisEnvironment[G] {
   final def sInter[K: Schema](destination: K, keys: K*): ResultBuilder1[Chunk, G] =
     new ResultBuilder1[Chunk, G] {
       def returning[R: Schema]: G[Chunk[R]] =
-        runCommand(
-          RedisCommand(SInter, NonEmptyList(ArbitraryKeyInput[K]()), ChunkOutput(ArbitraryOutput[R]())),
-          (destination, keys.toList)
-        )
+        RedisCommand(SInter, NonEmptyList(ArbitraryKeyInput[K]()), ChunkOutput(ArbitraryOutput[R]()))
+          .run((destination, keys.toList))
     }
 
   /**
@@ -140,7 +136,7 @@ trait Sets[G[+_]] extends RedisEnvironment[G] {
       Tuple2(ArbitraryValueInput[D](), NonEmptyList(ArbitraryKeyInput[K]())),
       LongOutput
     )
-    runCommand(command, (destination, (key, keys.toList)))
+    command.run((destination, (key, keys.toList)))
   }
 
   /**
@@ -157,7 +153,7 @@ trait Sets[G[+_]] extends RedisEnvironment[G] {
   final def sIsMember[K: Schema, M: Schema](key: K, member: M): G[Boolean] = {
     val command =
       RedisCommand(SIsMember, Tuple2(ArbitraryKeyInput[K](), ArbitraryValueInput[M]()), BoolOutput)
-    runCommand(command, (key, member))
+    command.run((key, member))
   }
 
   /**
@@ -171,7 +167,7 @@ trait Sets[G[+_]] extends RedisEnvironment[G] {
   final def sMembers[K: Schema](key: K): ResultBuilder1[Chunk, G] =
     new ResultBuilder1[Chunk, G] {
       def returning[R: Schema]: G[Chunk[R]] =
-        runCommand(RedisCommand(SMembers, ArbitraryKeyInput[K](), ChunkOutput(ArbitraryOutput[R]())), key)
+        RedisCommand(SMembers, ArbitraryKeyInput[K](), ChunkOutput(ArbitraryOutput[R]())).run(key)
     }
 
   /**
@@ -196,7 +192,7 @@ trait Sets[G[+_]] extends RedisEnvironment[G] {
       Tuple3(ArbitraryValueInput[S](), ArbitraryValueInput[D](), ArbitraryValueInput[M]()),
       BoolOutput
     )
-    runCommand(command, (source, destination, member))
+    command.run((source, destination, member))
   }
 
   /**
@@ -217,7 +213,7 @@ trait Sets[G[+_]] extends RedisEnvironment[G] {
           Tuple2(ArbitraryKeyInput[K](), OptionalInput(LongInput)),
           MultiStringChunkOutput(ArbitraryOutput[R]())
         )
-        runCommand(command, (key, count))
+        command.run((key, count))
       }
     }
 
@@ -239,7 +235,7 @@ trait Sets[G[+_]] extends RedisEnvironment[G] {
           Tuple2(ArbitraryKeyInput[K](), OptionalInput(LongInput)),
           MultiStringChunkOutput(ArbitraryOutput[R]())
         )
-        runCommand(command, (key, count))
+        command.run((key, count))
       }
     }
 
@@ -258,7 +254,7 @@ trait Sets[G[+_]] extends RedisEnvironment[G] {
   final def sRem[K: Schema, M: Schema](key: K, member: M, members: M*): G[Long] = {
     val command =
       RedisCommand(SRem, Tuple2(ArbitraryKeyInput[K](), NonEmptyList(ArbitraryValueInput[M]())), LongOutput)
-    runCommand(command, (key, (member, members.toList)))
+    command.run((key, (member, members.toList)))
   }
 
   /**
@@ -291,7 +287,7 @@ trait Sets[G[+_]] extends RedisEnvironment[G] {
           Tuple4(ArbitraryKeyInput[K](), LongInput, OptionalInput(PatternInput), OptionalInput(CountInput)),
           Tuple2Output(MultiStringOutput.map(_.toLong), ChunkOutput(ArbitraryOutput[R]()))
         )
-        runCommand(command, (key, cursor, pattern.map(Pattern(_)), count))
+        command.run((key, cursor, pattern.map(Pattern(_)), count))
       }
     }
 
@@ -308,10 +304,8 @@ trait Sets[G[+_]] extends RedisEnvironment[G] {
   final def sUnion[K: Schema](key: K, keys: K*): ResultBuilder1[Chunk, G] =
     new ResultBuilder1[Chunk, G] {
       def returning[R: Schema]: G[Chunk[R]] =
-        runCommand(
-          RedisCommand(SUnion, NonEmptyList(ArbitraryKeyInput[K]()), ChunkOutput(ArbitraryOutput[R]())),
-          (key, keys.toList)
-        )
+        RedisCommand(SUnion, NonEmptyList(ArbitraryKeyInput[K]()), ChunkOutput(ArbitraryOutput[R]()))
+          .run((key, keys.toList))
     }
 
   /**
@@ -336,7 +330,7 @@ trait Sets[G[+_]] extends RedisEnvironment[G] {
       Tuple2(ArbitraryValueInput[D](), NonEmptyList(ArbitraryKeyInput[K]())),
       LongOutput
     )
-    runCommand(command, (destination, (key, keys.toList)))
+    command.run((destination, (key, keys.toList)))
   }
 }
 

--- a/modules/redis/src/main/scala/zio/redis/api/Sets.scala
+++ b/modules/redis/src/main/scala/zio/redis/api/Sets.scala
@@ -42,8 +42,8 @@ trait Sets[G[+_]] extends RedisEnvironment[G] {
    */
   final def sAdd[K: Schema, M: Schema](key: K, member: M, members: M*): G[Long] = {
     val command =
-      RedisCommand(SAdd, Tuple2(ArbitraryKeyInput[K](), NonEmptyList(ArbitraryValueInput[M]())), LongOutput, executor)
-    command.run((key, (member, members.toList)))
+      RedisCommand(SAdd, Tuple2(ArbitraryKeyInput[K](), NonEmptyList(ArbitraryValueInput[M]())), LongOutput)
+    runCommand(command, (key, (member, members.toList)))
   }
 
   /**
@@ -55,8 +55,8 @@ trait Sets[G[+_]] extends RedisEnvironment[G] {
    *   Returns the cardinality (number of elements) of the set, or 0 if key does not exist.
    */
   final def sCard[K: Schema](key: K): G[Long] = {
-    val command = RedisCommand(SCard, ArbitraryKeyInput[K](), LongOutput, executor)
-    command.run(key)
+    val command = RedisCommand(SCard, ArbitraryKeyInput[K](), LongOutput)
+    runCommand(command, key)
   }
 
   /**
@@ -72,8 +72,10 @@ trait Sets[G[+_]] extends RedisEnvironment[G] {
   final def sDiff[K: Schema](key: K, keys: K*): ResultBuilder1[Chunk, G] =
     new ResultBuilder1[Chunk, G] {
       def returning[R: Schema]: G[Chunk[R]] =
-        RedisCommand(SDiff, NonEmptyList(ArbitraryKeyInput[K]()), ChunkOutput(ArbitraryOutput[R]()), executor)
-          .run((key, keys.toList))
+        runCommand(
+          RedisCommand(SDiff, NonEmptyList(ArbitraryKeyInput[K]()), ChunkOutput(ArbitraryOutput[R]())),
+          (key, keys.toList)
+        )
     }
 
   /**
@@ -92,10 +94,9 @@ trait Sets[G[+_]] extends RedisEnvironment[G] {
     val command = RedisCommand(
       SDiffStore,
       Tuple2(ArbitraryValueInput[D](), NonEmptyList(ArbitraryKeyInput[K]())),
-      LongOutput,
-      executor
+      LongOutput
     )
-    command.run((destination, (key, keys.toList)))
+    runCommand(command, (destination, (key, keys.toList)))
   }
 
   /**
@@ -111,8 +112,10 @@ trait Sets[G[+_]] extends RedisEnvironment[G] {
   final def sInter[K: Schema](destination: K, keys: K*): ResultBuilder1[Chunk, G] =
     new ResultBuilder1[Chunk, G] {
       def returning[R: Schema]: G[Chunk[R]] =
-        RedisCommand(SInter, NonEmptyList(ArbitraryKeyInput[K]()), ChunkOutput(ArbitraryOutput[R]()), executor)
-          .run((destination, keys.toList))
+        runCommand(
+          RedisCommand(SInter, NonEmptyList(ArbitraryKeyInput[K]()), ChunkOutput(ArbitraryOutput[R]())),
+          (destination, keys.toList)
+        )
     }
 
   /**
@@ -135,10 +138,9 @@ trait Sets[G[+_]] extends RedisEnvironment[G] {
     val command = RedisCommand(
       SInterStore,
       Tuple2(ArbitraryValueInput[D](), NonEmptyList(ArbitraryKeyInput[K]())),
-      LongOutput,
-      executor
+      LongOutput
     )
-    command.run((destination, (key, keys.toList)))
+    runCommand(command, (destination, (key, keys.toList)))
   }
 
   /**
@@ -154,8 +156,8 @@ trait Sets[G[+_]] extends RedisEnvironment[G] {
    */
   final def sIsMember[K: Schema, M: Schema](key: K, member: M): G[Boolean] = {
     val command =
-      RedisCommand(SIsMember, Tuple2(ArbitraryKeyInput[K](), ArbitraryValueInput[M]()), BoolOutput, executor)
-    command.run((key, member))
+      RedisCommand(SIsMember, Tuple2(ArbitraryKeyInput[K](), ArbitraryValueInput[M]()), BoolOutput)
+    runCommand(command, (key, member))
   }
 
   /**
@@ -169,7 +171,7 @@ trait Sets[G[+_]] extends RedisEnvironment[G] {
   final def sMembers[K: Schema](key: K): ResultBuilder1[Chunk, G] =
     new ResultBuilder1[Chunk, G] {
       def returning[R: Schema]: G[Chunk[R]] =
-        RedisCommand(SMembers, ArbitraryKeyInput[K](), ChunkOutput(ArbitraryOutput[R]()), executor).run(key)
+        runCommand(RedisCommand(SMembers, ArbitraryKeyInput[K](), ChunkOutput(ArbitraryOutput[R]())), key)
     }
 
   /**
@@ -192,10 +194,9 @@ trait Sets[G[+_]] extends RedisEnvironment[G] {
     val command = RedisCommand(
       SMove,
       Tuple3(ArbitraryValueInput[S](), ArbitraryValueInput[D](), ArbitraryValueInput[M]()),
-      BoolOutput,
-      executor
+      BoolOutput
     )
-    command.run((source, destination, member))
+    runCommand(command, (source, destination, member))
   }
 
   /**
@@ -214,10 +215,9 @@ trait Sets[G[+_]] extends RedisEnvironment[G] {
         val command = RedisCommand(
           SPop,
           Tuple2(ArbitraryKeyInput[K](), OptionalInput(LongInput)),
-          MultiStringChunkOutput(ArbitraryOutput[R]()),
-          executor
+          MultiStringChunkOutput(ArbitraryOutput[R]())
         )
-        command.run((key, count))
+        runCommand(command, (key, count))
       }
     }
 
@@ -237,10 +237,9 @@ trait Sets[G[+_]] extends RedisEnvironment[G] {
         val command = RedisCommand(
           SRandMember,
           Tuple2(ArbitraryKeyInput[K](), OptionalInput(LongInput)),
-          MultiStringChunkOutput(ArbitraryOutput[R]()),
-          executor
+          MultiStringChunkOutput(ArbitraryOutput[R]())
         )
-        command.run((key, count))
+        runCommand(command, (key, count))
       }
     }
 
@@ -258,8 +257,8 @@ trait Sets[G[+_]] extends RedisEnvironment[G] {
    */
   final def sRem[K: Schema, M: Schema](key: K, member: M, members: M*): G[Long] = {
     val command =
-      RedisCommand(SRem, Tuple2(ArbitraryKeyInput[K](), NonEmptyList(ArbitraryValueInput[M]())), LongOutput, executor)
-    command.run((key, (member, members.toList)))
+      RedisCommand(SRem, Tuple2(ArbitraryKeyInput[K](), NonEmptyList(ArbitraryValueInput[M]())), LongOutput)
+    runCommand(command, (key, (member, members.toList)))
   }
 
   /**
@@ -290,10 +289,9 @@ trait Sets[G[+_]] extends RedisEnvironment[G] {
         val command = RedisCommand(
           SScan,
           Tuple4(ArbitraryKeyInput[K](), LongInput, OptionalInput(PatternInput), OptionalInput(CountInput)),
-          Tuple2Output(MultiStringOutput.map(_.toLong), ChunkOutput(ArbitraryOutput[R]())),
-          executor
+          Tuple2Output(MultiStringOutput.map(_.toLong), ChunkOutput(ArbitraryOutput[R]()))
         )
-        command.run((key, cursor, pattern.map(Pattern(_)), count))
+        runCommand(command, (key, cursor, pattern.map(Pattern(_)), count))
       }
     }
 
@@ -310,8 +308,10 @@ trait Sets[G[+_]] extends RedisEnvironment[G] {
   final def sUnion[K: Schema](key: K, keys: K*): ResultBuilder1[Chunk, G] =
     new ResultBuilder1[Chunk, G] {
       def returning[R: Schema]: G[Chunk[R]] =
-        RedisCommand(SUnion, NonEmptyList(ArbitraryKeyInput[K]()), ChunkOutput(ArbitraryOutput[R]()), executor)
-          .run((key, keys.toList))
+        runCommand(
+          RedisCommand(SUnion, NonEmptyList(ArbitraryKeyInput[K]()), ChunkOutput(ArbitraryOutput[R]())),
+          (key, keys.toList)
+        )
     }
 
   /**
@@ -334,10 +334,9 @@ trait Sets[G[+_]] extends RedisEnvironment[G] {
     val command = RedisCommand(
       SUnionStore,
       Tuple2(ArbitraryValueInput[D](), NonEmptyList(ArbitraryKeyInput[K]())),
-      LongOutput,
-      executor
+      LongOutput
     )
-    command.run((destination, (key, keys.toList)))
+    runCommand(command, (destination, (key, keys.toList)))
   }
 }
 

--- a/modules/redis/src/main/scala/zio/redis/api/SortedSets.scala
+++ b/modules/redis/src/main/scala/zio/redis/api/SortedSets.scala
@@ -60,7 +60,7 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
             OptionalOutput(memberScoreOutput)
           )
 
-        runCommand(command, ((key, keys.toList), timeout))
+        command.run(((key, keys.toList), timeout))
       }
     }
 
@@ -97,7 +97,7 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
             OptionalOutput(memberScoreOutput)
           )
 
-        runCommand(command, ((key, keys.toList), timeout))
+        command.run(((key, keys.toList), timeout))
       }
     }
 
@@ -132,7 +132,7 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
       ),
       LongOutput
     )
-    runCommand(command, (key, update, change, (memberScore, memberScores.toList)))
+    command.run((key, update, change, (memberScore, memberScores.toList)))
   }
 
   /**
@@ -170,7 +170,7 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
       ),
       OptionalOutput(DoubleOutput)
     )
-    runCommand(command, (key, update, change, increment, (memberScore, memberScores.toList)))
+    command.run((key, update, change, increment, (memberScore, memberScores.toList)))
   }
 
   /**
@@ -183,7 +183,7 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
    */
   final def zCard[K: Schema](key: K): G[Long] = {
     val command = RedisCommand(ZCard, ArbitraryKeyInput[K](), LongOutput)
-    runCommand(command, key)
+    command.run(key)
   }
 
   /**
@@ -198,7 +198,7 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
    */
   final def zCount[K: Schema](key: K, range: Range): G[Long] = {
     val command = RedisCommand(ZCount, Tuple2(ArbitraryKeyInput[K](), RangeInput), LongOutput)
-    runCommand(command, (key, range))
+    command.run((key, range))
   }
 
   /**
@@ -223,7 +223,7 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
             ),
             ChunkOutput(ArbitraryOutput[M]())
           )
-        runCommand(command, (keys.size + 1, (key, keys.toList)))
+        command.run((keys.size + 1, (key, keys.toList)))
       }
     }
 
@@ -251,7 +251,7 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
             ChunkTuple2Output(ArbitraryOutput[M](), DoubleOutput)
               .map(_.map { case (m, s) => MemberScore(m, s) })
           )
-        runCommand(command, (keys.size + 1, (key, keys.toList), WithScores))
+        command.run((keys.size + 1, (key, keys.toList), WithScores))
       }
     }
 
@@ -278,7 +278,7 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
         ),
         LongOutput
       )
-    runCommand(command, (destination, keys.size + 1, (key, keys.toList)))
+    command.run((destination, keys.size + 1, (key, keys.toList)))
   }
 
   /**
@@ -296,7 +296,7 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
   final def zIncrBy[K: Schema, M: Schema](key: K, increment: Long, member: M): G[Double] = {
     val command =
       RedisCommand(ZIncrBy, Tuple3(ArbitraryKeyInput[K](), LongInput, ArbitraryValueInput[M]()), DoubleOutput)
-    runCommand(command, (key, increment, member))
+    command.run((key, increment, member))
   }
 
   /**
@@ -331,7 +331,7 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
           ),
           ChunkOutput(ArbitraryOutput[M]())
         )
-        runCommand(command, (keys.size + 1, (key, keys.toList), aggregate, weights))
+        command.run((keys.size + 1, (key, keys.toList), aggregate, weights))
       }
     }
 
@@ -369,7 +369,7 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
           ChunkTuple2Output(ArbitraryOutput[M](), DoubleOutput)
             .map(_.map { case (m, s) => MemberScore(m, s) })
         )
-        runCommand(command, (keys.size + 1, (key, keys.toList), aggregate, weights, WithScores))
+        command.run((keys.size + 1, (key, keys.toList), aggregate, weights, WithScores))
       }
     }
 
@@ -406,7 +406,7 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
       ),
       LongOutput
     )
-    runCommand(command, (destination, keys.size + 1, (key, keys.toList), aggregate, weights))
+    command.run((destination, keys.size + 1, (key, keys.toList), aggregate, weights))
   }
 
   /**
@@ -425,7 +425,7 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
       Tuple3(ArbitraryKeyInput[K](), ArbitraryValueInput[String](), ArbitraryValueInput[String]()),
       LongOutput
     )
-    runCommand(command, (key, lexRange.min.asString, lexRange.max.asString))
+    command.run((key, lexRange.min.asString, lexRange.max.asString))
   }
 
   /**
@@ -441,7 +441,7 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
   final def zMScore[K: Schema](key: K, keys: K*): G[Chunk[Option[Double]]] = {
     val command =
       RedisCommand(ZMScore, NonEmptyList(ArbitraryKeyInput[K]()), ChunkOutput(OptionalOutput(DoubleOutput)))
-    runCommand(command, (key, keys.toList))
+    command.run((key, keys.toList))
   }
 
   /**
@@ -465,7 +465,7 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
           ChunkTuple2Output(ArbitraryOutput[M](), DoubleOutput)
             .map(_.map { case (m, s) => MemberScore(m, s) })
         )
-        runCommand(command, (key, count))
+        command.run((key, count))
       }
     }
 
@@ -490,7 +490,7 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
           ChunkTuple2Output(ArbitraryOutput[M](), DoubleOutput)
             .map(_.map { case (m, s) => MemberScore(m, s) })
         )
-        runCommand(command, (key, count))
+        command.run((key, count))
       }
     }
 
@@ -505,7 +505,7 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
   final def zRandMember[K: Schema](key: K): ResultBuilder1[Option, G] =
     new ResultBuilder1[Option, G] {
       def returning[R: Schema]: G[Option[R]] =
-        runCommand(RedisCommand(ZRandMember, ArbitraryKeyInput[K](), OptionalOutput(ArbitraryOutput[R]())), key)
+        RedisCommand(ZRandMember, ArbitraryKeyInput[K](), OptionalOutput(ArbitraryOutput[R]())).run(key)
     }
 
   /**
@@ -527,7 +527,7 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
           Tuple2(ArbitraryKeyInput[K](), LongInput),
           ZRandMemberOutput(ArbitraryOutput[M]())
         )
-        runCommand(command, (key, count))
+        command.run((key, count))
       }
     }
 
@@ -554,7 +554,7 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
             .map(_.map { case (m, s) => MemberScore(m, s) })
         )
 
-        runCommand(command, (key, count, WithScores))
+        command.run((key, count, WithScores))
       }
     }
 
@@ -573,7 +573,7 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
       def returning[M: Schema]: G[Chunk[M]] = {
         val command =
           RedisCommand(ZRange, Tuple2(ArbitraryKeyInput[K](), RangeInput), ChunkOutput(ArbitraryOutput[M]()))
-        runCommand(command, (key, range))
+        command.run((key, range))
       }
     }
 
@@ -596,7 +596,7 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
           ChunkTuple2Output(ArbitraryOutput[M](), DoubleOutput)
             .map(_.map { case (m, s) => MemberScore(m, s) })
         )
-        runCommand(command, (key, range, WithScores))
+        command.run((key, range, WithScores))
       }
     }
 
@@ -626,7 +626,7 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
           ),
           ChunkOutput(ArbitraryOutput[M]())
         )
-        runCommand(command, (key, lexRange.min.asString, lexRange.max.asString, limit))
+        command.run((key, lexRange.min.asString, lexRange.max.asString, limit))
       }
     }
 
@@ -660,7 +660,7 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
           ),
           ChunkOutput(ArbitraryOutput[M]())
         )
-        runCommand(command, (key, scoreRange.min.asString, scoreRange.max.asString, limit))
+        command.run((key, scoreRange.min.asString, scoreRange.max.asString, limit))
       }
     }
 
@@ -696,7 +696,7 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
           ChunkTuple2Output(ArbitraryOutput[M](), DoubleOutput)
             .map(_.map { case (m, s) => MemberScore(m, s) })
         )
-        runCommand(command, (key, scoreRange.min.asString, scoreRange.max.asString, WithScores, limit))
+        command.run((key, scoreRange.min.asString, scoreRange.max.asString, WithScores, limit))
       }
     }
 
@@ -717,7 +717,7 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
         Tuple2(ArbitraryKeyInput[K](), ArbitraryValueInput[M]()),
         OptionalOutput(LongOutput)
       )
-    runCommand(command, (key, member))
+    command.run((key, member))
   }
 
   /**
@@ -737,7 +737,7 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
         Tuple3(ArbitraryKeyInput[K](), ArbitraryValueInput[M](), WithScoreInput),
         OptionalOutput(Tuple2Output(LongOutput, DoubleOutput).map { case (r, s) => RankScore(r, s) })
       )
-    runCommand(command, (key, member, WithScore))
+    command.run((key, member, WithScore))
   }
 
   /**
@@ -755,7 +755,7 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
   final def zRem[K: Schema, M: Schema](key: K, member: M, members: M*): G[Long] = {
     val command =
       RedisCommand(ZRem, Tuple2(ArbitraryKeyInput[K](), NonEmptyList(ArbitraryValueInput[M]())), LongOutput)
-    runCommand(command, (key, (member, members.toList)))
+    command.run((key, (member, members.toList)))
   }
 
   /**
@@ -774,7 +774,7 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
       Tuple3(ArbitraryKeyInput[K](), ArbitraryValueInput[String](), ArbitraryValueInput[String]()),
       LongOutput
     )
-    runCommand(command, (key, lexRange.min.asString, lexRange.max.asString))
+    command.run((key, lexRange.min.asString, lexRange.max.asString))
   }
 
   /**
@@ -789,7 +789,7 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
    */
   final def zRemRangeByRank[K: Schema](key: K, range: Range): G[Long] = {
     val command = RedisCommand(ZRemRangeByRank, Tuple2(ArbitraryKeyInput[K](), RangeInput), LongOutput)
-    runCommand(command, (key, range))
+    command.run((key, range))
   }
 
   /**
@@ -808,7 +808,7 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
       Tuple3(ArbitraryKeyInput[K](), ArbitraryValueInput[String](), ArbitraryValueInput[String]()),
       LongOutput
     )
-    runCommand(command, (key, scoreRange.min.asString, scoreRange.max.asString))
+    command.run((key, scoreRange.min.asString, scoreRange.max.asString))
   }
 
   /**
@@ -829,7 +829,7 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
           Tuple2(ArbitraryKeyInput[K](), RangeInput),
           ChunkOutput(ArbitraryOutput[M]())
         )
-        runCommand(command, (key, range))
+        command.run((key, range))
       }
     }
 
@@ -852,7 +852,7 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
           ChunkTuple2Output(ArbitraryOutput[M](), DoubleOutput)
             .map(_.map { case (m, s) => MemberScore(m, s) })
         )
-        runCommand(command, (key, range, WithScores))
+        command.run((key, range, WithScores))
       }
     }
 
@@ -886,7 +886,7 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
           ),
           ChunkOutput(ArbitraryOutput[M]())
         )
-        runCommand(command, (key, lexRange.max.asString, lexRange.min.asString, limit))
+        command.run((key, lexRange.max.asString, lexRange.min.asString, limit))
       }
     }
 
@@ -920,7 +920,7 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
           ),
           ChunkOutput(ArbitraryOutput[M]())
         )
-        runCommand(command, (key, scoreRange.max.asString, scoreRange.min.asString, limit))
+        command.run((key, scoreRange.max.asString, scoreRange.min.asString, limit))
       }
     }
 
@@ -956,7 +956,7 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
           ChunkTuple2Output(ArbitraryOutput[M](), DoubleOutput)
             .map(_.map { case (m, s) => MemberScore(m, s) })
         )
-        runCommand(command, (key, scoreRange.max.asString, scoreRange.min.asString, WithScores, limit))
+        command.run((key, scoreRange.max.asString, scoreRange.min.asString, WithScores, limit))
       }
     }
 
@@ -976,7 +976,7 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
       Tuple2(ArbitraryKeyInput[K](), ArbitraryValueInput[M]()),
       OptionalOutput(LongOutput)
     )
-    runCommand(command, (key, member))
+    command.run((key, member))
   }
 
   /**
@@ -995,7 +995,7 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
       Tuple3(ArbitraryKeyInput[K](), ArbitraryValueInput[M](), WithScoreInput),
       OptionalOutput(Tuple2Output(LongOutput, DoubleOutput).map { case (r, s) => RankScore(r, s) })
     )
-    runCommand(command, (key, member, WithScore))
+    command.run((key, member, WithScore))
   }
 
   /**
@@ -1030,7 +1030,7 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
             Tuple2Output(MultiStringOutput.map(_.toLong), memberScoresOutput)
           )
 
-        runCommand(command, (key, cursor, pattern.map(Pattern(_)), count))
+        command.run((key, cursor, pattern.map(Pattern(_)), count))
       }
     }
 
@@ -1050,7 +1050,7 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
       Tuple2(ArbitraryKeyInput[K](), ArbitraryValueInput[M]()),
       OptionalOutput(DoubleOutput)
     )
-    runCommand(command, (key, member))
+    command.run((key, member))
   }
 
   /**
@@ -1086,7 +1086,7 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
             ),
             ChunkOutput(ArbitraryOutput[M]())
           )
-        runCommand(command, (keys.size + 1, (key, keys.toList), weights, aggregate))
+        command.run((keys.size + 1, (key, keys.toList), weights, aggregate))
       }
     }
 
@@ -1125,7 +1125,7 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
             ChunkTuple2Output(ArbitraryOutput[M](), DoubleOutput)
               .map(_.map { case (m, s) => MemberScore(m, s) })
           )
-        runCommand(command, (keys.size + 1, (key, keys.toList), weights, aggregate, WithScores))
+        command.run((keys.size + 1, (key, keys.toList), weights, aggregate, WithScores))
       }
     }
 
@@ -1162,7 +1162,7 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
       ),
       LongOutput
     )
-    runCommand(command, (destination, keys.size + 1, (key, keys.toList), weights, aggregate))
+    command.run((destination, keys.size + 1, (key, keys.toList), weights, aggregate))
   }
 }
 

--- a/modules/redis/src/main/scala/zio/redis/api/SortedSets.scala
+++ b/modules/redis/src/main/scala/zio/redis/api/SortedSets.scala
@@ -895,7 +895,11 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
    * @return
    *   Chunk of elements in the specified score range.
    */
-  final def zRevRangeByLex[K: Schema](key: K, lexRange: LexRange, limit: Option[Limit] = None): ResultBuilder1[Chunk, G] =
+  final def zRevRangeByLex[K: Schema](
+    key: K,
+    lexRange: LexRange,
+    limit: Option[Limit] = None
+  ): ResultBuilder1[Chunk, G] =
     new ResultBuilder1[Chunk, G] {
       def returning[M: Schema]: G[Chunk[M]] = {
         val command = RedisCommand(

--- a/modules/redis/src/main/scala/zio/redis/api/SortedSets.scala
+++ b/modules/redis/src/main/scala/zio/redis/api/SortedSets.scala
@@ -57,11 +57,10 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
           RedisCommand(
             BzPopMax,
             Tuple2(NonEmptyList(ArbitraryKeyInput[K]()), DurationSecondsInput),
-            OptionalOutput(memberScoreOutput),
-            executor
+            OptionalOutput(memberScoreOutput)
           )
 
-        command.run(((key, keys.toList), timeout))
+        runCommand(command, ((key, keys.toList), timeout))
       }
     }
 
@@ -95,11 +94,10 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
           RedisCommand(
             BzPopMin,
             Tuple2(NonEmptyList(ArbitraryKeyInput[K]()), DurationSecondsInput),
-            OptionalOutput(memberScoreOutput),
-            executor
+            OptionalOutput(memberScoreOutput)
           )
 
-        command.run(((key, keys.toList), timeout))
+        runCommand(command, ((key, keys.toList), timeout))
       }
     }
 
@@ -132,10 +130,9 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
         OptionalInput(ChangedInput),
         NonEmptyList(MemberScoreInput[M]())
       ),
-      LongOutput,
-      executor
+      LongOutput
     )
-    command.run((key, update, change, (memberScore, memberScores.toList)))
+    runCommand(command, (key, update, change, (memberScore, memberScores.toList)))
   }
 
   /**
@@ -171,10 +168,9 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
         IncrementInput,
         NonEmptyList(MemberScoreInput[M]())
       ),
-      OptionalOutput(DoubleOutput),
-      executor
+      OptionalOutput(DoubleOutput)
     )
-    command.run((key, update, change, increment, (memberScore, memberScores.toList)))
+    runCommand(command, (key, update, change, increment, (memberScore, memberScores.toList)))
   }
 
   /**
@@ -186,8 +182,8 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
    *   The cardinality (number of elements) of the sorted set, or 0 if key does not exist.
    */
   final def zCard[K: Schema](key: K): G[Long] = {
-    val command = RedisCommand(ZCard, ArbitraryKeyInput[K](), LongOutput, executor)
-    command.run(key)
+    val command = RedisCommand(ZCard, ArbitraryKeyInput[K](), LongOutput)
+    runCommand(command, key)
   }
 
   /**
@@ -201,8 +197,8 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
    *   the number of elements in the specified score range.
    */
   final def zCount[K: Schema](key: K, range: Range): G[Long] = {
-    val command = RedisCommand(ZCount, Tuple2(ArbitraryKeyInput[K](), RangeInput), LongOutput, executor)
-    command.run((key, range))
+    val command = RedisCommand(ZCount, Tuple2(ArbitraryKeyInput[K](), RangeInput), LongOutput)
+    runCommand(command, (key, range))
   }
 
   /**
@@ -225,10 +221,9 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
               IntInput,
               NonEmptyList(ArbitraryKeyInput[K]())
             ),
-            ChunkOutput(ArbitraryOutput[M]()),
-            executor
+            ChunkOutput(ArbitraryOutput[M]())
           )
-        command.run((keys.size + 1, (key, keys.toList)))
+        runCommand(command, (keys.size + 1, (key, keys.toList)))
       }
     }
 
@@ -254,10 +249,9 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
               WithScoresInput
             ),
             ChunkTuple2Output(ArbitraryOutput[M](), DoubleOutput)
-              .map(_.map { case (m, s) => MemberScore(m, s) }),
-            executor
+              .map(_.map { case (m, s) => MemberScore(m, s) })
           )
-        command.run((keys.size + 1, (key, keys.toList), WithScores))
+        runCommand(command, (keys.size + 1, (key, keys.toList), WithScores))
       }
     }
 
@@ -282,10 +276,9 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
           IntInput,
           NonEmptyList(ArbitraryKeyInput[K]())
         ),
-        LongOutput,
-        executor
+        LongOutput
       )
-    command.run((destination, keys.size + 1, (key, keys.toList)))
+    runCommand(command, (destination, keys.size + 1, (key, keys.toList)))
   }
 
   /**
@@ -302,8 +295,8 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
    */
   final def zIncrBy[K: Schema, M: Schema](key: K, increment: Long, member: M): G[Double] = {
     val command =
-      RedisCommand(ZIncrBy, Tuple3(ArbitraryKeyInput[K](), LongInput, ArbitraryValueInput[M]()), DoubleOutput, executor)
-    command.run((key, increment, member))
+      RedisCommand(ZIncrBy, Tuple3(ArbitraryKeyInput[K](), LongInput, ArbitraryValueInput[M]()), DoubleOutput)
+    runCommand(command, (key, increment, member))
   }
 
   /**
@@ -336,10 +329,9 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
             OptionalInput(AggregateInput),
             OptionalInput(WeightsInput)
           ),
-          ChunkOutput(ArbitraryOutput[M]()),
-          executor
+          ChunkOutput(ArbitraryOutput[M]())
         )
-        command.run((keys.size + 1, (key, keys.toList), aggregate, weights))
+        runCommand(command, (keys.size + 1, (key, keys.toList), aggregate, weights))
       }
     }
 
@@ -375,10 +367,9 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
             WithScoresInput
           ),
           ChunkTuple2Output(ArbitraryOutput[M](), DoubleOutput)
-            .map(_.map { case (m, s) => MemberScore(m, s) }),
-          executor
+            .map(_.map { case (m, s) => MemberScore(m, s) })
         )
-        command.run((keys.size + 1, (key, keys.toList), aggregate, weights, WithScores))
+        runCommand(command, (keys.size + 1, (key, keys.toList), aggregate, weights, WithScores))
       }
     }
 
@@ -413,10 +404,9 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
         OptionalInput(AggregateInput),
         OptionalInput(WeightsInput)
       ),
-      LongOutput,
-      executor
+      LongOutput
     )
-    command.run((destination, keys.size + 1, (key, keys.toList), aggregate, weights))
+    runCommand(command, (destination, keys.size + 1, (key, keys.toList), aggregate, weights))
   }
 
   /**
@@ -433,10 +423,9 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
     val command = RedisCommand(
       ZLexCount,
       Tuple3(ArbitraryKeyInput[K](), ArbitraryValueInput[String](), ArbitraryValueInput[String]()),
-      LongOutput,
-      executor
+      LongOutput
     )
-    command.run((key, lexRange.min.asString, lexRange.max.asString))
+    runCommand(command, (key, lexRange.min.asString, lexRange.max.asString))
   }
 
   /**
@@ -451,8 +440,8 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
    */
   final def zMScore[K: Schema](key: K, keys: K*): G[Chunk[Option[Double]]] = {
     val command =
-      RedisCommand(ZMScore, NonEmptyList(ArbitraryKeyInput[K]()), ChunkOutput(OptionalOutput(DoubleOutput)), executor)
-    command.run((key, keys.toList))
+      RedisCommand(ZMScore, NonEmptyList(ArbitraryKeyInput[K]()), ChunkOutput(OptionalOutput(DoubleOutput)))
+    runCommand(command, (key, keys.toList))
   }
 
   /**
@@ -474,10 +463,9 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
           ZPopMax,
           Tuple2(ArbitraryKeyInput[K](), OptionalInput(LongInput)),
           ChunkTuple2Output(ArbitraryOutput[M](), DoubleOutput)
-            .map(_.map { case (m, s) => MemberScore(m, s) }),
-          executor
+            .map(_.map { case (m, s) => MemberScore(m, s) })
         )
-        command.run((key, count))
+        runCommand(command, (key, count))
       }
     }
 
@@ -500,10 +488,9 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
           ZPopMin,
           Tuple2(ArbitraryKeyInput[K](), OptionalInput(LongInput)),
           ChunkTuple2Output(ArbitraryOutput[M](), DoubleOutput)
-            .map(_.map { case (m, s) => MemberScore(m, s) }),
-          executor
+            .map(_.map { case (m, s) => MemberScore(m, s) })
         )
-        command.run((key, count))
+        runCommand(command, (key, count))
       }
     }
 
@@ -518,8 +505,7 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
   final def zRandMember[K: Schema](key: K): ResultBuilder1[Option, G] =
     new ResultBuilder1[Option, G] {
       def returning[R: Schema]: G[Option[R]] =
-        RedisCommand(ZRandMember, ArbitraryKeyInput[K](), OptionalOutput(ArbitraryOutput[R]()), executor)
-          .run(key)
+        runCommand(RedisCommand(ZRandMember, ArbitraryKeyInput[K](), OptionalOutput(ArbitraryOutput[R]())), key)
     }
 
   /**
@@ -539,10 +525,9 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
         val command = RedisCommand(
           ZRandMember,
           Tuple2(ArbitraryKeyInput[K](), LongInput),
-          ZRandMemberOutput(ArbitraryOutput[M]()),
-          executor
+          ZRandMemberOutput(ArbitraryOutput[M]())
         )
-        command.run((key, count))
+        runCommand(command, (key, count))
       }
     }
 
@@ -566,11 +551,10 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
           ZRandMember,
           Tuple3(ArbitraryKeyInput[K](), LongInput, WithScoresInput),
           ZRandMemberTuple2Output(ArbitraryOutput[M](), DoubleOutput)
-            .map(_.map { case (m, s) => MemberScore(m, s) }),
-          executor
+            .map(_.map { case (m, s) => MemberScore(m, s) })
         )
 
-        command.run((key, count, WithScores))
+        runCommand(command, (key, count, WithScores))
       }
     }
 
@@ -588,8 +572,8 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
     new ResultBuilder1[Chunk, G] {
       def returning[M: Schema]: G[Chunk[M]] = {
         val command =
-          RedisCommand(ZRange, Tuple2(ArbitraryKeyInput[K](), RangeInput), ChunkOutput(ArbitraryOutput[M]()), executor)
-        command.run((key, range))
+          RedisCommand(ZRange, Tuple2(ArbitraryKeyInput[K](), RangeInput), ChunkOutput(ArbitraryOutput[M]()))
+        runCommand(command, (key, range))
       }
     }
 
@@ -610,10 +594,9 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
           ZRange,
           Tuple3(ArbitraryKeyInput[K](), RangeInput, WithScoresInput),
           ChunkTuple2Output(ArbitraryOutput[M](), DoubleOutput)
-            .map(_.map { case (m, s) => MemberScore(m, s) }),
-          executor
+            .map(_.map { case (m, s) => MemberScore(m, s) })
         )
-        command.run((key, range, WithScores))
+        runCommand(command, (key, range, WithScores))
       }
     }
 
@@ -641,10 +624,9 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
             ArbitraryValueInput[String](),
             OptionalInput(LimitInput)
           ),
-          ChunkOutput(ArbitraryOutput[M]()),
-          executor
+          ChunkOutput(ArbitraryOutput[M]())
         )
-        command.run((key, lexRange.min.asString, lexRange.max.asString, limit))
+        runCommand(command, (key, lexRange.min.asString, lexRange.max.asString, limit))
       }
     }
 
@@ -676,10 +658,9 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
             ArbitraryValueInput[String](),
             OptionalInput(LimitInput)
           ),
-          ChunkOutput(ArbitraryOutput[M]()),
-          executor
+          ChunkOutput(ArbitraryOutput[M]())
         )
-        command.run((key, scoreRange.min.asString, scoreRange.max.asString, limit))
+        runCommand(command, (key, scoreRange.min.asString, scoreRange.max.asString, limit))
       }
     }
 
@@ -713,10 +694,9 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
             OptionalInput(LimitInput)
           ),
           ChunkTuple2Output(ArbitraryOutput[M](), DoubleOutput)
-            .map(_.map { case (m, s) => MemberScore(m, s) }),
-          executor
+            .map(_.map { case (m, s) => MemberScore(m, s) })
         )
-        command.run((key, scoreRange.min.asString, scoreRange.max.asString, WithScores, limit))
+        runCommand(command, (key, scoreRange.min.asString, scoreRange.max.asString, WithScores, limit))
       }
     }
 
@@ -735,10 +715,9 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
       RedisCommand(
         ZRank,
         Tuple2(ArbitraryKeyInput[K](), ArbitraryValueInput[M]()),
-        OptionalOutput(LongOutput),
-        executor
+        OptionalOutput(LongOutput)
       )
-    command.run((key, member))
+    runCommand(command, (key, member))
   }
 
   /**
@@ -756,10 +735,9 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
       RedisCommand(
         ZRank,
         Tuple3(ArbitraryKeyInput[K](), ArbitraryValueInput[M](), WithScoreInput),
-        OptionalOutput(Tuple2Output(LongOutput, DoubleOutput).map { case (r, s) => RankScore(r, s) }),
-        executor
+        OptionalOutput(Tuple2Output(LongOutput, DoubleOutput).map { case (r, s) => RankScore(r, s) })
       )
-    command.run((key, member, WithScore))
+    runCommand(command, (key, member, WithScore))
   }
 
   /**
@@ -776,8 +754,8 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
    */
   final def zRem[K: Schema, M: Schema](key: K, member: M, members: M*): G[Long] = {
     val command =
-      RedisCommand(ZRem, Tuple2(ArbitraryKeyInput[K](), NonEmptyList(ArbitraryValueInput[M]())), LongOutput, executor)
-    command.run((key, (member, members.toList)))
+      RedisCommand(ZRem, Tuple2(ArbitraryKeyInput[K](), NonEmptyList(ArbitraryValueInput[M]())), LongOutput)
+    runCommand(command, (key, (member, members.toList)))
   }
 
   /**
@@ -794,10 +772,9 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
     val command = RedisCommand(
       ZRemRangeByLex,
       Tuple3(ArbitraryKeyInput[K](), ArbitraryValueInput[String](), ArbitraryValueInput[String]()),
-      LongOutput,
-      executor
+      LongOutput
     )
-    command.run((key, lexRange.min.asString, lexRange.max.asString))
+    runCommand(command, (key, lexRange.min.asString, lexRange.max.asString))
   }
 
   /**
@@ -811,8 +788,8 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
    *   The number of elements removed.
    */
   final def zRemRangeByRank[K: Schema](key: K, range: Range): G[Long] = {
-    val command = RedisCommand(ZRemRangeByRank, Tuple2(ArbitraryKeyInput[K](), RangeInput), LongOutput, executor)
-    command.run((key, range))
+    val command = RedisCommand(ZRemRangeByRank, Tuple2(ArbitraryKeyInput[K](), RangeInput), LongOutput)
+    runCommand(command, (key, range))
   }
 
   /**
@@ -829,10 +806,9 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
     val command = RedisCommand(
       ZRemRangeByScore,
       Tuple3(ArbitraryKeyInput[K](), ArbitraryValueInput[String](), ArbitraryValueInput[String]()),
-      LongOutput,
-      executor
+      LongOutput
     )
-    command.run((key, scoreRange.min.asString, scoreRange.max.asString))
+    runCommand(command, (key, scoreRange.min.asString, scoreRange.max.asString))
   }
 
   /**
@@ -851,10 +827,9 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
         val command = RedisCommand(
           ZRevRange,
           Tuple2(ArbitraryKeyInput[K](), RangeInput),
-          ChunkOutput(ArbitraryOutput[M]()),
-          executor
+          ChunkOutput(ArbitraryOutput[M]())
         )
-        command.run((key, range))
+        runCommand(command, (key, range))
       }
     }
 
@@ -875,10 +850,9 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
           ZRevRange,
           Tuple3(ArbitraryKeyInput[K](), RangeInput, WithScoresInput),
           ChunkTuple2Output(ArbitraryOutput[M](), DoubleOutput)
-            .map(_.map { case (m, s) => MemberScore(m, s) }),
-          executor
+            .map(_.map { case (m, s) => MemberScore(m, s) })
         )
-        command.run((key, range, WithScores))
+        runCommand(command, (key, range, WithScores))
       }
     }
 
@@ -910,10 +884,9 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
             ArbitraryValueInput[String](),
             OptionalInput(LimitInput)
           ),
-          ChunkOutput(ArbitraryOutput[M]()),
-          executor
+          ChunkOutput(ArbitraryOutput[M]())
         )
-        command.run((key, lexRange.max.asString, lexRange.min.asString, limit))
+        runCommand(command, (key, lexRange.max.asString, lexRange.min.asString, limit))
       }
     }
 
@@ -945,10 +918,9 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
             ArbitraryValueInput[String](),
             OptionalInput(LimitInput)
           ),
-          ChunkOutput(ArbitraryOutput[M]()),
-          executor
+          ChunkOutput(ArbitraryOutput[M]())
         )
-        command.run((key, scoreRange.max.asString, scoreRange.min.asString, limit))
+        runCommand(command, (key, scoreRange.max.asString, scoreRange.min.asString, limit))
       }
     }
 
@@ -982,10 +954,9 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
             OptionalInput(LimitInput)
           ),
           ChunkTuple2Output(ArbitraryOutput[M](), DoubleOutput)
-            .map(_.map { case (m, s) => MemberScore(m, s) }),
-          executor
+            .map(_.map { case (m, s) => MemberScore(m, s) })
         )
-        command.run((key, scoreRange.max.asString, scoreRange.min.asString, WithScores, limit))
+        runCommand(command, (key, scoreRange.max.asString, scoreRange.min.asString, WithScores, limit))
       }
     }
 
@@ -1003,10 +974,9 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
     val command = RedisCommand(
       ZRevRank,
       Tuple2(ArbitraryKeyInput[K](), ArbitraryValueInput[M]()),
-      OptionalOutput(LongOutput),
-      executor
+      OptionalOutput(LongOutput)
     )
-    command.run((key, member))
+    runCommand(command, (key, member))
   }
 
   /**
@@ -1023,10 +993,9 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
     val command = RedisCommand(
       ZRevRank,
       Tuple3(ArbitraryKeyInput[K](), ArbitraryValueInput[M](), WithScoreInput),
-      OptionalOutput(Tuple2Output(LongOutput, DoubleOutput).map { case (r, s) => RankScore(r, s) }),
-      executor
+      OptionalOutput(Tuple2Output(LongOutput, DoubleOutput).map { case (r, s) => RankScore(r, s) })
     )
-    command.run((key, member, WithScore))
+    runCommand(command, (key, member, WithScore))
   }
 
   /**
@@ -1058,11 +1027,10 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
           RedisCommand(
             ZScan,
             Tuple4(ArbitraryKeyInput[K](), LongInput, OptionalInput(PatternInput), OptionalInput(CountInput)),
-            Tuple2Output(MultiStringOutput.map(_.toLong), memberScoresOutput),
-            executor
+            Tuple2Output(MultiStringOutput.map(_.toLong), memberScoresOutput)
           )
 
-        command.run((key, cursor, pattern.map(Pattern(_)), count))
+        runCommand(command, (key, cursor, pattern.map(Pattern(_)), count))
       }
     }
 
@@ -1080,10 +1048,9 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
     val command = RedisCommand(
       ZScore,
       Tuple2(ArbitraryKeyInput[K](), ArbitraryValueInput[M]()),
-      OptionalOutput(DoubleOutput),
-      executor
+      OptionalOutput(DoubleOutput)
     )
-    command.run((key, member))
+    runCommand(command, (key, member))
   }
 
   /**
@@ -1117,10 +1084,9 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
               OptionalInput(WeightsInput),
               OptionalInput(AggregateInput)
             ),
-            ChunkOutput(ArbitraryOutput[M]()),
-            executor
+            ChunkOutput(ArbitraryOutput[M]())
           )
-        command.run((keys.size + 1, (key, keys.toList), weights, aggregate))
+        runCommand(command, (keys.size + 1, (key, keys.toList), weights, aggregate))
       }
     }
 
@@ -1157,10 +1123,9 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
               WithScoresInput
             ),
             ChunkTuple2Output(ArbitraryOutput[M](), DoubleOutput)
-              .map(_.map { case (m, s) => MemberScore(m, s) }),
-            executor
+              .map(_.map { case (m, s) => MemberScore(m, s) })
           )
-        command.run((keys.size + 1, (key, keys.toList), weights, aggregate, WithScores))
+        runCommand(command, (keys.size + 1, (key, keys.toList), weights, aggregate, WithScores))
       }
     }
 
@@ -1195,10 +1160,9 @@ trait SortedSets[G[+_]] extends RedisEnvironment[G] {
         OptionalInput(WeightsInput),
         OptionalInput(AggregateInput)
       ),
-      LongOutput,
-      executor
+      LongOutput
     )
-    command.run((destination, keys.size + 1, (key, keys.toList), weights, aggregate))
+    runCommand(command, (destination, keys.size + 1, (key, keys.toList), weights, aggregate))
   }
 }
 

--- a/modules/redis/src/main/scala/zio/redis/api/Strings.scala
+++ b/modules/redis/src/main/scala/zio/redis/api/Strings.scala
@@ -42,7 +42,7 @@ trait Strings[G[+_]] extends RedisEnvironment[G] {
   final def append[K: Schema, V: Schema](key: K, value: V): G[Long] = {
     val command =
       RedisCommand(Append, Tuple2(ArbitraryKeyInput[K](), ArbitraryValueInput[V]()), LongOutput)
-    runCommand(command, (key, value))
+    command.run((key, value))
   }
 
   /**
@@ -58,7 +58,7 @@ trait Strings[G[+_]] extends RedisEnvironment[G] {
   final def bitCount[K: Schema](key: K, range: Option[Range] = None): G[Long] = {
     val command =
       RedisCommand(BitCount, Tuple2(ArbitraryKeyInput[K](), OptionalInput(RangeInput)), LongOutput)
-    runCommand(command, (key, range))
+    command.run((key, range))
   }
 
   /**
@@ -83,7 +83,7 @@ trait Strings[G[+_]] extends RedisEnvironment[G] {
       Tuple2(ArbitraryKeyInput[K](), NonEmptyList(BitFieldCommandInput)),
       ChunkOutput(OptionalOutput(LongOutput))
     )
-    runCommand(command, (key, (bitFieldCommand, bitFieldCommands.toList)))
+    command.run((key, (bitFieldCommand, bitFieldCommands.toList)))
   }
 
   /**
@@ -112,7 +112,7 @@ trait Strings[G[+_]] extends RedisEnvironment[G] {
         Tuple3(BitOperationInput, ArbitraryValueInput[D](), NonEmptyList(ArbitraryValueInput[S]())),
         LongOutput
       )
-    runCommand(command, (operation, destKey, (srcKey, srcKeys.toList)))
+    command.run((operation, destKey, (srcKey, srcKeys.toList)))
   }
 
   /**
@@ -134,7 +134,7 @@ trait Strings[G[+_]] extends RedisEnvironment[G] {
   ): G[Long] = {
     val command =
       RedisCommand(BitPos, Tuple3(ArbitraryKeyInput[K](), BoolInput, OptionalInput(BitPosRangeInput)), LongOutput)
-    runCommand(command, (key, bit, range))
+    command.run((key, bit, range))
   }
 
   /**
@@ -147,7 +147,7 @@ trait Strings[G[+_]] extends RedisEnvironment[G] {
    */
   final def decr[K: Schema](key: K): G[Long] = {
     val command = RedisCommand(Decr, ArbitraryKeyInput[K](), LongOutput)
-    runCommand(command, key)
+    command.run(key)
   }
 
   /**
@@ -162,7 +162,7 @@ trait Strings[G[+_]] extends RedisEnvironment[G] {
    */
   final def decrBy[K: Schema](key: K, decrement: Long): G[Long] = {
     val command = RedisCommand(DecrBy, Tuple2(ArbitraryKeyInput[K](), LongInput), LongOutput)
-    runCommand(command, (key, decrement))
+    command.run((key, decrement))
   }
 
   /**
@@ -176,7 +176,7 @@ trait Strings[G[+_]] extends RedisEnvironment[G] {
   final def get[K: Schema](key: K): ResultBuilder1[Option, G] =
     new ResultBuilder1[Option, G] {
       def returning[R: Schema]: G[Option[R]] =
-        runCommand(RedisCommand(Get, ArbitraryKeyInput[K](), OptionalOutput(ArbitraryOutput[R]())), key)
+        RedisCommand(Get, ArbitraryKeyInput[K](), OptionalOutput(ArbitraryOutput[R]())).run(key)
     }
 
   /**
@@ -191,7 +191,7 @@ trait Strings[G[+_]] extends RedisEnvironment[G] {
    */
   final def getBit[K: Schema](key: K, offset: Long): G[Long] = {
     val command = RedisCommand(GetBit, Tuple2(ArbitraryKeyInput[K](), LongInput), LongOutput)
-    runCommand(command, (key, offset))
+    command.run((key, offset))
   }
 
   /**
@@ -205,7 +205,7 @@ trait Strings[G[+_]] extends RedisEnvironment[G] {
   final def getDel[K: Schema](key: K): ResultBuilder1[Option, G] =
     new ResultBuilder1[Option, G] {
       def returning[R: Schema]: G[Option[R]] =
-        runCommand(RedisCommand(GetDel, ArbitraryKeyInput[K](), OptionalOutput(ArbitraryOutput[R]())), key)
+        RedisCommand(GetDel, ArbitraryKeyInput[K](), OptionalOutput(ArbitraryOutput[R]())).run(key)
     }
 
   /**
@@ -224,10 +224,7 @@ trait Strings[G[+_]] extends RedisEnvironment[G] {
   final def getEx[K: Schema](key: K, expire: Expire, expireTime: Duration): ResultBuilder1[Option, G] =
     new ResultBuilder1[Option, G] {
       def returning[R: Schema]: G[Option[R]] =
-        runCommand(
-          RedisCommand(GetEx, GetExInput[K](), OptionalOutput(ArbitraryOutput[R]())),
-          (key, expire, expireTime)
-        )
+        RedisCommand(GetEx, GetExInput[K](), OptionalOutput(ArbitraryOutput[R]())).run((key, expire, expireTime))
     }
 
   /**
@@ -246,10 +243,7 @@ trait Strings[G[+_]] extends RedisEnvironment[G] {
   final def getEx[K: Schema](key: K, expiredAt: ExpiredAt, timestamp: Instant): ResultBuilder1[Option, G] =
     new ResultBuilder1[Option, G] {
       def returning[R: Schema]: G[Option[R]] =
-        runCommand(
-          RedisCommand(GetEx, GetExAtInput[K](), OptionalOutput(ArbitraryOutput[R]())),
-          (key, expiredAt, timestamp)
-        )
+        RedisCommand(GetEx, GetExAtInput[K](), OptionalOutput(ArbitraryOutput[R]())).run((key, expiredAt, timestamp))
     }
 
   /**
@@ -265,7 +259,7 @@ trait Strings[G[+_]] extends RedisEnvironment[G] {
   final def getEx[K: Schema](key: K, persist: Boolean): ResultBuilder1[Option, G] =
     new ResultBuilder1[Option, G] {
       def returning[R: Schema]: G[Option[R]] =
-        runCommand(RedisCommand(GetEx, GetExPersistInput[K](), OptionalOutput(ArbitraryOutput[R]())), (key, persist))
+        RedisCommand(GetEx, GetExPersistInput[K](), OptionalOutput(ArbitraryOutput[R]())).run((key, persist))
     }
 
   /**
@@ -281,10 +275,8 @@ trait Strings[G[+_]] extends RedisEnvironment[G] {
   final def getRange[K: Schema](key: K, range: Range): ResultBuilder1[Option, G] =
     new ResultBuilder1[Option, G] {
       def returning[R: Schema]: G[Option[R]] =
-        runCommand(
-          RedisCommand(GetRange, Tuple2(ArbitraryKeyInput[K](), RangeInput), OptionalOutput(ArbitraryOutput[R]())),
-          (key, range)
-        )
+        RedisCommand(GetRange, Tuple2(ArbitraryKeyInput[K](), RangeInput), OptionalOutput(ArbitraryOutput[R]()))
+          .run((key, range))
     }
 
   /**
@@ -300,14 +292,11 @@ trait Strings[G[+_]] extends RedisEnvironment[G] {
   final def getSet[K: Schema, V: Schema](key: K, value: V): ResultBuilder1[Option, G] =
     new ResultBuilder1[Option, G] {
       def returning[R: Schema]: G[Option[R]] =
-        runCommand(
-          RedisCommand(
-            GetSet,
-            Tuple2(ArbitraryKeyInput[K](), ArbitraryValueInput[V]()),
-            OptionalOutput(ArbitraryOutput[R]())
-          ),
-          (key, value)
-        )
+        RedisCommand(
+          GetSet,
+          Tuple2(ArbitraryKeyInput[K](), ArbitraryValueInput[V]()),
+          OptionalOutput(ArbitraryOutput[R]())
+        ).run((key, value))
     }
 
   /**
@@ -320,7 +309,7 @@ trait Strings[G[+_]] extends RedisEnvironment[G] {
    */
   final def incr[K: Schema](key: K): G[Long] = {
     val command = RedisCommand(Incr, ArbitraryKeyInput[K](), LongOutput)
-    runCommand(command, key)
+    command.run(key)
   }
 
   /**
@@ -336,7 +325,7 @@ trait Strings[G[+_]] extends RedisEnvironment[G] {
   final def incrBy[K: Schema](key: K, increment: Long): G[Long] = {
     val command =
       RedisCommand(IncrBy, Tuple2(ArbitraryKeyInput[K](), LongInput), LongOutput)
-    runCommand(command, (key, increment))
+    command.run((key, increment))
   }
 
   /**
@@ -351,7 +340,7 @@ trait Strings[G[+_]] extends RedisEnvironment[G] {
    */
   final def incrByFloat[K: Schema](key: K, increment: Double): G[Double] = {
     val command = RedisCommand(IncrByFloat, Tuple2(ArbitraryKeyInput[K](), DoubleInput), DoubleOutput)
-    runCommand(command, (key, increment))
+    command.run((key, increment))
   }
 
   /**
@@ -379,7 +368,7 @@ trait Strings[G[+_]] extends RedisEnvironment[G] {
       ),
       LcsOutput
     )
-    runCommand(redisCommand, (keyA, keyB, lcsQueryType))
+    redisCommand.run((keyA, keyB, lcsQueryType))
   }
 
   /**
@@ -400,7 +389,7 @@ trait Strings[G[+_]] extends RedisEnvironment[G] {
       def returning[V: Schema]: G[Chunk[Option[V]]] = {
         val command =
           RedisCommand(MGet, NonEmptyList(ArbitraryKeyInput[K]()), ChunkOutput(OptionalOutput(ArbitraryOutput[V]())))
-        runCommand(command, (key, keys.toList))
+        command.run((key, keys.toList))
       }
     }
 
@@ -415,7 +404,7 @@ trait Strings[G[+_]] extends RedisEnvironment[G] {
   final def mSet[K: Schema, V: Schema](keyValue: (K, V), keyValues: (K, V)*): G[Unit] = {
     val command =
       RedisCommand(MSet, NonEmptyList(Tuple2(ArbitraryKeyInput[K](), ArbitraryValueInput[V]())), UnitOutput)
-    runCommand(command, (keyValue, keyValues.toList))
+    command.run((keyValue, keyValues.toList))
   }
 
   /**
@@ -434,7 +423,7 @@ trait Strings[G[+_]] extends RedisEnvironment[G] {
   ): G[Boolean] = {
     val command =
       RedisCommand(MSetNx, NonEmptyList(Tuple2(ArbitraryKeyInput[K](), ArbitraryValueInput[V]())), BoolOutput)
-    runCommand(command, (keyValue, keyValues.toList))
+    command.run((keyValue, keyValues.toList))
   }
 
   /**
@@ -458,7 +447,7 @@ trait Strings[G[+_]] extends RedisEnvironment[G] {
         Tuple3(ArbitraryKeyInput[K](), DurationMillisecondsInput, ArbitraryValueInput[V]()),
         UnitOutput
       )
-    runCommand(command, (key, milliseconds, value))
+    command.run((key, milliseconds, value))
   }
 
   /**
@@ -495,7 +484,7 @@ trait Strings[G[+_]] extends RedisEnvironment[G] {
       )
 
     val command = RedisCommand(Set, input, SetOutput)
-    runCommand(command, (key, value, expireTime, update, keepTtl))
+    command.run((key, value, expireTime, update, keepTtl))
   }
 
   /**
@@ -513,7 +502,7 @@ trait Strings[G[+_]] extends RedisEnvironment[G] {
   final def setBit[K: Schema](key: K, offset: Long, value: Boolean): G[Boolean] = {
     val command =
       RedisCommand(SetBit, Tuple3(ArbitraryKeyInput[K](), LongInput, BoolInput), BoolOutput)
-    runCommand(command, (key, offset, value))
+    command.run((key, offset, value))
   }
 
   /**
@@ -533,7 +522,7 @@ trait Strings[G[+_]] extends RedisEnvironment[G] {
   ): G[Unit] = {
     val command =
       RedisCommand(SetEx, Tuple3(ArbitraryKeyInput[K](), DurationSecondsInput, ArbitraryValueInput[V]()), UnitOutput)
-    runCommand(command, (key, expiration, value))
+    command.run((key, expiration, value))
   }
 
   /**
@@ -571,7 +560,7 @@ trait Strings[G[+_]] extends RedisEnvironment[G] {
       )
 
     val command = RedisCommand(Set, input, OptionalOutput(ArbitraryOutput[V]()))
-    runCommand(command, (key, value, expireTime, update, keepTtl, GetKeyword))
+    command.run((key, value, expireTime, update, keepTtl, GetKeyword))
   }
 
   /**
@@ -587,7 +576,7 @@ trait Strings[G[+_]] extends RedisEnvironment[G] {
   final def setNx[K: Schema, V: Schema](key: K, value: V): G[Boolean] = {
     val command =
       RedisCommand(SetNx, Tuple2(ArbitraryKeyInput[K](), ArbitraryValueInput[V]()), BoolOutput)
-    runCommand(command, (key, value))
+    command.run((key, value))
   }
 
   /**
@@ -605,7 +594,7 @@ trait Strings[G[+_]] extends RedisEnvironment[G] {
   final def setRange[K: Schema, V: Schema](key: K, offset: Long, value: V): G[Long] = {
     val command =
       RedisCommand(SetRange, Tuple3(ArbitraryKeyInput[K](), LongInput, ArbitraryValueInput[V]()), LongOutput)
-    runCommand(command, (key, offset, value))
+    command.run((key, offset, value))
   }
 
   /**
@@ -618,7 +607,7 @@ trait Strings[G[+_]] extends RedisEnvironment[G] {
    */
   final def strLen[K: Schema](key: K): G[Long] = {
     val command = RedisCommand(StrLen, ArbitraryKeyInput[K](), LongOutput)
-    runCommand(command, key)
+    command.run(key)
   }
 }
 

--- a/modules/redis/src/main/scala/zio/redis/internal/ClusterConnection.scala
+++ b/modules/redis/src/main/scala/zio/redis/internal/ClusterConnection.scala
@@ -25,7 +25,7 @@ private[redis] final case class ClusterConnection(
   executors: Map[RedisUri, ExecutorScope],
   slots: Map[Slot, RedisUri]
 ) {
-  def executor(slot: Slot): Option[RedisExecutor[RedisExecutor.Sync]] = executors.get(slots(slot)).map(_.executor)
+  def executor(slot: Slot): Option[RedisExecutor] = executors.get(slots(slot)).map(_.executor)
 
   def addExecutor(uri: RedisUri, es: ExecutorScope): ClusterConnection =
     copy(executors = executors + (uri -> es))

--- a/modules/redis/src/main/scala/zio/redis/internal/ClusterConnection.scala
+++ b/modules/redis/src/main/scala/zio/redis/internal/ClusterConnection.scala
@@ -25,7 +25,7 @@ private[redis] final case class ClusterConnection(
   executors: Map[RedisUri, ExecutorScope],
   slots: Map[Slot, RedisUri]
 ) {
-  def executor(slot: Slot): Option[RedisExecutor] = executors.get(slots(slot)).map(_.executor)
+  def executor(slot: Slot): Option[RedisExecutor[RedisExecutor.Sync]] = executors.get(slots(slot)).map(_.executor)
 
   def addExecutor(uri: RedisUri, es: ExecutorScope): ClusterConnection =
     copy(executors = executors + (uri -> es))

--- a/modules/redis/src/main/scala/zio/redis/internal/ClusterExecutor.scala
+++ b/modules/redis/src/main/scala/zio/redis/internal/ClusterExecutor.scala
@@ -18,7 +18,7 @@ package zio.redis.internal
 
 import zio._
 import zio.redis._
-import zio.redis.api.Cluster.AskingCommand
+import zio.redis.api.Cluster.askingCommand
 import zio.redis.options.Cluster._
 
 import java.io.IOException
@@ -45,7 +45,7 @@ private[redis] final class ClusterExecutor private (
     def executeAsk(address: RedisUri): RedisExecutor.Sync[RespValue] =
       for {
         executor <- executor(address)
-        _        <- toG(executor.execute(AskingCommand(this).resp(())))
+        _        <- toG(executor.execute(askingCommand(this).resp(())))
         res      <- toG(executor.execute(command))
       } yield res
 

--- a/modules/redis/src/main/scala/zio/redis/internal/ClusterExecutor.scala
+++ b/modules/redis/src/main/scala/zio/redis/internal/ClusterExecutor.scala
@@ -49,7 +49,7 @@ private[redis] final class ClusterExecutor private (
       val recover = execute(keySlot).flatMap {
         case e: RespValue.Error => ZIO.fail(e.asRedisError)
         case success            => ZIO.succeed(success)
-      }.catchSome {
+      }.catchSome[Any, RedisError, RespValue] {
         case e: RedisError.Ask   => executeAsk(e.address)
         case _: RedisError.Moved => refreshConnect *> execute(keySlot)
       }

--- a/modules/redis/src/main/scala/zio/redis/internal/ClusterExecutor.scala
+++ b/modules/redis/src/main/scala/zio/redis/internal/ClusterExecutor.scala
@@ -32,17 +32,17 @@ private[redis] final class ClusterExecutor private (
 
   def execute(command: RespCommand): UIO[IO[RedisError, RespValue]] = {
 
-    def execute(keySlot: Slot): RedisExecutor.Sync[RespValue] =
+    def execute(keySlot: Slot): GenRedis.Sync[RespValue] =
       for {
         executor <- executor(keySlot)
-        res      <- RedisExecutor.sync(executor.execute(command))
+        res      <- GenRedis.sync(executor.execute(command))
       } yield res
 
-    def executeAsk(address: RedisUri): RedisExecutor.Sync[RespValue] =
+    def executeAsk(address: RedisUri): GenRedis.Sync[RespValue] =
       for {
         executor <- executor(address)
-        _        <- RedisExecutor.sync(executor.execute(askingCommand.resp(())))
-        res      <- RedisExecutor.sync(executor.execute(command))
+        _        <- GenRedis.sync(executor.execute(askingCommand.resp(())))
+        res      <- GenRedis.sync(executor.execute(command))
       } yield res
 
     def executeSafe(keySlot: Slot): IO[RedisError, RespValue] = {

--- a/modules/redis/src/main/scala/zio/redis/internal/ClusterExecutor.scala
+++ b/modules/redis/src/main/scala/zio/redis/internal/ClusterExecutor.scala
@@ -149,7 +149,10 @@ private[redis] object ClusterExecutor {
     for {
       closableScope <- Scope.make
       connection    <- closableScope.extend[Any](RedisConnection.create(RedisConfig(address.host, address.port)))
-      executor      <- closableScope.extend[Any](SingleNodeExecutor.create(connection))
+      executor      <-
+        closableScope
+          .extend[Any](SingleNodeExecutor.create(connection))
+          .map(_.get[RedisExecutor[RedisExecutor.Sync]])
       layerScope    <- ZIO.scope
       _             <- layerScope.addFinalizerExit(closableScope.close(_))
     } yield ExecutorScope(executor, closableScope)

--- a/modules/redis/src/main/scala/zio/redis/internal/ClusterExecutor.scala
+++ b/modules/redis/src/main/scala/zio/redis/internal/ClusterExecutor.scala
@@ -49,7 +49,7 @@ private[redis] final class ClusterExecutor private (
       val recover = execute(keySlot).flatMap {
         case e: RespValue.Error => ZIO.fail(e.asRedisError)
         case success            => ZIO.succeed(success)
-      }.catchSome[Any, RedisError, RespValue] {
+      }.catchSome {
         case e: RedisError.Ask   => executeAsk(e.address)
         case _: RedisError.Moved => refreshConnect *> execute(keySlot)
       }

--- a/modules/redis/src/main/scala/zio/redis/internal/ClusterExecutor.scala
+++ b/modules/redis/src/main/scala/zio/redis/internal/ClusterExecutor.scala
@@ -30,9 +30,7 @@ private[redis] final class ClusterExecutor private (
 ) extends RedisExecutor[RedisExecutor.Sync] {
   import ClusterExecutor._
 
-  def toG: ToG[RedisExecutor.Sync] = new ToG[RedisExecutor.Sync] {
-    def apply[A](r: UIO[IO[RedisError, A]]): RedisExecutor.Sync[A] = r.flatten
-  }
+  def toG[A](io: UIO[IO[RedisError, A]]) = RedisExecutor.sync[A](io)
 
   def execute(command: RespCommand): UIO[IO[RedisError, RespValue]] = {
 

--- a/modules/redis/src/main/scala/zio/redis/internal/ExecutorScope.scala
+++ b/modules/redis/src/main/scala/zio/redis/internal/ExecutorScope.scala
@@ -18,4 +18,4 @@ package zio.redis.internal
 
 import zio.Scope
 
-private[redis] final case class ExecutorScope(executor: RedisExecutor, scope: Scope.Closeable)
+private[redis] final case class ExecutorScope(executor: RedisExecutor[RedisExecutor.Sync], scope: Scope.Closeable)

--- a/modules/redis/src/main/scala/zio/redis/internal/ExecutorScope.scala
+++ b/modules/redis/src/main/scala/zio/redis/internal/ExecutorScope.scala
@@ -18,4 +18,4 @@ package zio.redis.internal
 
 import zio.Scope
 
-private[redis] final case class ExecutorScope(executor: RedisExecutor[RedisExecutor.Sync], scope: Scope.Closeable)
+private[redis] final case class ExecutorScope(executor: RedisExecutor, scope: Scope.Closeable)

--- a/modules/redis/src/main/scala/zio/redis/internal/RedisCommand.scala
+++ b/modules/redis/src/main/scala/zio/redis/internal/RedisCommand.scala
@@ -28,10 +28,13 @@ private[redis] final class RedisCommand[-In, +Out, G[+_]] private (
 ) {
   def run(in: In): G[Out] =
     executor.toG(
-    executor
-      .execute(resp(in))
-      .map(_.flatMap[Any, Throwable, Out](out => ZIO.attempt(output.unsafeDecode(out)))
-      .refineToOrDie[RedisError]))
+      executor
+        .execute(resp(in))
+        .map(
+          _.flatMap[Any, Throwable, Out](out => ZIO.attempt(output.unsafeDecode(out)))
+            .refineToOrDie[RedisError]
+        )
+    )
 
   def resp(in: In): RespCommand =
     Varargs(CommandNameInput).encode(name.split(" ")) ++ input.encode(in)

--- a/modules/redis/src/main/scala/zio/redis/internal/RedisCommand.scala
+++ b/modules/redis/src/main/scala/zio/redis/internal/RedisCommand.scala
@@ -20,28 +20,29 @@ import zio._
 import zio.redis.Input.{CommandNameInput, Varargs}
 import zio.redis._
 
-private[redis] final class RedisCommand[-In, +Out] private (
+private[redis] final class RedisCommand[-In, +Out, G[+_]] private (
   val name: String,
   val input: Input[In],
   val output: Output[Out],
-  val executor: RedisExecutor
+  val executor: RedisExecutor[G]
 ) {
-  def run(in: In): IO[RedisError, Out] =
+  def run(in: In): G[Out] =
+    executor.toG(
     executor
       .execute(resp(in))
-      .flatMap[Any, Throwable, Out](out => ZIO.attempt(output.unsafeDecode(out)))
-      .refineToOrDie[RedisError]
+      .map(_.flatMap[Any, Throwable, Out](out => ZIO.attempt(output.unsafeDecode(out)))
+      .refineToOrDie[RedisError]))
 
   def resp(in: In): RespCommand =
     Varargs(CommandNameInput).encode(name.split(" ")) ++ input.encode(in)
 }
 
 private[redis] object RedisCommand {
-  def apply[In, Out](
+  def apply[In, Out, G[+_]](
     name: String,
     input: Input[In],
     output: Output[Out],
-    executor: RedisExecutor
-  ): RedisCommand[In, Out] =
+    executor: RedisExecutor[G]
+  ): RedisCommand[In, Out, G] =
     new RedisCommand(name, input, output, executor)
 }

--- a/modules/redis/src/main/scala/zio/redis/internal/RedisEnvironment.scala
+++ b/modules/redis/src/main/scala/zio/redis/internal/RedisEnvironment.scala
@@ -28,10 +28,7 @@ private[redis] trait RedisEnvironment[G[+_]] {
     def run(in: In): G[Out] = toG(
       executor
         .execute(cmd.resp(in))
-        .map(
-          _.flatMap[Any, Throwable, Out](out => ZIO.attempt(cmd.output.unsafeDecode(out)))
-            .refineToOrDie[RedisError]
-        )
+        .map(_.flatMap(out => ZIO.attempt(cmd.output.unsafeDecode(out))).refineToOrDie[RedisError])
     )
   }
 

--- a/modules/redis/src/main/scala/zio/redis/internal/RedisEnvironment.scala
+++ b/modules/redis/src/main/scala/zio/redis/internal/RedisEnvironment.scala
@@ -32,7 +32,7 @@ private[redis] trait RedisEnvironment[G[+_]] {
     )
   }
 
-  def lift[A](in: UIO[IO[RedisError, A]]): G[A]
+  protected def lift[A](in: UIO[IO[RedisError, A]]): G[A]
 
   protected final implicit def codec[A: Schema]: BinaryCodec[A] = codecSupplier.get
 }

--- a/modules/redis/src/main/scala/zio/redis/internal/RedisEnvironment.scala
+++ b/modules/redis/src/main/scala/zio/redis/internal/RedisEnvironment.scala
@@ -25,14 +25,14 @@ private[redis] trait RedisEnvironment[G[+_]] {
   protected def codecSupplier: CodecSupplier
   protected def executor: RedisExecutor
   protected implicit class RunOps[In, Out](cmd: RedisCommand[In, Out]) {
-    def run(in: In): G[Out] = toG(
+    def run(in: In): G[Out] = lift(
       executor
         .execute(cmd.resp(in))
         .map(_.flatMap[Any, Throwable, Out](out => ZIO.attempt(cmd.output.unsafeDecode(out))).refineToOrDie[RedisError])
     )
   }
 
-  def toG[A](in: UIO[IO[RedisError, A]]): G[A]
+  def lift[A](in: UIO[IO[RedisError, A]]): G[A]
 
   protected final implicit def codec[A: Schema]: BinaryCodec[A] = codecSupplier.get
 }

--- a/modules/redis/src/main/scala/zio/redis/internal/RedisEnvironment.scala
+++ b/modules/redis/src/main/scala/zio/redis/internal/RedisEnvironment.scala
@@ -19,7 +19,7 @@ package zio.redis.internal
 import zio.redis.{CodecSupplier, RedisError}
 import zio.schema.Schema
 import zio.schema.codec.BinaryCodec
-import zio.{UIO, IO, ZIO}
+import zio.{IO, UIO, ZIO}
 
 private[redis] trait RedisEnvironment[G[+_]] {
   protected def codecSupplier: CodecSupplier

--- a/modules/redis/src/main/scala/zio/redis/internal/RedisEnvironment.scala
+++ b/modules/redis/src/main/scala/zio/redis/internal/RedisEnvironment.scala
@@ -28,7 +28,7 @@ private[redis] trait RedisEnvironment[G[+_]] {
     def run(in: In): G[Out] = toG(
       executor
         .execute(cmd.resp(in))
-        .map(_.flatMap(out => ZIO.attempt(cmd.output.unsafeDecode(out))).refineToOrDie[RedisError])
+        .map(_.flatMap[Any, Throwable, Out](out => ZIO.attempt(cmd.output.unsafeDecode(out))).refineToOrDie[RedisError])
     )
   }
 

--- a/modules/redis/src/main/scala/zio/redis/internal/RedisEnvironment.scala
+++ b/modules/redis/src/main/scala/zio/redis/internal/RedisEnvironment.scala
@@ -20,9 +20,9 @@ import zio.redis.CodecSupplier
 import zio.schema.Schema
 import zio.schema.codec.BinaryCodec
 
-private[redis] trait RedisEnvironment {
+private[redis] trait RedisEnvironment[G[+_]] {
   protected def codecSupplier: CodecSupplier
-  protected def executor: RedisExecutor
+  protected def executor: RedisExecutor[G]
 
   protected final implicit def codec[A: Schema]: BinaryCodec[A] = codecSupplier.get
 }

--- a/modules/redis/src/main/scala/zio/redis/internal/RedisEnvironment.scala
+++ b/modules/redis/src/main/scala/zio/redis/internal/RedisEnvironment.scala
@@ -24,7 +24,7 @@ import zio.{IO, UIO, ZIO}
 private[redis] trait RedisEnvironment[G[+_]] {
   protected def codecSupplier: CodecSupplier
   protected def executor: RedisExecutor
-  protected implicit class RunOps[In, Out](cmd: RedisCommand[In, Out]) {
+  protected implicit final class RunOps[In, Out](cmd: RedisCommand[In, Out]) {
     def run(in: In): G[Out] = lift(
       executor
         .execute(cmd.resp(in))

--- a/modules/redis/src/main/scala/zio/redis/internal/RedisEnvironment.scala
+++ b/modules/redis/src/main/scala/zio/redis/internal/RedisEnvironment.scala
@@ -24,7 +24,7 @@ import zio.{IO, UIO, ZIO}
 private[redis] trait RedisEnvironment[G[+_]] {
   protected def codecSupplier: CodecSupplier
   protected def executor: RedisExecutor
-  implicit class RunOps[In, Out](cmd: RedisCommand[In, Out]) {
+  protected implicit class RunOps[In, Out](cmd: RedisCommand[In, Out]) {
     def run(in: In): G[Out] = toG(
       executor
         .execute(cmd.resp(in))

--- a/modules/redis/src/main/scala/zio/redis/internal/RedisExecutor.scala
+++ b/modules/redis/src/main/scala/zio/redis/internal/RedisExecutor.scala
@@ -19,16 +19,15 @@ package zio.redis.internal
 import zio.redis.RedisError
 import zio.{IO, UIO}
 
-private[redis] trait ToG[G[+_]] {
-  def apply[A](in: UIO[IO[RedisError, A]]): G[A]
-}
-
 private[redis] trait RedisExecutor[G[+_]] {
   def execute(command: RespCommand): UIO[IO[RedisError, RespValue]]
-  def toG: ToG[G]
+  def toG[A](in: UIO[IO[RedisError, A]]): G[A]
 }
 
 object RedisExecutor {
   type Async[+A] = IO[RedisError, IO[RedisError, A]]
-  type Sync[+A]  = IO[RedisError, A]
+  private[internal] def async[A](io: UIO[IO[RedisError, A]]) = io
+  type Sync[+A] = IO[RedisError, A]
+  private[internal] def sync[A](io: UIO[IO[RedisError, A]]) = io.flatten
+
 }

--- a/modules/redis/src/main/scala/zio/redis/internal/RedisExecutor.scala
+++ b/modules/redis/src/main/scala/zio/redis/internal/RedisExecutor.scala
@@ -22,11 +22,3 @@ import zio.{IO, UIO}
 private[redis] trait RedisExecutor {
   def execute(command: RespCommand): UIO[IO[RedisError, RespValue]]
 }
-
-object RedisExecutor {
-  type Async[+A] = IO[RedisError, IO[RedisError, A]]
-  private[redis] def async[A](io: UIO[IO[RedisError, A]]) = io
-  type Sync[+A] = IO[RedisError, A]
-  private[redis] def sync[A](io: UIO[IO[RedisError, A]]) = io.flatten
-
-}

--- a/modules/redis/src/main/scala/zio/redis/internal/RedisExecutor.scala
+++ b/modules/redis/src/main/scala/zio/redis/internal/RedisExecutor.scala
@@ -16,8 +16,8 @@
 
 package zio.redis.internal
 
-import zio.{IO, UIO}
 import zio.redis.RedisError
+import zio.{IO, UIO}
 
 private[redis] trait ToG[G[+_]] {
   def apply[A](in: UIO[IO[RedisError, A]]): G[A]

--- a/modules/redis/src/main/scala/zio/redis/internal/RedisExecutor.scala
+++ b/modules/redis/src/main/scala/zio/redis/internal/RedisExecutor.scala
@@ -29,6 +29,6 @@ private[redis] trait RedisExecutor[G[+_]] {
 }
 
 object RedisExecutor {
-  type Sync[+A]  = IO[RedisError, A]
   type Async[+A] = IO[RedisError, IO[RedisError, A]]
+  type Sync[+A]  = IO[RedisError, A]
 }

--- a/modules/redis/src/main/scala/zio/redis/internal/RedisExecutor.scala
+++ b/modules/redis/src/main/scala/zio/redis/internal/RedisExecutor.scala
@@ -29,6 +29,6 @@ private[redis] trait RedisExecutor[G[+_]] {
 }
 
 object RedisExecutor {
-  type Sync[+A] = IO[RedisError, A]
+  type Sync[+A]  = IO[RedisError, A]
   type Async[+A] = IO[RedisError, IO[RedisError, A]]
 }

--- a/modules/redis/src/main/scala/zio/redis/internal/RedisExecutor.scala
+++ b/modules/redis/src/main/scala/zio/redis/internal/RedisExecutor.scala
@@ -19,15 +19,14 @@ package zio.redis.internal
 import zio.redis.RedisError
 import zio.{IO, UIO}
 
-private[redis] trait RedisExecutor[G[+_]] {
+private[redis] trait RedisExecutor {
   def execute(command: RespCommand): UIO[IO[RedisError, RespValue]]
-  def toG[A](in: UIO[IO[RedisError, A]]): G[A]
 }
 
 object RedisExecutor {
   type Async[+A] = IO[RedisError, IO[RedisError, A]]
-  private[internal] def async[A](io: UIO[IO[RedisError, A]]) = io
+  private[redis] def async[A](io: UIO[IO[RedisError, A]]) = io
   type Sync[+A] = IO[RedisError, A]
-  private[internal] def sync[A](io: UIO[IO[RedisError, A]]) = io.flatten
+  private[redis] def sync[A](io: UIO[IO[RedisError, A]]) = io.flatten
 
 }

--- a/modules/redis/src/main/scala/zio/redis/internal/RedisExecutor.scala
+++ b/modules/redis/src/main/scala/zio/redis/internal/RedisExecutor.scala
@@ -16,9 +16,19 @@
 
 package zio.redis.internal
 
-import zio.IO
+import zio.{IO, UIO}
 import zio.redis.RedisError
 
-private[redis] trait RedisExecutor {
-  def execute(command: RespCommand): IO[RedisError, RespValue]
+private[redis] trait ToG[G[+_]] {
+  def apply[A](in: UIO[IO[RedisError, A]]): G[A]
+}
+
+private[redis] trait RedisExecutor[G[+_]] {
+  def execute(command: RespCommand): UIO[IO[RedisError, RespValue]]
+  def toG: ToG[G]
+}
+
+object RedisExecutor {
+  type Sync[+A] = IO[RedisError, A]
+  type Async[+A] = IO[RedisError, IO[RedisError, A]]
 }

--- a/modules/redis/src/main/scala/zio/redis/internal/SingleNodeExecutor.scala
+++ b/modules/redis/src/main/scala/zio/redis/internal/SingleNodeExecutor.scala
@@ -68,9 +68,7 @@ private[redis] object SingleNodeExecutor {
   lazy val local: ZLayer[Any, RedisError.IOError, RedisExecutor] =
     RedisConnection.local >>> makeLayer
 
-  def create(
-    connection: RedisConnection
-  ): URIO[Scope, SingleNodeExecutor] =
+  def create(connection: RedisConnection): URIO[Scope, SingleNodeExecutor] =
     for {
       requests  <- Queue.bounded[Request](RequestQueueSize)
       responses <- Queue.unbounded[Promise[RedisError, RespValue]]

--- a/modules/redis/src/main/scala/zio/redis/internal/SingleNodeExecutor.scala
+++ b/modules/redis/src/main/scala/zio/redis/internal/SingleNodeExecutor.scala
@@ -74,11 +74,7 @@ private[redis] object SingleNodeExecutor {
     for {
       requests  <- Queue.bounded[Request](RequestQueueSize)
       responses <- Queue.unbounded[Promise[RedisError, RespValue]]
-      executor   = new SingleNodeExecutor(
-                     connection,
-                     requests,
-                     responses
-                   )
+      executor   = new SingleNodeExecutor(connection, requests, responses)
       _         <- executor.run.forkScoped
       _         <- logScopeFinalizer(s"$executor Node Executor is closed")
     } yield executor

--- a/modules/redis/src/main/scala/zio/redis/internal/SingleNodeExecutor.scala
+++ b/modules/redis/src/main/scala/zio/redis/internal/SingleNodeExecutor.scala
@@ -64,7 +64,7 @@ private[redis] final class SingleNodeExecutor[G[+_]] private (
 
 private[redis] object SingleNodeExecutor {
   lazy val layer: ZLayer[RedisConfig, RedisError.IOError, RedisExecutor[RedisExecutor.Sync]
-    with RedisExecutor[RedisExecutor.Async]] =
+    & RedisExecutor[RedisExecutor.Async]] =
     RedisConnection.layer >>> makeLayer
 
   lazy val local
@@ -73,7 +73,7 @@ private[redis] object SingleNodeExecutor {
 
   def create(
     connection: RedisConnection
-  ): URIO[Scope, ZEnvironment[SingleNodeExecutor[RedisExecutor.Sync] with SingleNodeExecutor[RedisExecutor.Async]]] =
+  ): URIO[Scope, ZEnvironment[SingleNodeExecutor[RedisExecutor.Sync] & SingleNodeExecutor[RedisExecutor.Async]]] =
     for {
       requests     <- Queue.bounded[Request](RequestQueueSize)
       responses    <- Queue.unbounded[Promise[RedisError, RespValue]]
@@ -99,6 +99,6 @@ private[redis] object SingleNodeExecutor {
   private final case class Request(command: Chunk[RespValue.BulkString], promise: Promise[RedisError, RespValue])
 
   private def makeLayer: ZLayer[RedisConnection, RedisError.IOError, RedisExecutor[RedisExecutor.Sync]
-    with RedisExecutor[RedisExecutor.Async]] =
+    & RedisExecutor[RedisExecutor.Async]] =
     ZLayer.scopedEnvironment(ZIO.serviceWithZIO[RedisConnection](create))
 }

--- a/modules/redis/src/main/scala/zio/redis/package.scala
+++ b/modules/redis/src/main/scala/zio/redis/package.scala
@@ -16,6 +16,8 @@
 
 package zio
 
+import zio.redis.internal.RedisExecutor
+
 package object redis
     extends options.Connection
     with options.Geo
@@ -28,4 +30,7 @@ package object redis
     with options.Scripting {
 
   type Id[+A] = A
+
+  type Redis      = GenRedis[RedisExecutor.Sync]
+  type AsyncRedis = GenRedis[RedisExecutor.Async]
 }

--- a/modules/redis/src/main/scala/zio/redis/package.scala
+++ b/modules/redis/src/main/scala/zio/redis/package.scala
@@ -31,6 +31,6 @@ package object redis
 
   type Id[+A] = A
 
-  type Redis      = GenRedis[RedisExecutor.Sync]
   type AsyncRedis = GenRedis[RedisExecutor.Async]
+  type Redis      = GenRedis[RedisExecutor.Sync]
 }

--- a/modules/redis/src/main/scala/zio/redis/package.scala
+++ b/modules/redis/src/main/scala/zio/redis/package.scala
@@ -16,8 +16,6 @@
 
 package zio
 
-import zio.redis.internal.RedisExecutor
-
 package object redis
     extends options.Connection
     with options.Geo
@@ -31,6 +29,6 @@ package object redis
 
   type Id[+A] = A
 
-  type AsyncRedis = GenRedis[RedisExecutor.Async]
-  type Redis      = GenRedis[RedisExecutor.Sync]
+  type AsyncRedis = GenRedis[GenRedis.Async]
+  type Redis      = GenRedis[GenRedis.Sync]
 }


### PR DESCRIPTION
Resolves #916 

Hey @mijicd,

I've hacked together something to implement the improved async support that I laid out in #916. The code could certainly be made a little bit prettier here and there, but the primary aim here is to try out the idea and see if you consider this a viable way forward.

The essential changes are:
 - change from `requests.offer(…stuff…) *> promise.await` to `requests.offer(…stuff…).as(promise.await))`, which makes it possible to continue processing as soon as the request was placed in the queue (SingleNodeExecutor.scala:35)
 - add a type parameter to the `Redis` trait to indicate whether it will return `UIO[IO[RedisError, A]]` or `IO[RedisError, A]` (Redis.scala:23)
 - change `Redis.singleNode` and `Redis.local` to provide both a synchronous and an asynchronous implementation of the Redis client (Redis.scala:45)
 
The resources like Queues and the Redis connection are shared between the synchronous and asynchronous Redis client, see the changes in `SingleNodeExecutor`.

The biggest drawback right now is that I haven't yet looked into the cluster support, so the `cluster` ZLayer doesn't give you an `AsyncRedis` object. I'd like to get some feedback on the general approach first before tackling that. 