### PR TITLE
Rename zio-redis-it's BaseSpec to avoid confusion with test's BaseSpec

### DIFF
--- a/modules/redis-it/src/test/scala/zio/redis/ApiSpec.scala
+++ b/modules/redis-it/src/test/scala/zio/redis/ApiSpec.scala
@@ -24,9 +24,9 @@ object ApiSpec
     suite("Redis commands")(ClusterSuite, SingleNodeSuite)
       .provideShared(
         compose(
-          service(BaseSpec.SingleNode0, ".*Ready to accept connections.*"),
-          service(BaseSpec.SingleNode1, ".*Ready to accept connections.*"),
-          service(BaseSpec.MasterNode, ".*Cluster correctly created.*")
+          service(IntegrationSpec.SingleNode0, ".*Ready to accept connections.*"),
+          service(IntegrationSpec.SingleNode1, ".*Ready to accept connections.*"),
+          service(IntegrationSpec.MasterNode, ".*Cluster correctly created.*")
         )
       ) @@ sequential @@ withLiveEnvironment
 
@@ -48,7 +48,7 @@ object ApiSpec
       Redis.cluster,
       masterNodeConfig,
       ZLayer.succeed(ProtobufCodecSupplier)
-    ).filterNotTags(_.contains(BaseSpec.ClusterExecutorUnsupported))
+    ).filterNotTags(_.contains(IntegrationSpec.ClusterExecutorUnsupported))
       .getOrElse(Spec.empty) @@ flaky @@ ifEnvNotSet("CI")
 
   private final val SingleNodeSuite =
@@ -68,7 +68,7 @@ object ApiSpec
     ).provideSomeShared[DockerComposeContainer](
       Redis.singleNode,
       RedisSubscription.singleNode,
-      singleNodeConfig(BaseSpec.SingleNode0),
+      singleNodeConfig(IntegrationSpec.SingleNode0),
       ZLayer.succeed(ProtobufCodecSupplier)
     )
 }

--- a/modules/redis-it/src/test/scala/zio/redis/ClusterSpec.scala
+++ b/modules/redis-it/src/test/scala/zio/redis/ClusterSpec.scala
@@ -4,7 +4,7 @@ import com.dimafeng.testcontainers.DockerComposeContainer
 import zio._
 import zio.test._
 
-trait ClusterSpec extends BaseSpec {
+trait ClusterSpec extends IntegrationSpec {
   def clusterSpec: Spec[DockerComposeContainer & Redis, RedisError] =
     suite("cluster")(
       suite("slots")(

--- a/modules/redis-it/src/test/scala/zio/redis/ConnectionSpec.scala
+++ b/modules/redis-it/src/test/scala/zio/redis/ConnectionSpec.scala
@@ -5,7 +5,7 @@ import zio.test.Assertion._
 import zio.test.TestAspect._
 import zio.test._
 
-trait ConnectionSpec extends BaseSpec {
+trait ConnectionSpec extends IntegrationSpec {
   def connectionSuite: Spec[Redis, RedisError] =
     suite("connection")(
       suite("authenticating")(

--- a/modules/redis-it/src/test/scala/zio/redis/GeoSpec.scala
+++ b/modules/redis-it/src/test/scala/zio/redis/GeoSpec.scala
@@ -4,7 +4,7 @@ import zio.test.Assertion._
 import zio.test._
 import zio.{Chunk, ZIO}
 
-trait GeoSpec extends BaseSpec {
+trait GeoSpec extends IntegrationSpec {
   def geoSuite: Spec[Redis, RedisError] =
     suite("geo")(
       test("geoAdd followed by geoPos") {

--- a/modules/redis-it/src/test/scala/zio/redis/HashSpec.scala
+++ b/modules/redis-it/src/test/scala/zio/redis/HashSpec.scala
@@ -4,7 +4,7 @@ import zio.test.Assertion._
 import zio.test._
 import zio.{Chunk, ZIO}
 
-trait HashSpec extends BaseSpec {
+trait HashSpec extends IntegrationSpec {
   def hashSuite: Spec[Redis, RedisError] =
     suite("hash")(
       suite("hSet, hGet, hGetAll and hDel")(

--- a/modules/redis-it/src/test/scala/zio/redis/HyperLogLogSpec.scala
+++ b/modules/redis-it/src/test/scala/zio/redis/HyperLogLogSpec.scala
@@ -4,7 +4,7 @@ import zio.ZIO
 import zio.test.Assertion._
 import zio.test._
 
-trait HyperLogLogSpec extends BaseSpec {
+trait HyperLogLogSpec extends IntegrationSpec {
   def hyperLogLogSuite: Spec[Redis, RedisError] =
     suite("hyperloglog")(
       suite("add elements")(

--- a/modules/redis-it/src/test/scala/zio/redis/IntegrationSpec.scala
+++ b/modules/redis-it/src/test/scala/zio/redis/IntegrationSpec.scala
@@ -12,7 +12,7 @@ import zio.{ULayer, _}
 import java.io.File
 import java.util.UUID
 
-trait BaseSpec extends ZIOSpecDefault {
+trait IntegrationSpec extends ZIOSpecDefault {
   implicit def summonCodec[A: Schema]: BinaryCodec[A] = ProtobufCodec.protobufCodec
 
   override def aspects: Chunk[TestAspectAtLeastR[Live]] =
@@ -30,7 +30,7 @@ trait BaseSpec extends ZIOSpecDefault {
     ZLayer {
       for {
         docker      <- ZIO.service[DockerComposeContainer]
-        hostAndPort <- docker.getHostAndPort(BaseSpec.MasterNode)(6379)
+        hostAndPort <- docker.getHostAndPort(IntegrationSpec.MasterNode)(6379)
         uri          = RedisUri(s"${hostAndPort._1}:${hostAndPort._2}")
       } yield RedisClusterConfig(Chunk(uri))
     }
@@ -53,7 +53,7 @@ trait BaseSpec extends ZIOSpecDefault {
    *  - fork/join approach for commands that operate on keys with different slots
    */
   final val clusterExecutorUnsupported: TestAspectPoly =
-    tag(BaseSpec.ClusterExecutorUnsupported)
+    tag(IntegrationSpec.ClusterExecutorUnsupported)
 
   final val genStringRedisTypeOption: Gen[Any, Option[RedisType]] =
     Gen.option(Gen.constSample(Sample.noShrink(RedisType.String)))
@@ -68,7 +68,7 @@ trait BaseSpec extends ZIOSpecDefault {
     ZIO.succeed(UUID.randomUUID().toString)
 }
 
-object BaseSpec {
+object IntegrationSpec {
   final val ClusterExecutorUnsupported = "cluster executor not supported"
   final val MasterNode                 = "cluster-node-5"
   final val SingleNode0                = "single-node-0"

--- a/modules/redis-it/src/test/scala/zio/redis/KeysSpec.scala
+++ b/modules/redis-it/src/test/scala/zio/redis/KeysSpec.scala
@@ -7,7 +7,7 @@ import zio.test.Assertion.{exists => _, _}
 import zio.test.TestAspect.{restore => _, _}
 import zio.test._
 
-trait KeysSpec extends BaseSpec {
+trait KeysSpec extends IntegrationSpec {
   def keysSuite: Spec[DockerComposeContainer & Redis, RedisError] = {
     suite("keys")(
       test("set followed by get") {
@@ -177,7 +177,7 @@ trait KeysSpec extends BaseSpec {
             _         <- redis.set(key, value)
             response  <- redis
                            .migrate(
-                             BaseSpec.SingleNode1,
+                             IntegrationSpec.SingleNode1,
                              6379,
                              key,
                              0L,
@@ -199,7 +199,7 @@ trait KeysSpec extends BaseSpec {
             redis     <- ZIO.service[Redis]
             _         <- redis.set(key, value)
             response  <- redis.migrate(
-                           BaseSpec.SingleNode1,
+                           IntegrationSpec.SingleNode1,
                            6379L,
                            key,
                            0L,
@@ -225,7 +225,7 @@ trait KeysSpec extends BaseSpec {
                           .provideLayer(secondExecutor) // also add to second Redis
             response <- redis
                           .migrate(
-                            BaseSpec.SingleNode1,
+                            IntegrationSpec.SingleNode1,
                             6379,
                             key,
                             0L,
@@ -515,7 +515,7 @@ trait KeysSpec extends BaseSpec {
   private val secondExecutor =
     ZLayer
       .makeSome[DockerComposeContainer, Redis](
-        singleNodeConfig(BaseSpec.SingleNode1),
+        singleNodeConfig(IntegrationSpec.SingleNode1),
         ZLayer.succeed[CodecSupplier](ProtobufCodecSupplier),
         Redis.singleNode
       )

--- a/modules/redis-it/src/test/scala/zio/redis/ListSpec.scala
+++ b/modules/redis-it/src/test/scala/zio/redis/ListSpec.scala
@@ -8,7 +8,7 @@ import zio.test._
 
 import java.util.concurrent.TimeUnit
 
-trait ListSpec extends BaseSpec {
+trait ListSpec extends IntegrationSpec {
   def listSuite: Spec[Redis, Any] =
     suite("lists")(
       suite("pop")(

--- a/modules/redis-it/src/test/scala/zio/redis/PubSubSpec.scala
+++ b/modules/redis-it/src/test/scala/zio/redis/PubSubSpec.scala
@@ -7,7 +7,7 @@ import zio.{Promise, ZIO}
 
 import scala.util.Random
 
-trait PubSubSpec extends BaseSpec {
+trait PubSubSpec extends IntegrationSpec {
   def pubSubSuite: Spec[Redis with RedisSubscription, RedisError] =
     suite("pubSubs")(
       suite("subscribe")(

--- a/modules/redis-it/src/test/scala/zio/redis/ScriptingSpec.scala
+++ b/modules/redis-it/src/test/scala/zio/redis/ScriptingSpec.scala
@@ -11,7 +11,7 @@ import zio.test._
 
 import scala.util.Random
 
-trait ScriptingSpec extends BaseSpec {
+trait ScriptingSpec extends IntegrationSpec {
   def scriptingSpec: Spec[Redis, RedisError] =
     suite("scripting")(
       suite("eval")(

--- a/modules/redis-it/src/test/scala/zio/redis/SetsSpec.scala
+++ b/modules/redis-it/src/test/scala/zio/redis/SetsSpec.scala
@@ -6,7 +6,7 @@ import zio.stream.ZStream
 import zio.test.Assertion._
 import zio.test._
 
-trait SetsSpec extends BaseSpec {
+trait SetsSpec extends IntegrationSpec {
   def setsSuite: Spec[Redis, RedisError] =
     suite("sets")(
       suite("sAdd")(

--- a/modules/redis-it/src/test/scala/zio/redis/SortedSetsSpec.scala
+++ b/modules/redis-it/src/test/scala/zio/redis/SortedSetsSpec.scala
@@ -6,7 +6,7 @@ import zio.stream.ZStream
 import zio.test.Assertion._
 import zio.test._
 
-trait SortedSetsSpec extends BaseSpec {
+trait SortedSetsSpec extends IntegrationSpec {
   def sortedSetsSuite: Spec[Redis, RedisError] =
     suite("sorted sets")(
       suite("bzPopMax")(

--- a/modules/redis-it/src/test/scala/zio/redis/StreamsSpec.scala
+++ b/modules/redis-it/src/test/scala/zio/redis/StreamsSpec.scala
@@ -6,7 +6,7 @@ import zio.test.Assertion._
 import zio.test.TestAspect.{flaky, ignore}
 import zio.test._
 
-trait StreamsSpec extends BaseSpec {
+trait StreamsSpec extends IntegrationSpec {
   def streamsSuite: Spec[Redis, RedisError] =
     suite("streams")(
       suite("xAck")(

--- a/modules/redis-it/src/test/scala/zio/redis/StringsSpec.scala
+++ b/modules/redis-it/src/test/scala/zio/redis/StringsSpec.scala
@@ -6,7 +6,7 @@ import zio.test.Assertion.{exists => _, _}
 import zio.test.TestAspect.{flaky, ignore}
 import zio.test._
 
-trait StringsSpec extends BaseSpec {
+trait StringsSpec extends IntegrationSpec {
   def stringsSuite: Spec[Redis, RedisError] =
     suite("strings")(
       suite("append")(

--- a/modules/redis-it/src/test/scala/zio/redis/internal/ClusterExecutorSpec.scala
+++ b/modules/redis-it/src/test/scala/zio/redis/internal/ClusterExecutorSpec.scala
@@ -6,7 +6,7 @@ import zio.redis.options.Cluster.{Slot, SlotsAmount}
 import zio.test.TestAspect.{flaky, ifEnvNotSet}
 import zio.test._
 
-object ClusterExecutorSpec extends BaseSpec {
+object ClusterExecutorSpec extends IntegrationSpec {
   def spec: Spec[TestEnvironment, Any] =
     suite("Cluster executor")(
       test("check cluster responsiveness when ASK redirect happens") {
@@ -62,7 +62,7 @@ object ClusterExecutorSpec extends BaseSpec {
       }
     ).provideShared(
       Redis.cluster,
-      compose(service(BaseSpec.MasterNode, ".*Cluster correctly created.*")),
+      compose(service(IntegrationSpec.MasterNode, ".*Cluster correctly created.*")),
       masterNodeConfig,
       ZLayer.succeed(ProtobufCodecSupplier)
     ) @@ flaky @@ ifEnvNotSet("CI")


### PR DESCRIPTION
Would it be correct to rename `zio.redis.BaseSpec` inside `modules/redis-it/src/test/scala/zio/redis/BaseSpec.scala`?

If so, this PR does it.

The problem is that IntelliJ IDEA imports sbt projects incorrectly and adds an implicit `test->test` dependency to all dependent modules. This leads to confusing `zio.redis.BaseSpec` in `modules/redis/src/test/scala/zio/redis/BaseSpec.scala` and `modules/redis-it/src/test/scala/zio/redis/BaseSpec.scala`. Also, test's BaseSpec wins over it's BaseSpec.

This problem only affects IJ IDEA, for example VSCode + Metals works as expected.

An alternative solution might be to rename `zio.redis` package for itegration tests to something like `zio.redis_it`.