### PR TITLE
Support for infinity in sorted set commands params & results

### DIFF
--- a/modules/redis/src/main/scala/zio/redis/Input.scala
+++ b/modules/redis/src/main/scala/zio/redis/Input.scala
@@ -337,8 +337,14 @@ object Input {
   }
 
   final case class MemberScoreInput[M: BinaryCodec]() extends Input[MemberScore[M]] {
-    def encode(data: MemberScore[M]): RespCommand =
-      RespCommand(RespCommandArgument.Value(data.score.toString), RespCommandArgument.Value(data.member))
+    def encode(data: MemberScore[M]): RespCommand = {
+      val score = data.score match {
+        case Double.NegativeInfinity => "-inf"
+        case Double.PositiveInfinity => "+inf"
+        case d: Double               => d.toString.toLowerCase
+      }
+      RespCommand(RespCommandArgument.Value(score), RespCommandArgument.Value(data.member))
+    }
   }
 
   case object NoAckInput extends Input[NoAck] {

--- a/modules/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/modules/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -552,6 +552,11 @@ object InputSpec extends BaseSpec {
             result <- ZIO.attempt(MemberScoreInput[String]().encode(MemberScore("", 4.2d)))
           } yield assert(result)(equalTo(RespCommand(Value("4.2"), Value(""))))
         },
+        test("with positive score in scientific notation and non-empty member") {
+          for {
+            result <- ZIO.attempt(MemberScoreInput[String]().encode(MemberScore("member", 3.141592e100)))
+          } yield assert(result)(equalTo(RespCommand(Value("3.141592e100"), Value("member"))))
+        },
         test("with negative score and empty member") {
           for {
             result <- ZIO.attempt(MemberScoreInput[String]().encode(MemberScore("", -4.2d)))
@@ -576,6 +581,16 @@ object InputSpec extends BaseSpec {
           for {
             result <- ZIO.attempt(MemberScoreInput[String]().encode(MemberScore("member", 0d)))
           } yield assert(result)(equalTo(RespCommand(Value("0.0"), Value("member"))))
+        },
+        test("with positive infinity score and non-empty member") {
+          for {
+            result <- ZIO.attempt(MemberScoreInput[String]().encode(MemberScore("member", Double.PositiveInfinity)))
+          } yield assert(result)(equalTo(RespCommand(Value("+inf"), Value("member"))))
+        },
+        test("with negative infinity score and non-empty member") {
+          for {
+            result <- ZIO.attempt(MemberScoreInput[String]().encode(MemberScore("member", Double.NegativeInfinity)))
+          } yield assert(result)(equalTo(RespCommand(Value("-inf"), Value("member"))))
         }
       ),
       suite("NoInput")(


### PR DESCRIPTION
`+inf`, `-inf` are supported as a score in redis sorted set commands.

Infinity can be passed as a parameter to `ZADD` and received as a result from `Z*WITHSCORE`, `ZSCORE`, `ZMSCORE`, `BZPOP*` etc.

In the model we can map ±inf to `Double.PositiveInfinity` and `Double.NegativeInfinity`.

Strange thing: despite the fact that `+inf` is passed as a parameter with a plus at the end, it returns as `inf` without `+`.

It's a part of #352, which I'm going to implement later.