### PR TITLE
fix infinity loop in RedisUri, add tests for ClusterPartitionOutput

### DIFF
--- a/modules/redis-it/src/test/scala/zio/redis/ClusterSpec.scala
+++ b/modules/redis-it/src/test/scala/zio/redis/ClusterSpec.scala
@@ -18,7 +18,7 @@ trait ClusterSpec extends IntegrationSpec {
                 .foreach(0 to 5) { n =>
                   ZIO
                     .attempt(docker.getServiceHost(s"cluster-node$n", port))
-                    .map(host => RedisUri(s"$host:$port"))
+                    .map(host => RedisUri(host, port))
                 }
                 .orDie
             actual    = res.map(_.master.address) ++ res.flatMap(_.slaves.map(_.address))

--- a/modules/redis-it/src/test/scala/zio/redis/IntegrationSpec.scala
+++ b/modules/redis-it/src/test/scala/zio/redis/IntegrationSpec.scala
@@ -31,7 +31,7 @@ trait IntegrationSpec extends ZIOSpecDefault {
       for {
         docker      <- ZIO.service[DockerComposeContainer]
         hostAndPort <- docker.getHostAndPort(IntegrationSpec.MasterNode)(6379)
-        uri          = RedisUri(s"${hostAndPort._1}:${hostAndPort._2}")
+        uri          = RedisUri(hostAndPort._1, hostAndPort._2)
       } yield RedisClusterConfig(Chunk(uri))
     }
 

--- a/modules/redis/src/main/scala/zio/redis/Output.scala
+++ b/modules/redis/src/main/scala/zio/redis/Output.scala
@@ -101,7 +101,7 @@ object Output {
           val host   = MultiStringOutput.unsafeDecode(values(0))
           val port   = LongOutput.unsafeDecode(values(1))
           val nodeId = MultiStringOutput.unsafeDecode(values(2))
-          Node(nodeId, RedisUri(s"$host:$port"))
+          Node(nodeId, RedisUri(host, port.toInt))
         case other                   => throw ProtocolError(s"$other isn't an array")
       }
   }

--- a/modules/redis/src/main/scala/zio/redis/RedisUri.scala
+++ b/modules/redis/src/main/scala/zio/redis/RedisUri.scala
@@ -26,6 +26,9 @@ object RedisUri {
     val splitting = hostAndPort.split(':')
     val host      = splitting(0)
     val port      = splitting(1).toInt
-    RedisUri(s"$host:$port")
+    RedisUri(host, port, ssl = false, sni = None)
   }
+
+  def apply(host: String, port: Int): RedisUri =
+    RedisUri(host, port, ssl = false, sni = None)
 }


### PR DESCRIPTION
fixes #970

Bug in RedisUri was introduced when adding TLS support (#930). `RedisUri.apply(String)` constructor called itself after building connection URI string, causing cluster spec to hang.

Unfortunately I haven't managed to run cluster spec locally yet, but now it's another problem, possibly with NATted network environment inside the test cluster.