### PR TITLE
Update zio-testcontainers to support docker compose V2

### DIFF
--- a/modules/redis-it/src/test/resources/docker-compose.yml
+++ b/modules/redis-it/src/test/resources/docker-compose.yml
@@ -1,56 +1,56 @@
 version: "3.3"
 
 services:
-  single-node-0:
+  single-node0:
     image: bitnami/redis:7.2
     environment:
       - 'ALLOW_EMPTY_PASSWORD=yes'
 
-  single-node-1:
+  single-node1:
     image: bitnami/redis:7.2
     environment:
       - 'ALLOW_EMPTY_PASSWORD=yes'
 
-  cluster-node-0:
+  cluster-node0:
     image: bitnami/redis-cluster:7.2
     environment:
       - 'ALLOW_EMPTY_PASSWORD=yes'
-      - 'REDIS_NODES=cluster-node-0 cluster-node-1 cluster-node-2 cluster-node-3 cluster-node-4 cluster-node-5'
+      - 'REDIS_NODES=cluster-node0 cluster-node1 cluster-node2 cluster-node3 cluster-node4 cluster-node5'
 
-  cluster-node-1:
+  cluster-node1:
     image: bitnami/redis-cluster:7.2
     environment:
       - 'ALLOW_EMPTY_PASSWORD=yes'
-      - 'REDIS_NODES=cluster-node-0 cluster-node-1 cluster-node-2 cluster-node-3 cluster-node-4 cluster-node-5'
+      - 'REDIS_NODES=cluster-node0 cluster-node1 cluster-node2 cluster-node3 cluster-node4 cluster-node5'
 
-  cluster-node-2:
+  cluster-node2:
     image: bitnami/redis-cluster:7.2
     environment:
       - 'ALLOW_EMPTY_PASSWORD=yes'
-      - 'REDIS_NODES=cluster-node-0 cluster-node-1 cluster-node-2 cluster-node-3 cluster-node-4 cluster-node-5'
+      - 'REDIS_NODES=cluster-node0 cluster-node1 cluster-node2 cluster-node3 cluster-node4 cluster-node5'
 
-  cluster-node-3:
+  cluster-node3:
     image: bitnami/redis-cluster:7.2
     environment:
       - 'ALLOW_EMPTY_PASSWORD=yes'
-      - 'REDIS_NODES=cluster-node-0 cluster-node-1 cluster-node-2 cluster-node-3 cluster-node-4 cluster-node-5'
+      - 'REDIS_NODES=cluster-node0 cluster-node1 cluster-node2 cluster-node3 cluster-node4 cluster-node5'
 
-  cluster-node-4:
+  cluster-node4:
     image: bitnami/redis-cluster:7.2
     environment:
       - 'ALLOW_EMPTY_PASSWORD=yes'
-      - 'REDIS_NODES=cluster-node-0 cluster-node-1 cluster-node-2 cluster-node-3 cluster-node-4 cluster-node-5'
+      - 'REDIS_NODES=cluster-node0 cluster-node1 cluster-node2 cluster-node3 cluster-node4 cluster-node5'
 
-  cluster-node-5:
+  cluster-node5:
     image: bitnami/redis-cluster:7.2
     depends_on:
-      - cluster-node-0
-      - cluster-node-1
-      - cluster-node-2
-      - cluster-node-3
-      - cluster-node-4
+      - cluster-node0
+      - cluster-node1
+      - cluster-node2
+      - cluster-node3
+      - cluster-node4
     environment:
       - 'ALLOW_EMPTY_PASSWORD=yes'
       - 'REDIS_CLUSTER_REPLICAS=1'
-      - 'REDIS_NODES=cluster-node-0 cluster-node-1 cluster-node-2 cluster-node-3 cluster-node-4 cluster-node-5'
+      - 'REDIS_NODES=cluster-node0 cluster-node1 cluster-node2 cluster-node3 cluster-node4 cluster-node5'
       - 'REDIS_CLUSTER_CREATOR=yes'

--- a/modules/redis-it/src/test/scala/zio/redis/ClusterSpec.scala
+++ b/modules/redis-it/src/test/scala/zio/redis/ClusterSpec.scala
@@ -17,7 +17,7 @@ trait ClusterSpec extends IntegrationSpec {
               ZIO
                 .foreach(0 to 5) { n =>
                   ZIO
-                    .attempt(docker.getServiceHost(s"cluster-node-$n", port))
+                    .attempt(docker.getServiceHost(s"cluster-node$n", port))
                     .map(host => RedisUri(s"$host:$port"))
                 }
                 .orDie

--- a/modules/redis-it/src/test/scala/zio/redis/IntegrationSpec.scala
+++ b/modules/redis-it/src/test/scala/zio/redis/IntegrationSpec.scala
@@ -70,7 +70,7 @@ trait IntegrationSpec extends ZIOSpecDefault {
 
 object IntegrationSpec {
   final val ClusterExecutorUnsupported = "cluster executor not supported"
-  final val MasterNode                 = "cluster-node-5"
-  final val SingleNode0                = "single-node-0"
-  final val SingleNode1                = "single-node-1"
+  final val MasterNode                 = "cluster-node5"
+  final val SingleNode0                = "single-node0"
+  final val SingleNode1                = "single-node1"
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
     val ZioConfig         = "4.0.2"
     val ZioJson           = "0.6.2"
     val ZioSchema         = "1.2.2"
-    val ZioTestContainers = "0.4.1"
+    val ZioTestContainers = "0.5.0"
   }
 
   lazy val Benchmarks =


### PR DESCRIPTION
testcontainers-scala migrated to new backend implementation in https://github.com/testcontainers/testcontainers-scala/pull/260

The new version of zio-testcontainers updated to the new testcontainers-scala in v0.4.3

Also, testcontainers have a bug with setting exposed ports in socat container if the service name ends with `\-[0-9]+`, because it's [recognised as a multi-instance service name](https://github.com/testcontainers/testcontainers-java/blob/1.19.1/core/src/main/java/org/testcontainers/containers/ComposeDelegate.java#L324-L327). I think the easiest way to deal with this would be to just use different names.