### PR TITLE
Streams api#1000

### DIFF
--- a/modules/redis-it/src/test/scala/zio/redis/ApiSpec.scala
+++ b/modules/redis-it/src/test/scala/zio/redis/ApiSpec.scala
@@ -21,7 +21,7 @@ object ApiSpec
     with PubSubSpec {
 
   def spec: Spec[TestEnvironment, Any] =
-    suite("Redis commands")(SingleNodeSuite)
+    suite("Redis commands")(ClusterSuite, SingleNodeSuite)
       .provideShared(
         compose(
           service(IntegrationSpec.SingleNode0, ".*Ready to accept connections.*"),

--- a/modules/redis-it/src/test/scala/zio/redis/ApiSpec.scala
+++ b/modules/redis-it/src/test/scala/zio/redis/ApiSpec.scala
@@ -21,7 +21,7 @@ object ApiSpec
     with PubSubSpec {
 
   def spec: Spec[TestEnvironment, Any] =
-    suite("Redis commands")(ClusterSuite, SingleNodeSuite)
+    suite("Redis commands")(SingleNodeSuite)
       .provideShared(
         compose(
           service(IntegrationSpec.SingleNode0, ".*Ready to accept connections.*"),

--- a/modules/redis-it/src/test/scala/zio/redis/KeysSpec.scala
+++ b/modules/redis-it/src/test/scala/zio/redis/KeysSpec.scala
@@ -418,7 +418,7 @@ trait KeysSpec extends IntegrationSpec {
             key    <- uuid
             field  <- uuid
             value  <- uuid
-            _      <- redis.xAdd(key, "*", (field, value)).returning[String]
+            _      <- redis.xAdd(key, "*")((field, value)).returning[String]
             stream <- redis.typeOf(key)
           } yield assert(stream)(equalTo(RedisType.Stream))
         }

--- a/modules/redis-it/src/test/scala/zio/redis/StreamsSpec.scala
+++ b/modules/redis-it/src/test/scala/zio/redis/StreamsSpec.scala
@@ -1022,6 +1022,28 @@ trait StreamsSpec extends IntegrationSpec {
             result <- redis.xGroupSetId(stream, group, id).either
           } yield assert(result)(isRight)
         },
+        test("for an existing group and message with entries read option") {
+          for {
+            redis  <- ZIO.service[Redis]
+            stream <- uuid
+            group  <- uuid
+            id     <- redis.xAdd(stream, "*")("a" -> "b").returning[String].some
+            _      <- redis.xAdd(stream, "*")("a" -> "b").returning[String]
+            _      <- redis.xAdd(stream, "*")("a" -> "b").returning[String]
+            _      <- redis.xGroupCreate(stream, group, "$")
+            result <- redis.xGroupSetId(stream, group, id, entriesRead = Some(2L)).either
+          } yield assert(result)(isRight)
+        },
+        test("for an existing group and message last entry") {
+          for {
+            redis  <- ZIO.service[Redis]
+            stream <- uuid
+            group  <- uuid
+            id     <- redis.xAdd(stream, "*")("a" -> "b").returning[String].some
+            _      <- redis.xGroupCreate(stream, group, "$")
+            result <- redis.xGroupSetIdLastEntry(stream, group).either
+          } yield assert(result)(isRight)
+        },
         test("error when non-existent group and an existing message") {
           for {
             redis  <- ZIO.service[Redis]

--- a/modules/redis-it/src/test/scala/zio/redis/StreamsSpec.scala
+++ b/modules/redis-it/src/test/scala/zio/redis/StreamsSpec.scala
@@ -962,6 +962,16 @@ trait StreamsSpec extends IntegrationSpec {
             redis  <- ZIO.service[Redis]
             stream <- uuid
             group  <- uuid
+            result <- redis.xGroupCreateLastEntry(stream, group, mkStream = true).either
+          } yield assert(result)(isRight)
+        }
+      ),
+      suite("xGroupCreate")(
+        test("new group") {
+          for {
+            redis  <- ZIO.service[Redis]
+            stream <- uuid
+            group  <- uuid
             result <- redis.xGroupCreate(stream, group, "$", mkStream = true).either
           } yield assert(result)(isRight)
         },

--- a/modules/redis-it/src/test/scala/zio/redis/StreamsSpec.scala
+++ b/modules/redis-it/src/test/scala/zio/redis/StreamsSpec.scala
@@ -1039,7 +1039,7 @@ trait StreamsSpec extends IntegrationSpec {
             redis  <- ZIO.service[Redis]
             stream <- uuid
             group  <- uuid
-            id     <- redis.xAdd(stream, "*")("a" -> "b").returning[String].some
+            _      <- redis.xAdd(stream, "*")("a" -> "b").returning[String].some
             _      <- redis.xGroupCreate(stream, group, "$")
             result <- redis.xGroupSetIdLastEntry(stream, group).either
           } yield assert(result)(isRight)

--- a/modules/redis/src/main/scala/zio/redis/Input.scala
+++ b/modules/redis/src/main/scala/zio/redis/Input.scala
@@ -717,7 +717,12 @@ object Input {
         RespCommandArgument.Value(data.id)
       )
 
-      RespCommand(if (data.mkStream) chunk :+ RespCommandArgument.Literal(MkStream.asString) else chunk)
+      val mkStreamChunk = if (data.mkStream) Chunk(RespCommandArgument.Literal(MkStream.asString)) else Chunk.empty
+      val entriesReadChunk = data.entriesRead.fold(Chunk.empty[RespCommandArgument])(id =>
+        Chunk(RespCommandArgument.Literal("ENTRIESREAD"), RespCommandArgument.Value(id))
+      )
+
+      RespCommand(chunk ++ mkStreamChunk ++ entriesReadChunk)
     }
   }
 

--- a/modules/redis/src/main/scala/zio/redis/Input.scala
+++ b/modules/redis/src/main/scala/zio/redis/Input.scala
@@ -438,63 +438,63 @@ object Input {
       RespCommand(RespCommandArgument.Literal("STORE"), RespCommandArgument.Value(data.key))
   }
 
-  sealed trait CappedStreamLiterals {
-    val maxLenLiteral: RespCommandArgument.Literal = RespCommandArgument.Literal("MAXLEN")
-    val minIdLiteral: RespCommandArgument.Literal  = RespCommandArgument.Literal("MINID")
-    val approxLiteral: RespCommandArgument.Literal = RespCommandArgument.Literal("~")
-    val exactLiteral: RespCommandArgument.Literal  = RespCommandArgument.Literal("=")
-    val limitLiteral: RespCommandArgument.Literal  = RespCommandArgument.Literal("LIMIT")
-  }
-
-  case object MaxLenApproxInput extends Input[CappedStreamType.MaxLenApprox] with CappedStreamLiterals {
-    override private[redis] def encode(data: CappedStreamType.MaxLenApprox): RespCommand = {
+  case object MaxLenApproxInput extends Input[CappedStreamType.MaxLenApprox] {
+    def encode(data: CappedStreamType.MaxLenApprox): RespCommand = {
       val maxLenChunk: Chunk[RespCommandArgument] = Chunk(
-        maxLenLiteral,
-        approxLiteral,
+        RespCommandArgument.Literal("MAXLEN"),
+        RespCommandArgument.Literal("~"),
         RespCommandArgument.Value(data.count.toString)
       )
 
       val limitChunk = data.limit.fold(Chunk.empty[RespCommandArgument])(limit =>
-        Chunk(limitLiteral, RespCommandArgument.Value(limit.toString))
+        Chunk(RespCommandArgument.Literal("LIMIT"), RespCommandArgument.Value(limit.toString))
       )
 
       RespCommand(maxLenChunk ++ limitChunk)
     }
   }
 
-  case object MaxLenExactInput extends Input[CappedStreamType.MaxLenExact] with CappedStreamLiterals {
-    override private[redis] def encode(data: CappedStreamType.MaxLenExact): RespCommand =
-      RespCommand(Chunk(maxLenLiteral, exactLiteral, RespCommandArgument.Value(data.count.toString)))
+  case object MaxLenExactInput extends Input[CappedStreamType.MaxLenExact] {
+    def encode(data: CappedStreamType.MaxLenExact): RespCommand =
+      RespCommand(
+        Chunk(
+          RespCommandArgument.Literal("MAXLEN"),
+          RespCommandArgument.Literal("="),
+          RespCommandArgument.Value(data.count.toString)
+        )
+      )
   }
 
-  final case class MinIdApproxInput[I: BinaryCodec]()
-      extends Input[CappedStreamType.MinIdApprox[I]]
-      with CappedStreamLiterals {
-    override private[redis] def encode(data: CappedStreamType.MinIdApprox[I]): RespCommand = {
+  final case class MinIdApproxInput[I: BinaryCodec]() extends Input[CappedStreamType.MinIdApprox[I]] {
+    def encode(data: CappedStreamType.MinIdApprox[I]): RespCommand = {
       val minIdChunk =
         Chunk(
-          minIdLiteral,
-          approxLiteral,
+          RespCommandArgument.Literal("MINID"),
+          RespCommandArgument.Literal("~"),
           RespCommandArgument.Value(data.id)
         )
 
       val limitChunk = data.limit.fold(Chunk.empty[RespCommandArgument])(limit =>
-        Chunk(limitLiteral, RespCommandArgument.Value(limit.toString))
+        Chunk(RespCommandArgument.Literal("LIMIT"), RespCommandArgument.Value(limit.toString))
       )
 
       RespCommand(minIdChunk ++ limitChunk)
     }
   }
 
-  final case class MinIdExactInput[I: BinaryCodec]()
-      extends Input[CappedStreamType.MinIdExact[I]]
-      with CappedStreamLiterals {
-    override private[redis] def encode(data: _root_.zio.redis.CappedStreamType.MinIdExact[I]): RespCommand =
-      RespCommand(Chunk(minIdLiteral, exactLiteral, RespCommandArgument.Value(data.id)))
+  final case class MinIdExactInput[I: BinaryCodec]() extends Input[CappedStreamType.MinIdExact[I]] {
+    def encode(data: _root_.zio.redis.CappedStreamType.MinIdExact[I]): RespCommand =
+      RespCommand(
+        Chunk(
+          RespCommandArgument.Literal("MINID"),
+          RespCommandArgument.Literal("="),
+          RespCommandArgument.Value(data.id)
+        )
+      )
   }
 
   case object MkStreamInput extends Input[MkStream] {
-    override private[redis] def encode(data: MkStream): RespCommand =
+    def encode(data: MkStream): RespCommand =
       RespCommand(RespCommandArgument.Value(data.asString))
   }
 
@@ -675,7 +675,7 @@ object Input {
   }
 
   final case class LastIdInput[I: BinaryCodec]() extends Input[LastId[I]] {
-    override private[redis] def encode(data: LastId[I]): RespCommand = {
+    def encode(data: LastId[I]): RespCommand = {
       val chunk = Chunk(RespCommandArgument.Literal("LASTID"), RespCommandArgument.Value(data.lastId))
       RespCommand(chunk)
     }
@@ -702,7 +702,7 @@ object Input {
   }
 
   case object WithEntriesReadInput extends Input[WithEntriesRead] {
-    override private[redis] def encode(data: WithEntriesRead): RespCommand =
+    def encode(data: WithEntriesRead): RespCommand =
       RespCommand(RespCommandArgument.Literal("ENTRIESREAD"), RespCommandArgument.Value(data.entries.toString))
   }
 

--- a/modules/redis/src/main/scala/zio/redis/Input.scala
+++ b/modules/redis/src/main/scala/zio/redis/Input.scala
@@ -662,6 +662,13 @@ object Input {
       RespCommand(RespCommandArgument.Literal(data.asString))
   }
 
+  final case class LastIdInput[I: BinaryCodec]() extends Input[LastId[I]] {
+    override private[redis] def encode(data: LastId[I]): RespCommand = {
+      val chunk = Chunk(RespCommandArgument.Literal("LASTID"), RespCommandArgument.Value(data.lastId))
+      RespCommand(chunk)
+    }
+  }
+
   case object WithHashInput extends Input[WithHash] {
     def encode(data: WithHash): RespCommand =
       RespCommand(RespCommandArgument.Literal(data.asString))

--- a/modules/redis/src/main/scala/zio/redis/Output.scala
+++ b/modules/redis/src/main/scala/zio/redis/Output.scala
@@ -478,6 +478,10 @@ object Output {
                       streamGroupsInfo = streamGroupsInfo.copy(pending = value.value)
                     else if (key.asString == XInfoFields.Consumers)
                       streamGroupsInfo = streamGroupsInfo.copy(consumers = value.value)
+                    else if (key.asString == XInfoFields.EntriesRead)
+                      streamGroupsInfo = streamGroupsInfo.copy(entriesRead = value.value)
+                    else if (key.asString == XInfoFields.Lag)
+                      streamGroupsInfo = streamGroupsInfo.copy(lag = value.value)
                   case _                                                                =>
                 }
                 pos += 2

--- a/modules/redis/src/main/scala/zio/redis/Output.scala
+++ b/modules/redis/src/main/scala/zio/redis/Output.scala
@@ -370,6 +370,8 @@ object Output {
                       streamConsumersInfo = streamConsumersInfo.copy(pending = value.value)
                     else if (key.asString == XInfoFields.Idle)
                       streamConsumersInfo = streamConsumersInfo.copy(idle = value.value.millis)
+                    else if (key.asString == XInfoFields.Inactive)
+                      streamConsumersInfo = streamConsumersInfo.copy(inactive = value.value.millis)
                   case _                                                             =>
                 }
                 pos += 2

--- a/modules/redis/src/main/scala/zio/redis/api/Streams.scala
+++ b/modules/redis/src/main/scala/zio/redis/api/Streams.scala
@@ -20,8 +20,8 @@ import zio._
 import zio.redis.Input._
 import zio.redis.Output._
 import zio.redis.ResultBuilder._
+import zio.redis._
 import zio.redis.internal.{RedisCommand, RedisEnvironment}
-import zio.redis.{Input, _}
 import zio.schema.Schema
 
 trait Streams[G[+_]] extends RedisEnvironment[G] {

--- a/modules/redis/src/main/scala/zio/redis/api/Streams.scala
+++ b/modules/redis/src/main/scala/zio/redis/api/Streams.scala
@@ -207,7 +207,7 @@ trait Streams[G[+_]] extends RedisEnvironment[G] {
             Tuple5(
               ArbitraryKeyInput[SK](),
               OptionalInput(NoMkStreamInput),
-              OptionalInput(MinIdApproxInput[I]),
+              OptionalInput(MinIdApproxInput[I]()),
               ArbitraryValueInput[I](),
               NonEmptyList(Tuple2(ArbitraryKeyInput[K](), ArbitraryValueInput[V]()))
             ),
@@ -221,7 +221,7 @@ trait Streams[G[+_]] extends RedisEnvironment[G] {
             Tuple5(
               ArbitraryKeyInput[SK](),
               OptionalInput(NoMkStreamInput),
-              OptionalInput(MinIdExactInput[I]),
+              OptionalInput(MinIdExactInput[I]()),
               ArbitraryValueInput[I](),
               NonEmptyList(Tuple2(ArbitraryKeyInput[K](), ArbitraryValueInput[V]()))
             ),
@@ -1067,10 +1067,10 @@ trait Streams[G[+_]] extends RedisEnvironment[G] {
     limit: Option[Long] = None
   ): G[Long] =
     if (approximate) {
-      val command = RedisCommand(XTrim, Tuple2(ArbitraryKeyInput[SK](), MinIdApproxInput[I]), LongOutput)
+      val command = RedisCommand(XTrim, Tuple2(ArbitraryKeyInput[SK](), MinIdApproxInput[I]()), LongOutput)
       command.run((key, CappedStreamType.MinIdApprox(minId, limit)))
     } else {
-      val command = RedisCommand(XTrim, Tuple2(ArbitraryKeyInput[SK](), MinIdExactInput[I]), LongOutput)
+      val command = RedisCommand(XTrim, Tuple2(ArbitraryKeyInput[SK](), MinIdExactInput[I]()), LongOutput)
       command.run((key, CappedStreamType.MinIdExact(minId)))
     }
 }

--- a/modules/redis/src/main/scala/zio/redis/api/Streams.scala
+++ b/modules/redis/src/main/scala/zio/redis/api/Streams.scala
@@ -490,16 +490,40 @@ trait Streams[G[+_]] extends RedisEnvironment[G] {
    *   ID of the last item in the stream to consider already delivered
    * @param mkStream
    *   ID of the last item in the stream to consider already delivered
+   * @param entriesRead
+   *   Enable consumer group lag tracking
    */
   final def xGroupCreate[SK: Schema, SG: Schema, I: Schema](
     key: SK,
     group: SG,
     id: I,
-    mkStream: Boolean = false
+    mkStream: Boolean = false,
+    entriesRead: Option[I] = None
   ): G[Unit] = {
     val command = RedisCommand(XGroup, XGroupCreateInput[SK, SG, I](), UnitOutput)
-    command.run(Create(key, group, id, mkStream))
+    command.run(Create(key, group, id, mkStream, entriesRead))
   }
+
+  /**
+   * Create a new consumer group associated with a stream.
+   *
+   * @param key
+   *   ID of the stream
+   * @param group
+   *   ID of the consumer group
+   * @param id
+   *   ID of the last item in the stream to consider already delivered
+   * @param mkStream
+   *   ID of the last item in the stream to consider already delivered
+   * @param entriesRead
+   *   Enable consumer group lag tracking
+   */
+  final def xGroupCreateLastEntry[SK: Schema, SG: Schema](
+    key: SK,
+    group: SG,
+    mkStream: Boolean = false,
+    entriesRead: Option[String] = None
+  ): G[Unit] = xGroupCreate(key, group, "$", mkStream, entriesRead)
 
   /**
    * Create a new consumer associated with a consumer group.

--- a/modules/redis/src/main/scala/zio/redis/options/Streams.scala
+++ b/modules/redis/src/main/scala/zio/redis/options/Streams.scala
@@ -120,11 +120,13 @@ trait Streams {
     name: String,
     consumers: Long,
     pending: Long,
-    lastDeliveredId: String
+    lastDeliveredId: String,
+    entriesRead: Long,
+    lag: Long
   )
 
   object StreamGroupsInfo {
-    def empty: StreamGroupsInfo = StreamGroupsInfo("", 0, 0, "")
+    def empty: StreamGroupsInfo = StreamGroupsInfo("", 0, 0, "", 0, 0)
   }
 
   sealed case class StreamConsumersInfo(
@@ -184,6 +186,8 @@ trait Streams {
 
     val Consumers: String       = "consumers"
     val LastDeliveredId: String = "last-delivered-id"
+    val EntriesRead: String = "entries-read"
+    val Lag: String = "lag"
 
     val Length: String          = "length"
     val RadixTreeKeys: String   = "radix-tree-keys"

--- a/modules/redis/src/main/scala/zio/redis/options/Streams.scala
+++ b/modules/redis/src/main/scala/zio/redis/options/Streams.scala
@@ -106,14 +106,17 @@ trait Streams {
     length: Long,
     radixTreeKeys: Long,
     radixTreeNodes: Long,
-    groups: Long,
     lastGeneratedId: String,
+    maxDeletedEntryId: String,
+    entriesAdded: Long,
+    recordedFirstEntryId: String,
+    groups: Long,
     firstEntry: Option[StreamEntry[I, K, V]],
     lastEntry: Option[StreamEntry[I, K, V]]
   )
 
   object StreamInfo {
-    def empty[I, K, V]: StreamInfo[I, K, V] = StreamInfo(0, 0, 0, 0, "", None, None)
+    def empty[I, K, V]: StreamInfo[I, K, V] = StreamInfo(0, 0, 0, "", "", 0, "", 0, None, None)
   }
 
   sealed case class StreamGroupsInfo(
@@ -147,32 +150,37 @@ trait Streams {
       radixTreeKeys: Long,
       radixTreeNodes: Long,
       lastGeneratedId: String,
+      maxDeletedEntryId: String,
+      entriesAdded: Long,
+      recordedFirstEntryId: String,
       entries: Chunk[StreamEntry[I, K, V]],
       groups: Chunk[ConsumerGroups]
     )
 
     object FullStreamInfo {
-      def empty[I, K, V]: FullStreamInfo[I, K, V] = FullStreamInfo(0, 0, 0, "", Chunk.empty, Chunk.empty)
+      def empty[I, K, V]: FullStreamInfo[I, K, V] = FullStreamInfo(0, 0, 0, "", "", 0, "", Chunk.empty, Chunk.empty)
     }
 
     sealed case class ConsumerGroups(
       name: String,
       lastDeliveredId: String,
+      entriesRead: Long,
+      lag: Long,
       pelCount: Long,
       pending: Chunk[GroupPel],
       consumers: Chunk[Consumers]
     )
 
     object ConsumerGroups {
-      def empty: ConsumerGroups = ConsumerGroups("", "", 0, Chunk.empty, Chunk.empty)
+      def empty: ConsumerGroups = ConsumerGroups("", "", 0, 0, 0, Chunk.empty, Chunk.empty)
     }
 
     sealed case class GroupPel(entryId: String, consumerName: String, deliveryTime: Duration, deliveryCount: Long)
 
-    sealed case class Consumers(name: String, seenTime: Duration, pelCount: Long, pending: Chunk[ConsumerPel])
+    sealed case class Consumers(name: String, seenTime: Duration, activeTime: Duration, pelCount: Long, pending: Chunk[ConsumerPel])
 
     object Consumers {
-      def empty: Consumers = Consumers("", 0.millis, 0, Chunk.empty)
+      def empty: Consumers = Consumers("", 0.millis, 0.millis, 0, Chunk.empty)
     }
 
     sealed case class ConsumerPel(entryId: String, deliveryTime: Duration, deliveryCount: Long)
@@ -197,8 +205,13 @@ trait Streams {
     val FirstEntry: String      = "first-entry"
     val LastEntry: String       = "last-entry"
 
+    val MaxDeletedEntryId: String = "max-deleted-entry-id"
+    val EntriesAdded: String = "entries-added"
+    val RecordedFirstEntryId: String = "recorded-first-entry-id"
+
     val Entries: String  = "entries"
     val PelCount: String = "pel-count"
     val SeenTime: String = "seen-time"
+    val ActiveTime: String = "active-time"
   }
 }

--- a/modules/redis/src/main/scala/zio/redis/options/Streams.scala
+++ b/modules/redis/src/main/scala/zio/redis/options/Streams.scala
@@ -47,6 +47,12 @@ trait Streams {
 
   type MkStream = MkStream.type
 
+  case object NoMkStream {
+    private[redis] def asString = "NOMKSTREAM"
+  }
+
+  type NoMkStream = NoMkStream.type
+
   sealed case class PendingInfo(
     total: Long,
     first: Option[String],
@@ -72,6 +78,15 @@ trait Streams {
   type StreamChunks[N, I, K, V] = Chunk[StreamChunk[N, I, K, V]]
 
   sealed case class StreamMaxLen(approximate: Boolean, count: Long)
+
+  sealed trait CapType
+
+  sealed case class MaxLenApprox(count: Long, limit: Option[Long]) extends CapType
+  sealed case class MaxLenExact(count: Long)                       extends CapType
+  sealed case class MinIdApprox(id: Long, limit: Option[Long])     extends CapType
+  sealed case class MinIdExact(id: Long)                           extends CapType
+
+  sealed case class CappedStream(capType: CapType)
 
   sealed case class StreamEntry[I, K, V](id: I, fields: Map[K, V])
 

--- a/modules/redis/src/main/scala/zio/redis/options/Streams.scala
+++ b/modules/redis/src/main/scala/zio/redis/options/Streams.scala
@@ -130,11 +130,12 @@ trait Streams {
   sealed case class StreamConsumersInfo(
     name: String,
     pending: Long,
-    idle: Duration
+    idle: Duration,
+    inactive: Duration
   )
 
   object StreamConsumersInfo {
-    def empty: StreamConsumersInfo = StreamConsumersInfo("", 0, 0.millis)
+    def empty: StreamConsumersInfo = StreamConsumersInfo("", 0, 0.millis, 0.millis)
   }
 
   object StreamInfoWithFull {
@@ -179,6 +180,7 @@ trait Streams {
     val Name: String    = "name"
     val Idle: String    = "idle"
     val Pending: String = "pending"
+    val Inactive: String = "inactive"
 
     val Consumers: String       = "consumers"
     val LastDeliveredId: String = "last-delivered-id"

--- a/modules/redis/src/main/scala/zio/redis/options/Streams.scala
+++ b/modules/redis/src/main/scala/zio/redis/options/Streams.scala
@@ -177,7 +177,13 @@ trait Streams {
 
     sealed case class GroupPel(entryId: String, consumerName: String, deliveryTime: Duration, deliveryCount: Long)
 
-    sealed case class Consumers(name: String, seenTime: Duration, activeTime: Duration, pelCount: Long, pending: Chunk[ConsumerPel])
+    sealed case class Consumers(
+      name: String,
+      seenTime: Duration,
+      activeTime: Duration,
+      pelCount: Long,
+      pending: Chunk[ConsumerPel]
+    )
 
     object Consumers {
       def empty: Consumers = Consumers("", 0.millis, 0.millis, 0, Chunk.empty)
@@ -187,15 +193,15 @@ trait Streams {
   }
 
   private[redis] object XInfoFields {
-    val Name: String    = "name"
-    val Idle: String    = "idle"
-    val Pending: String = "pending"
+    val Name: String     = "name"
+    val Idle: String     = "idle"
+    val Pending: String  = "pending"
     val Inactive: String = "inactive"
 
     val Consumers: String       = "consumers"
     val LastDeliveredId: String = "last-delivered-id"
-    val EntriesRead: String = "entries-read"
-    val Lag: String = "lag"
+    val EntriesRead: String     = "entries-read"
+    val Lag: String             = "lag"
 
     val Length: String          = "length"
     val RadixTreeKeys: String   = "radix-tree-keys"
@@ -205,13 +211,13 @@ trait Streams {
     val FirstEntry: String      = "first-entry"
     val LastEntry: String       = "last-entry"
 
-    val MaxDeletedEntryId: String = "max-deleted-entry-id"
-    val EntriesAdded: String = "entries-added"
+    val MaxDeletedEntryId: String    = "max-deleted-entry-id"
+    val EntriesAdded: String         = "entries-added"
     val RecordedFirstEntryId: String = "recorded-first-entry-id"
 
-    val Entries: String  = "entries"
-    val PelCount: String = "pel-count"
-    val SeenTime: String = "seen-time"
+    val Entries: String    = "entries"
+    val PelCount: String   = "pel-count"
+    val SeenTime: String   = "seen-time"
     val ActiveTime: String = "active-time"
   }
 }

--- a/modules/redis/src/main/scala/zio/redis/options/Streams.scala
+++ b/modules/redis/src/main/scala/zio/redis/options/Streams.scala
@@ -79,16 +79,14 @@ trait Streams {
 
   type StreamChunks[N, I, K, V] = Chunk[StreamChunk[N, I, K, V]]
 
-  sealed case class StreamMaxLen(approximate: Boolean, count: Long)
+  sealed trait CappedStreamType
 
-  sealed trait CapType
-
-  sealed case class MaxLenApprox(count: Long, limit: Option[Long]) extends CapType
-  sealed case class MaxLenExact(count: Long)                       extends CapType
-  sealed case class MinIdApprox(id: Long, limit: Option[Long])     extends CapType
-  sealed case class MinIdExact(id: Long)                           extends CapType
-
-  sealed case class CappedStream(capType: CapType)
+  object CappedStreamType {
+    sealed case class MaxLenApprox(count: Long, limit: Option[Long]) extends CappedStreamType
+    sealed case class MaxLenExact(count: Long)                       extends CappedStreamType
+    sealed case class MinIdApprox[I](id: I, limit: Option[Long])     extends CappedStreamType
+    sealed case class MinIdExact[I](id: I)                           extends CappedStreamType
+  }
 
   sealed case class StreamEntry[I, K, V](id: I, fields: Map[K, V])
 

--- a/modules/redis/src/main/scala/zio/redis/options/Streams.scala
+++ b/modules/redis/src/main/scala/zio/redis/options/Streams.scala
@@ -31,6 +31,8 @@ trait Streams {
 
   type WithJustId = WithJustId.type
 
+  sealed case class LastId[I](lastId: I)
+
   sealed trait XGroupCommand
 
   object XGroupCommand {

--- a/modules/redis/src/main/scala/zio/redis/options/Streams.scala
+++ b/modules/redis/src/main/scala/zio/redis/options/Streams.scala
@@ -33,11 +33,12 @@ trait Streams {
 
   sealed case class LastId[I](lastId: I)
 
+  sealed case class WithEntriesRead(entries: Long)
+
   sealed trait XGroupCommand
 
   object XGroupCommand {
-    sealed case class Create[SK, SG, I](key: SK, group: SG, id: I, mkStream: Boolean, entriesRead: Option[I])
-        extends XGroupCommand
+    sealed case class Create[SK, SG, I](key: SK, group: SG, id: I)                 extends XGroupCommand
     sealed case class SetId[SK, SG, I](key: SK, group: SG, id: I)                  extends XGroupCommand
     sealed case class Destroy[SK, SG](key: SK, group: SG)                          extends XGroupCommand
     sealed case class CreateConsumer[SK, SG, SC](key: SK, group: SG, consumer: SC) extends XGroupCommand

--- a/modules/redis/src/main/scala/zio/redis/options/Streams.scala
+++ b/modules/redis/src/main/scala/zio/redis/options/Streams.scala
@@ -36,11 +36,12 @@ trait Streams {
   sealed trait XGroupCommand
 
   object XGroupCommand {
-    sealed case class Create[SK, SG, I](key: SK, group: SG, id: I, mkStream: Boolean) extends XGroupCommand
-    sealed case class SetId[SK, SG, I](key: SK, group: SG, id: I)                     extends XGroupCommand
-    sealed case class Destroy[SK, SG](key: SK, group: SG)                             extends XGroupCommand
-    sealed case class CreateConsumer[SK, SG, SC](key: SK, group: SG, consumer: SC)    extends XGroupCommand
-    sealed case class DelConsumer[SK, SG, SC](key: SK, group: SG, consumer: SC)       extends XGroupCommand
+    sealed case class Create[SK, SG, I](key: SK, group: SG, id: I, mkStream: Boolean, entriesRead: Option[I])
+        extends XGroupCommand
+    sealed case class SetId[SK, SG, I](key: SK, group: SG, id: I)                  extends XGroupCommand
+    sealed case class Destroy[SK, SG](key: SK, group: SG)                          extends XGroupCommand
+    sealed case class CreateConsumer[SK, SG, SC](key: SK, group: SG, consumer: SC) extends XGroupCommand
+    sealed case class DelConsumer[SK, SG, SC](key: SK, group: SG, consumer: SC)    extends XGroupCommand
   }
 
   case object MkStream {

--- a/modules/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/modules/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -1179,7 +1179,7 @@ object InputSpec extends BaseSpec {
           ZIO
             .attempt(XGroupSetIdInput[String, String, String]().encode(XGroupCommand.SetId("key", "group", "id")))
             .map(assert(_)(equalTo(RespCommand(Literal("SETID"), Key("key"), Value("group"), Value("id")))))
-        },
+        }
       ),
       suite("XGroupDestroy")(
         test("valid value") {

--- a/modules/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/modules/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -1167,28 +1167,6 @@ object InputSpec extends BaseSpec {
                 )
               )
             )
-        },
-        test("with entriesRead") {
-          ZIO
-            .attempt(
-              XGroupCreateInput[String, String, String]().encode(
-                XGroupCommand.Create("key", "group", "id", mkStream = false, entriesRead = Some("1-0"))
-              )
-            )
-            .map(
-              assert(_)(
-                equalTo(
-                  RespCommand(
-                    Literal("CREATE"),
-                    Key("key"),
-                    Value("group"),
-                    Value("id"),
-                    Literal("ENTRIESREAD"),
-                    Value("1-0")
-                  )
-                )
-              )
-            )
         }
       ),
       suite("XGroupSetId")(

--- a/modules/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/modules/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -1148,7 +1148,7 @@ object InputSpec extends BaseSpec {
           ZIO
             .attempt(
               XGroupCreateInput[String, String, String]().encode(
-                XGroupCommand.Create("key", "group", "id", mkStream = false, None)
+                XGroupCommand.Create("key", "group", "id")
               )
             )
             .map(assert(_)(equalTo(RespCommand(Literal("CREATE"), Key("key"), Value("group"), Value("id")))))
@@ -1157,35 +1157,13 @@ object InputSpec extends BaseSpec {
           ZIO
             .attempt(
               XGroupCreateInput[String, String, String]().encode(
-                XGroupCommand.Create("key", "group", "id", mkStream = true, None)
+                XGroupCommand.Create("key", "group", "id")
               )
             )
             .map(
               assert(_)(
                 equalTo(
                   RespCommand(Literal("CREATE"), Key("key"), Value("group"), Value("id"), Literal("MKSTREAM"))
-                )
-              )
-            )
-        },
-        test("with entriesRead") {
-          ZIO
-            .attempt(
-              XGroupCreateInput[String, String, String]().encode(
-                XGroupCommand.Create("key", "group", "id", mkStream = false, entriesRead = Some("1-0"))
-              )
-            )
-            .map(
-              assert(_)(
-                equalTo(
-                  RespCommand(
-                    Literal("CREATE"),
-                    Key("key"),
-                    Value("group"),
-                    Value("id"),
-                    Literal("ENTRIESREAD"),
-                    Value("1-0")
-                  )
                 )
               )
             )
@@ -1196,7 +1174,12 @@ object InputSpec extends BaseSpec {
           ZIO
             .attempt(XGroupSetIdInput[String, String, String]().encode(XGroupCommand.SetId("key", "group", "id")))
             .map(assert(_)(equalTo(RespCommand(Literal("SETID"), Key("key"), Value("group"), Value("id")))))
-        }
+        },
+        test("valid value with entries read") {
+          ZIO
+            .attempt(XGroupSetIdInput[String, String, String]().encode(XGroupCommand.SetId("key", "group", "id")))
+            .map(assert(_)(equalTo(RespCommand(Literal("SETID"), Key("key"), Value("group"), Value("id")))))
+        },
       ),
       suite("XGroupDestroy")(
         test("valid value") {

--- a/modules/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/modules/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -1257,6 +1257,46 @@ object InputSpec extends BaseSpec {
             .map(assert(_)(equalTo(RespCommand(Literal("MAXLEN"), Value("10")))))
         }
       ),
+      suite("CappedStreamOption")(
+        test("MaxLen with approx") {
+          ZIO
+            .attempt(CappedStreamInput.encode(CappedStream(MaxLenApprox(10, None))))
+            .map(assert(_)(equalTo(RespCommand(Literal("MAXLEN"), Literal("~"), Value("10")))))
+        },
+        test("MaxLen with approx and Limit") {
+          ZIO
+            .attempt(CappedStreamInput.encode(CappedStream(MaxLenApprox(10, Some(100)))))
+            .map(
+              assert(_)(
+                equalTo(RespCommand(Literal("MAXLEN"), Literal("~"), Value("10"), Literal("LIMIT"), Value("100")))
+              )
+            )
+        },
+        test("MaxLen with exact") {
+          ZIO
+            .attempt(CappedStreamInput.encode(CappedStream(MaxLenExact(10))))
+            .map(assert(_)(equalTo(RespCommand(Literal("MAXLEN"), Literal("="), Value("10")))))
+        },
+        test("MinId with approx") {
+          ZIO
+            .attempt(CappedStreamInput.encode(CappedStream(MinIdApprox(10, None))))
+            .map(assert(_)(equalTo(RespCommand(Literal("MINID"), Literal("~"), Value("10")))))
+        },
+        test("MinId with approx and Limit") {
+          ZIO
+            .attempt(CappedStreamInput.encode(CappedStream(MinIdApprox(10, Some(100)))))
+            .map(
+              assert(_)(
+                equalTo(RespCommand(Literal("MINID"), Literal("~"), Value("10"), Literal("LIMIT"), Value("100")))
+              )
+            )
+        },
+        test("MinId with exact") {
+          ZIO
+            .attempt(CappedStreamInput.encode(CappedStream(MinIdExact(10))))
+            .map(assert(_)(equalTo(RespCommand(Literal("MINID"), Literal("="), Value("10")))))
+        }
+      ),
       suite("WithForce")(
         test("valid value") {
           ZIO.attempt(WithForceInput.encode(WithForce)).map(assert(_)(equalTo(RespCommand(Literal("FORCE")))))

--- a/modules/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/modules/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -1163,7 +1163,7 @@ object InputSpec extends BaseSpec {
             .map(
               assert(_)(
                 equalTo(
-                  RespCommand(Literal("CREATE"), Key("key"), Value("group"), Value("id"), Literal("MKSTREAM"))
+                  RespCommand(Literal("CREATE"), Key("key"), Value("group"), Value("id"))
                 )
               )
             )
@@ -1272,12 +1272,12 @@ object InputSpec extends BaseSpec {
         },
         test("MinId with approx") {
           ZIO
-            .attempt(MinIdApproxInput[Long]().encode(CappedStreamType.MinIdApprox(10, None)))
+            .attempt(MinIdApproxInput[String]().encode(CappedStreamType.MinIdApprox("10", None)))
             .map(assert(_)(equalTo(RespCommand(Literal("MINID"), Literal("~"), Value("10")))))
         },
         test("MinId with approx and Limit") {
           ZIO
-            .attempt(MinIdApproxInput[Long]().encode(CappedStreamType.MinIdApprox(10, Some(100))))
+            .attempt(MinIdApproxInput[String]().encode(CappedStreamType.MinIdApprox("10", Some(100))))
             .map(
               assert(_)(
                 equalTo(RespCommand(Literal("MINID"), Literal("~"), Value("10"), Literal("LIMIT"), Value("100")))
@@ -1286,7 +1286,7 @@ object InputSpec extends BaseSpec {
         },
         test("MinId with exact") {
           ZIO
-            .attempt(MinIdExactInput[Long]().encode(CappedStreamType.MinIdExact(10)))
+            .attempt(MinIdExactInput[String]().encode(CappedStreamType.MinIdExact("10")))
             .map(assert(_)(equalTo(RespCommand(Literal("MINID"), Literal("="), Value("10")))))
         }
       ),

--- a/modules/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/modules/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -1148,7 +1148,7 @@ object InputSpec extends BaseSpec {
           ZIO
             .attempt(
               XGroupCreateInput[String, String, String]().encode(
-                XGroupCommand.Create("key", "group", "id", mkStream = false)
+                XGroupCommand.Create("key", "group", "id", mkStream = false, None)
               )
             )
             .map(assert(_)(equalTo(RespCommand(Literal("CREATE"), Key("key"), Value("group"), Value("id")))))
@@ -1157,13 +1157,35 @@ object InputSpec extends BaseSpec {
           ZIO
             .attempt(
               XGroupCreateInput[String, String, String]().encode(
-                XGroupCommand.Create("key", "group", "id", mkStream = true)
+                XGroupCommand.Create("key", "group", "id", mkStream = true, None)
               )
             )
             .map(
               assert(_)(
                 equalTo(
                   RespCommand(Literal("CREATE"), Key("key"), Value("group"), Value("id"), Literal("MKSTREAM"))
+                )
+              )
+            )
+        },
+        test("with entriesRead") {
+          ZIO
+            .attempt(
+              XGroupCreateInput[String, String, String]().encode(
+                XGroupCommand.Create("key", "group", "id", mkStream = false, entriesRead = Some("1-0"))
+              )
+            )
+            .map(
+              assert(_)(
+                equalTo(
+                  RespCommand(
+                    Literal("CREATE"),
+                    Key("key"),
+                    Value("group"),
+                    Value("id"),
+                    Literal("ENTRIESREAD"),
+                    Value("1-0")
+                  )
                 )
               )
             )

--- a/modules/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/modules/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -14,9 +14,9 @@ object InputSpec extends BaseSpec {
   import BitFieldCommand._
   import BitFieldType._
   import BitOperation._
+  import LcsQueryType._
   import Order._
   import RadiusUnit._
-  import LcsQueryType._
 
   def spec: Spec[Any, Throwable] =
     suite("Input encoders")(
@@ -1245,27 +1245,15 @@ object InputSpec extends BaseSpec {
           ZIO.attempt(NoAckInput.encode(NoAck)).map(assert(_)(equalTo(RespCommand(Value("NOACK")))))
         }
       ),
-      suite("MaxLen")(
-        test("with approximate") {
-          ZIO
-            .attempt(StreamMaxLenInput.encode(StreamMaxLen(approximate = true, 10)))
-            .map(assert(_)(equalTo(RespCommand(Literal("MAXLEN"), Literal("~"), Value("10")))))
-        },
-        test("without approximate") {
-          ZIO
-            .attempt(StreamMaxLenInput.encode(StreamMaxLen(approximate = false, 10)))
-            .map(assert(_)(equalTo(RespCommand(Literal("MAXLEN"), Value("10")))))
-        }
-      ),
       suite("CappedStreamOption")(
         test("MaxLen with approx") {
           ZIO
-            .attempt(CappedStreamInput.encode(CappedStream(MaxLenApprox(10, None))))
+            .attempt(MaxLenApproxInput.encode(CappedStreamType.MaxLenApprox(10, None)))
             .map(assert(_)(equalTo(RespCommand(Literal("MAXLEN"), Literal("~"), Value("10")))))
         },
         test("MaxLen with approx and Limit") {
           ZIO
-            .attempt(CappedStreamInput.encode(CappedStream(MaxLenApprox(10, Some(100)))))
+            .attempt(MaxLenApproxInput.encode(CappedStreamType.MaxLenApprox(10, Some(100))))
             .map(
               assert(_)(
                 equalTo(RespCommand(Literal("MAXLEN"), Literal("~"), Value("10"), Literal("LIMIT"), Value("100")))
@@ -1274,17 +1262,17 @@ object InputSpec extends BaseSpec {
         },
         test("MaxLen with exact") {
           ZIO
-            .attempt(CappedStreamInput.encode(CappedStream(MaxLenExact(10))))
+            .attempt(MaxLenExactInput.encode(CappedStreamType.MaxLenExact(10)))
             .map(assert(_)(equalTo(RespCommand(Literal("MAXLEN"), Literal("="), Value("10")))))
         },
         test("MinId with approx") {
           ZIO
-            .attempt(CappedStreamInput.encode(CappedStream(MinIdApprox(10, None))))
+            .attempt(MinIdApproxInput[Long]().encode(CappedStreamType.MinIdApprox(10, None)))
             .map(assert(_)(equalTo(RespCommand(Literal("MINID"), Literal("~"), Value("10")))))
         },
         test("MinId with approx and Limit") {
           ZIO
-            .attempt(CappedStreamInput.encode(CappedStream(MinIdApprox(10, Some(100)))))
+            .attempt(MinIdApproxInput[Long]().encode(CappedStreamType.MinIdApprox(10, Some(100))))
             .map(
               assert(_)(
                 equalTo(RespCommand(Literal("MINID"), Literal("~"), Value("10"), Literal("LIMIT"), Value("100")))
@@ -1293,7 +1281,7 @@ object InputSpec extends BaseSpec {
         },
         test("MinId with exact") {
           ZIO
-            .attempt(CappedStreamInput.encode(CappedStream(MinIdExact(10))))
+            .attempt(MinIdExactInput[Long]().encode(CappedStreamType.MinIdExact(10)))
             .map(assert(_)(equalTo(RespCommand(Literal("MINID"), Literal("="), Value("10")))))
         }
       ),

--- a/modules/redis/src/test/scala/zio/redis/InputSpec.scala
+++ b/modules/redis/src/test/scala/zio/redis/InputSpec.scala
@@ -1167,6 +1167,28 @@ object InputSpec extends BaseSpec {
                 )
               )
             )
+        },
+        test("with entriesRead") {
+          ZIO
+            .attempt(
+              XGroupCreateInput[String, String, String]().encode(
+                XGroupCommand.Create("key", "group", "id", mkStream = false, entriesRead = Some("1-0"))
+              )
+            )
+            .map(
+              assert(_)(
+                equalTo(
+                  RespCommand(
+                    Literal("CREATE"),
+                    Key("key"),
+                    Value("group"),
+                    Value("id"),
+                    Literal("ENTRIESREAD"),
+                    Value("1-0")
+                  )
+                )
+              )
+            )
         }
       ),
       suite("XGroupSetId")(

--- a/modules/redis/src/test/scala/zio/redis/OutputSpec.scala
+++ b/modules/redis/src/test/scala/zio/redis/OutputSpec.scala
@@ -698,7 +698,11 @@ object OutputSpec extends BaseSpec {
                 RespValue.bulkString("pending"),
                 RespValue.Integer(1),
                 RespValue.bulkString("last-delivered-id"),
-                RespValue.bulkString("1-0")
+                RespValue.bulkString("1-0"),
+                RespValue.bulkString("entries-read"),
+                RespValue.Integer(1),
+                RespValue.bulkString("lag"),
+                RespValue.Integer(1),
               ),
               RespValue.array(
                 RespValue.bulkString("name"),
@@ -708,15 +712,19 @@ object OutputSpec extends BaseSpec {
                 RespValue.bulkString("pending"),
                 RespValue.Integer(2),
                 RespValue.bulkString("last-delivered-id"),
-                RespValue.bulkString("2-0")
+                RespValue.bulkString("2-0"),
+                RespValue.bulkString("entries-read"),
+                RespValue.Integer(2),
+                RespValue.bulkString("lag"),
+                RespValue.Integer(2),
               )
             )
 
             assertZIO(ZIO.attempt(StreamGroupsInfoOutput.unsafeDecode(resp)))(
               equalTo(
                 Chunk(
-                  StreamGroupsInfo("group1", 1, 1, "1-0"),
-                  StreamGroupsInfo("group2", 2, 2, "2-0")
+                  StreamGroupsInfo("group1", 1, 1, "1-0", 1, 1),
+                  StreamGroupsInfo("group2", 2, 2, "2-0", 2, 2)
                 )
               )
             )

--- a/modules/redis/src/test/scala/zio/redis/OutputSpec.scala
+++ b/modules/redis/src/test/scala/zio/redis/OutputSpec.scala
@@ -736,6 +736,8 @@ object OutputSpec extends BaseSpec {
                 RespValue.bulkString("pending"),
                 RespValue.Integer(1),
                 RespValue.bulkString("idle"),
+                RespValue.Integer(100),
+                RespValue.bulkString("inactive"),
                 RespValue.Integer(100)
               ),
               RespValue.array(
@@ -744,6 +746,8 @@ object OutputSpec extends BaseSpec {
                 RespValue.bulkString("pending"),
                 RespValue.Integer(2),
                 RespValue.bulkString("idle"),
+                RespValue.Integer(200),
+                RespValue.bulkString("inactive"),
                 RespValue.Integer(200)
               )
             )
@@ -751,8 +755,8 @@ object OutputSpec extends BaseSpec {
             assertZIO(ZIO.attempt(StreamConsumersInfoOutput.unsafeDecode(resp)))(
               equalTo(
                 Chunk(
-                  StreamConsumersInfo("consumer1", 1, 100.millis),
-                  StreamConsumersInfo("consumer2", 2, 200.millis)
+                  StreamConsumersInfo("consumer1", 1, 100.millis, 100.millis),
+                  StreamConsumersInfo("consumer2", 2, 200.millis, 200.millis)
                 )
               )
             )

--- a/modules/redis/src/test/scala/zio/redis/OutputSpec.scala
+++ b/modules/redis/src/test/scala/zio/redis/OutputSpec.scala
@@ -861,7 +861,8 @@ object OutputSpec extends BaseSpec {
             )
             assertZIO(ZIO.attempt(StreamInfoFullOutput[String, String, String]().unsafeDecode(resp)))(
               equalTo(
-                StreamInfoWithFull.FullStreamInfo[String, String, String](1, 2, 3, "0-0", "1-0", 4, "2-0", Chunk.empty, Chunk.empty)
+                StreamInfoWithFull
+                  .FullStreamInfo[String, String, String](1, 2, 3, "0-0", "1-0", 4, "2-0", Chunk.empty, Chunk.empty)
               )
             )
           },

--- a/modules/redis/src/test/scala/zio/redis/OutputSpec.scala
+++ b/modules/redis/src/test/scala/zio/redis/OutputSpec.scala
@@ -632,10 +632,16 @@ object OutputSpec extends BaseSpec {
               RespValue.Integer(2),
               RespValue.bulkString("radix-tree-nodes"),
               RespValue.Integer(3),
-              RespValue.bulkString("groups"),
-              RespValue.Integer(2),
               RespValue.bulkString("last-generated-id"),
               RespValue.bulkString("2-0"),
+              RespValue.bulkString("max-deleted-entry-id"),
+              RespValue.bulkString("3-0"),
+              RespValue.bulkString("entries-added"),
+              RespValue.Integer(5),
+              RespValue.bulkString("recorded-first-entry-id"),
+              RespValue.bulkString("1-0"),
+              RespValue.bulkString("groups"),
+              RespValue.Integer(2),
               RespValue.bulkString("first-entry"),
               RespValue.array(
                 RespValue.bulkString("1-0"),
@@ -660,8 +666,11 @@ object OutputSpec extends BaseSpec {
                   1,
                   2,
                   3,
-                  2,
                   "2-0",
+                  "3-0",
+                  5,
+                  "1-0",
+                  2,
                   Some(StreamEntry("1-0", Map("key1" -> "value1"))),
                   Some(StreamEntry("2-0", Map("key2" -> "value2")))
                 )
@@ -676,14 +685,20 @@ object OutputSpec extends BaseSpec {
               RespValue.Integer(2),
               RespValue.bulkString("radix-tree-nodes"),
               RespValue.Integer(3),
-              RespValue.bulkString("groups"),
-              RespValue.Integer(1),
               RespValue.bulkString("last-generated-id"),
-              RespValue.bulkString("0-0")
+              RespValue.bulkString("2-0"),
+              RespValue.bulkString("max-deleted-entry-id"),
+              RespValue.bulkString("3-0"),
+              RespValue.bulkString("entries-added"),
+              RespValue.Integer(5),
+              RespValue.bulkString("recorded-first-entry-id"),
+              RespValue.bulkString("1-0"),
+              RespValue.bulkString("groups"),
+              RespValue.Integer(2)
             )
 
             assertZIO(ZIO.attempt(StreamInfoOutput[String, String, String]().unsafeDecode(resp)))(
-              equalTo(StreamInfo[String, String, String](1, 2, 3, 1, "0-0", None, None))
+              equalTo(StreamInfo[String, String, String](1, 2, 3, "2-0", "3-0", 5, "1-0", 2, None, None))
             )
           }
         ),
@@ -702,7 +717,7 @@ object OutputSpec extends BaseSpec {
                 RespValue.bulkString("entries-read"),
                 RespValue.Integer(1),
                 RespValue.bulkString("lag"),
-                RespValue.Integer(1),
+                RespValue.Integer(1)
               ),
               RespValue.array(
                 RespValue.bulkString("name"),
@@ -716,7 +731,7 @@ object OutputSpec extends BaseSpec {
                 RespValue.bulkString("entries-read"),
                 RespValue.Integer(2),
                 RespValue.bulkString("lag"),
-                RespValue.Integer(2),
+                RespValue.Integer(2)
               )
             )
 
@@ -786,6 +801,12 @@ object OutputSpec extends BaseSpec {
               RespValue.Integer(3),
               RespValue.bulkString("last-generated-id"),
               RespValue.bulkString("0-0"),
+              RespValue.bulkString("max-deleted-entry-id"),
+              RespValue.bulkString("1-0"),
+              RespValue.bulkString("entries-added"),
+              RespValue.Integer(4),
+              RespValue.bulkString("recorded-first-entry-id"),
+              RespValue.bulkString("2-0"),
               RespValue.bulkString("entries"),
               RespValue.array(
                 RespValue.array(
@@ -812,6 +833,9 @@ object OutputSpec extends BaseSpec {
                   2,
                   3,
                   "0-0",
+                  "1-0",
+                  4,
+                  "2-0",
                   Chunk(StreamEntry("3-0", Map("key1" -> "value1")), StreamEntry("4-0", Map("key1" -> "value1"))),
                   Chunk.empty
                 )
@@ -827,11 +851,17 @@ object OutputSpec extends BaseSpec {
               RespValue.bulkString("radix-tree-nodes"),
               RespValue.Integer(3),
               RespValue.bulkString("last-generated-id"),
-              RespValue.bulkString("0-0")
+              RespValue.bulkString("0-0"),
+              RespValue.bulkString("max-deleted-entry-id"),
+              RespValue.bulkString("1-0"),
+              RespValue.bulkString("entries-added"),
+              RespValue.Integer(4),
+              RespValue.bulkString("recorded-first-entry-id"),
+              RespValue.bulkString("2-0")
             )
             assertZIO(ZIO.attempt(StreamInfoFullOutput[String, String, String]().unsafeDecode(resp)))(
               equalTo(
-                StreamInfoWithFull.FullStreamInfo[String, String, String](1, 2, 3, "0-0", Chunk.empty, Chunk.empty)
+                StreamInfoWithFull.FullStreamInfo[String, String, String](1, 2, 3, "0-0", "1-0", 4, "2-0", Chunk.empty, Chunk.empty)
               )
             )
           },
@@ -839,7 +869,7 @@ object OutputSpec extends BaseSpec {
             val resp = RespValue.array()
             assertZIO(ZIO.attempt(StreamConsumersInfoOutput.unsafeDecode(resp)))(isEmpty)
           },
-          test("extract a valid value with groups") {
+          test("extract a valid value with groups and entries") {
             val resp = RespValue.array(
               RespValue.bulkString("length"),
               RespValue.Integer(1),
@@ -849,6 +879,12 @@ object OutputSpec extends BaseSpec {
               RespValue.Integer(3),
               RespValue.bulkString("last-generated-id"),
               RespValue.bulkString("0-0"),
+              RespValue.bulkString("max-deleted-entry-id"),
+              RespValue.bulkString("1-0"),
+              RespValue.bulkString("entries-added"),
+              RespValue.Integer(4),
+              RespValue.bulkString("recorded-first-entry-id"),
+              RespValue.bulkString("2-0"),
               RespValue.bulkString("entries"),
               RespValue.array(
                 RespValue.array(
@@ -873,8 +909,12 @@ object OutputSpec extends BaseSpec {
                   RespValue.bulkString("name1"),
                   RespValue.bulkString("last-delivered-id"),
                   RespValue.bulkString("lastDeliveredId"),
-                  RespValue.bulkString("pel-count"),
+                  RespValue.bulkString("entries-read"),
                   RespValue.Integer(1),
+                  RespValue.bulkString("lag"),
+                  RespValue.Integer(2),
+                  RespValue.bulkString("pel-count"),
+                  RespValue.Integer(3),
                   RespValue.bulkString("pending"),
                   RespValue.array(
                     RespValue.array(
@@ -896,6 +936,8 @@ object OutputSpec extends BaseSpec {
                       RespValue.bulkString("name"),
                       RespValue.bulkString("Alice"),
                       RespValue.bulkString("seen-time"),
+                      RespValue.Integer(1588152520299L),
+                      RespValue.bulkString("active-time"),
                       RespValue.Integer(1588152520299L),
                       RespValue.bulkString("pel-count"),
                       RespValue.Integer(1),
@@ -920,12 +962,17 @@ object OutputSpec extends BaseSpec {
                   2,
                   3,
                   "0-0",
+                  "1-0",
+                  4,
+                  "2-0",
                   Chunk(StreamEntry("3-0", Map("key1" -> "value1")), StreamEntry("4-0", Map("key1" -> "value1"))),
                   Chunk(
                     StreamInfoWithFull.ConsumerGroups(
                       "name1",
                       "lastDeliveredId",
                       1,
+                      2,
+                      3,
                       Chunk(
                         StreamInfoWithFull.GroupPel("entryId1", "consumerName1", 1588152520299L.millis, 1L),
                         StreamInfoWithFull.GroupPel("entryId2", "consumerName2", 1588152520299L.millis, 1L)
@@ -933,6 +980,7 @@ object OutputSpec extends BaseSpec {
                       Chunk(
                         StreamInfoWithFull.Consumers(
                           "Alice",
+                          1588152520299L.millis,
                           1588152520299L.millis,
                           1,
                           Chunk(


### PR DESCRIPTION
PR to Fix Extend Streams API #1000

- XAUTOCLAIM was not missing, so no action is needed here.
- XSETID is, according to the Redis docs, an internal command. So I am not sure if we need it in the streams API.