### PR TITLE
fix auto-approve.yml

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -8,6 +8,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: hmarr/auto-approve-action@v4
-        if: github.actor == 'scala-steward' || github.actor == 'renovate[bot]'
+        if: github.actor == 'zio-scala-steward[bot]' || github.actor == 'renovate[bot]'
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
The new scala-steward uses the GitHub app, and the user becomes zio-scala-steward[bot].
Now, a lot of workflows actually skip that action.