### PR TITLE
Fix SingleNodeExecutor hanging forever

### DIFF
--- a/modules/redis/src/main/scala/zio/redis/internal/SingleNodeRunner.scala
+++ b/modules/redis/src/main/scala/zio/redis/internal/SingleNodeRunner.scala
@@ -33,7 +33,7 @@ private[redis] trait SingleNodeRunner {
    */
   private[internal] final val run: IO[RedisError, AnyVal] =
     ZIO.logTrace(s"$this sender and reader has been started") *>
-      (send.repeat(Schedule.forever) race receive
+      (send.either.repeat(Schedule.forever) race receive
         .tapError(e => ZIO.logWarning(s"Reconnecting due to error: $e") *> onError(e))
         .retryWhile(True))
         .tapError(e => ZIO.logError(s"Executor exiting: $e"))


### PR DESCRIPTION
`repeat` doesn't repeat if there was an error in the effect. We want to repeat forever no matter if there was or no an error to avoid hanging.