### PR TITLE
Send AUTH on subscription connections - fixes #1249

### DIFF
--- a/modules/redis-it/src/test/scala/zio/redis/ConnectionSpec.scala
+++ b/modules/redis-it/src/test/scala/zio/redis/ConnectionSpec.scala
@@ -35,6 +35,44 @@ trait ConnectionSpec extends IntegrationSpec {
           Redis.singleNode,
           singleNodeConfig(IntegrationSpec.SingleNode2, Some("asdf")),
           ZLayer.succeed(ProtobufCodecSupplier)
+        ),
+        test("subscription auth required error") {
+          for {
+            subscription <- ZIO.service[RedisSubscription]
+            redisError   <- subscription
+                              .subscribeSingleWith("auth-test-channel")()
+                              .returning[String]
+                              .runHead
+                              .flip
+                              .orDieWith(res => new Throwable(s"Expected failure, got $res"))
+          } yield assertTrue(redisError.asInstanceOf[ProtocolError].message == "Authentication required.")
+        }.provideSome[DockerComposeContainer](
+          RedisSubscription.singleNode,
+          singleNodeConfig(IntegrationSpec.SingleNode2),
+          ZLayer.succeed(ProtobufCodecSupplier)
+        ),
+        test("subscription automatic auth") {
+          val channel = "auth-test-channel-" + java.util.UUID.randomUUID().toString
+          for {
+            redis        <- ZIO.service[Redis]
+            subscription <- ZIO.service[RedisSubscription]
+            subscribed   <- Promise.make[RedisError, Unit]
+            fiber        <- subscription
+                              .subscribeSingleWith(channel)(
+                                onSubscribe = (_, _) => subscribed.succeed(()).unit
+                              )
+                              .returning[String]
+                              .runHead
+                              .fork
+            _            <- subscribed.await
+            _            <- redis.publish(channel, "hello")
+            received     <- fiber.join
+          } yield assertTrue(received.contains("hello"))
+        }.provideSome[DockerComposeContainer](
+          Redis.singleNode,
+          RedisSubscription.singleNode,
+          singleNodeConfig(IntegrationSpec.SingleNode2, Some("asdf")),
+          ZLayer.succeed(ProtobufCodecSupplier)
         )
       ),
       suite("clientId")(

--- a/modules/redis-it/src/test/scala/zio/redis/ConnectionSpec.scala
+++ b/modules/redis-it/src/test/scala/zio/redis/ConnectionSpec.scala
@@ -53,7 +53,7 @@ trait ConnectionSpec extends IntegrationSpec {
         ),
         test("subscription automatic auth") {
           for {
-            channel      <- Random.nextUUID.map(uuid => "auth-test-channel-$uuid")
+            channel      <- Random.nextUUID.map(uuid => s"auth-test-channel-$uuid")
             redis        <- ZIO.service[Redis]
             subscription <- ZIO.service[RedisSubscription]
             subscribed   <- Promise.make[RedisError, Unit]

--- a/modules/redis-it/src/test/scala/zio/redis/ConnectionSpec.scala
+++ b/modules/redis-it/src/test/scala/zio/redis/ConnectionSpec.scala
@@ -52,8 +52,8 @@ trait ConnectionSpec extends IntegrationSpec {
           ZLayer.succeed(ProtobufCodecSupplier)
         ),
         test("subscription automatic auth") {
-          val channel = "auth-test-channel-" + java.util.UUID.randomUUID().toString
           for {
+            channel      <- Random.nextUUID.map(uuid => "auth-test-channel-$uuid")
             redis        <- ZIO.service[Redis]
             subscription <- ZIO.service[RedisSubscription]
             subscribed   <- Promise.make[RedisError, Unit]

--- a/modules/redis/src/main/scala/zio/redis/internal/SingleNodeSubscriptionExecutor.scala
+++ b/modules/redis/src/main/scala/zio/redis/internal/SingleNodeSubscriptionExecutor.scala
@@ -203,11 +203,11 @@ private[redis] final class SingleNodeSubscriptionExecutor private (
    * the `run` fiber starts, so that no other effect is reading from or writing to the
    * connection concurrently.
    */
-  val auth: UIO[Unit] = 
+  val auth: UIO[Unit] =
     ZIO.foreachDiscard(config.auth) { creds =>
       val cmd   = RedisCommand("AUTH", AuthInput, UnitOutput).resp(zio.redis.Auth(creds.username, creds.password))
       val bytes = RespValue.Array(cmd.args.map(_.value)).asBytes
-      
+
       val effect =
         for {
           _        <- connection.write(bytes).mapError(RedisError.IOError.apply)
@@ -224,7 +224,7 @@ private[redis] final class SingleNodeSubscriptionExecutor private (
                           ZIO.fail(RedisError.ProtocolError(s"Unexpected response to AUTH: $other"))
                       }
         } yield ()
-      
+
       effect.catchAll(e => ZIO.logError(s"Failed to authenticate subscription connection: $e"))
     }
 }

--- a/modules/redis/src/main/scala/zio/redis/internal/SingleNodeSubscriptionExecutor.scala
+++ b/modules/redis/src/main/scala/zio/redis/internal/SingleNodeSubscriptionExecutor.scala
@@ -203,7 +203,7 @@ private[redis] final class SingleNodeSubscriptionExecutor private (
    * the `run` fiber starts, so that no other effect is reading from or writing to the
    * connection concurrently.
    */
-  val auth: UIO[Unit] = ZIO.foreachDiscard(config.auth) { creds =>
+  val auth = ZIO.foreachDiscard(config.auth) { creds =>
     val cmd                          = RedisCommand("AUTH", AuthInput, UnitOutput).resp(zio.redis.Auth(creds.username, creds.password))
     val bytes                        = RespValue.Array(cmd.args.map(_.value)).asBytes
     val effect: IO[RedisError, Unit] =

--- a/modules/redis/src/main/scala/zio/redis/internal/SingleNodeSubscriptionExecutor.scala
+++ b/modules/redis/src/main/scala/zio/redis/internal/SingleNodeSubscriptionExecutor.scala
@@ -18,16 +18,17 @@ package zio.redis.internal
 
 import zio._
 import zio.concurrent.ConcurrentMap
-import zio.redis.Input.{CommandNameInput, StringInput}
-import zio.redis.Output.PushMessageOutput
+import zio.redis.Input.{AuthInput, CommandNameInput, StringInput}
+import zio.redis.Output.{PushMessageOutput, UnitOutput}
 import zio.redis.api.Subscription
 import zio.redis.internal.PubSub.{PushMessage, SubscriptionKey}
 import zio.redis.internal.SingleNodeRunner.True
 import zio.redis.internal.SingleNodeSubscriptionExecutor.Request
-import zio.redis.{Input, RedisError}
+import zio.redis.{Input, RedisConfig, RedisError}
 import zio.stream._
 
 private[redis] final class SingleNodeSubscriptionExecutor private (
+  config: RedisConfig,
   subscriptionMap: ConcurrentMap[SubscriptionKey, Hub[Take[RedisError, PushMessage]]],
   requests: Queue[Request],
   subsResponses: Queue[Promise[RedisError, PushMessage]],
@@ -195,6 +196,34 @@ private[redis] final class SingleNodeSubscriptionExecutor private (
                                .retryWhile(True)
     } yield ()
   }
+
+  /**
+   * Authenticates the subscription connection synchronously by writing an `AUTH`
+   * command and awaiting the reply on the same connection. It must be invoked before
+   * the `run` fiber starts, so that no other effect is reading from or writing to the
+   * connection concurrently.
+   */
+  val auth: UIO[Unit] = ZIO.foreachDiscard(config.auth) { creds =>
+    val cmd                          = RedisCommand("AUTH", AuthInput, UnitOutput).resp(zio.redis.Auth(creds.username, creds.password))
+    val bytes                        = RespValue.Array(cmd.args.map(_.value)).asBytes
+    val effect: IO[RedisError, Unit] =
+      for {
+        _        <- connection.write(bytes).mapError(RedisError.IOError.apply)
+        response <- connection.read
+                      .mapError(RedisError.IOError.apply)
+                      .via(RespValue.Decoder)
+                      .collectSome
+                      .runHead
+                      .someOrFail(RedisError.ProtocolError("No response to AUTH"))
+        _        <- response match {
+                      case _: RespValue.SimpleString => ZIO.unit
+                      case err: RespValue.Error      => ZIO.fail(err.asRedisError)
+                      case other                     =>
+                        ZIO.fail(RedisError.ProtocolError(s"Unexpected response to AUTH: $other"))
+                    }
+      } yield ()
+    effect.catchAll(e => ZIO.logError(s"Failed to authenticate subscription connection: $e"))
+  }
 }
 
 private[redis] object SingleNodeSubscriptionExecutor {
@@ -209,12 +238,13 @@ private[redis] object SingleNodeSubscriptionExecutor {
         extends Request
   }
 
-  def create(conn: RedisConnection): URIO[Scope, SubscriptionExecutor] =
+  def create(conn: RedisConnection, config: RedisConfig): URIO[Scope, SubscriptionExecutor] =
     for {
       reqQueue <- Queue.bounded[Request](RequestQueueSize)
       resQueue <- Queue.unbounded[Promise[RedisError, PushMessage]]
       subsRef  <- ConcurrentMap.empty[SubscriptionKey, Hub[Take[RedisError, PushMessage]]]
-      pubSub    = new SingleNodeSubscriptionExecutor(subsRef, reqQueue, resQueue, conn)
+      pubSub    = new SingleNodeSubscriptionExecutor(config, subsRef, reqQueue, resQueue, conn)
+      _        <- pubSub.auth
       _        <- pubSub.run.forkScoped
       _        <- logScopeFinalizer(s"$pubSub Subscription Node is closed")
     } yield pubSub

--- a/modules/redis/src/main/scala/zio/redis/internal/SingleNodeSubscriptionExecutor.scala
+++ b/modules/redis/src/main/scala/zio/redis/internal/SingleNodeSubscriptionExecutor.scala
@@ -206,7 +206,7 @@ private[redis] final class SingleNodeSubscriptionExecutor private (
   val auth = ZIO.foreachDiscard(config.auth) { creds =>
     val cmd                          = RedisCommand("AUTH", AuthInput, UnitOutput).resp(zio.redis.Auth(creds.username, creds.password))
     val bytes                        = RespValue.Array(cmd.args.map(_.value)).asBytes
-    val effect: IO[RedisError, Unit] =
+    val effect =
       for {
         _        <- connection.write(bytes).mapError(RedisError.IOError.apply)
         response <- connection.read

--- a/modules/redis/src/main/scala/zio/redis/internal/SingleNodeSubscriptionExecutor.scala
+++ b/modules/redis/src/main/scala/zio/redis/internal/SingleNodeSubscriptionExecutor.scala
@@ -203,27 +203,30 @@ private[redis] final class SingleNodeSubscriptionExecutor private (
    * the `run` fiber starts, so that no other effect is reading from or writing to the
    * connection concurrently.
    */
-  val auth = ZIO.foreachDiscard(config.auth) { creds =>
-    val cmd                          = RedisCommand("AUTH", AuthInput, UnitOutput).resp(zio.redis.Auth(creds.username, creds.password))
-    val bytes                        = RespValue.Array(cmd.args.map(_.value)).asBytes
-    val effect =
-      for {
-        _        <- connection.write(bytes).mapError(RedisError.IOError.apply)
-        response <- connection.read
-                      .mapError(RedisError.IOError.apply)
-                      .via(RespValue.Decoder)
-                      .collectSome
-                      .runHead
-                      .someOrFail(RedisError.ProtocolError("No response to AUTH"))
-        _        <- response match {
-                      case _: RespValue.SimpleString => ZIO.unit
-                      case err: RespValue.Error      => ZIO.fail(err.asRedisError)
-                      case other                     =>
-                        ZIO.fail(RedisError.ProtocolError(s"Unexpected response to AUTH: $other"))
-                    }
-      } yield ()
-    effect.catchAll(e => ZIO.logError(s"Failed to authenticate subscription connection: $e"))
-  }
+  val auth: UIO[Unit] = 
+    ZIO.foreachDiscard(config.auth) { creds =>
+      val cmd   = RedisCommand("AUTH", AuthInput, UnitOutput).resp(zio.redis.Auth(creds.username, creds.password))
+      val bytes = RespValue.Array(cmd.args.map(_.value)).asBytes
+      
+      val effect =
+        for {
+          _        <- connection.write(bytes).mapError(RedisError.IOError.apply)
+          response <- connection.read
+                        .mapError(RedisError.IOError.apply)
+                        .via(RespValue.Decoder)
+                        .collectSome
+                        .runHead
+                        .someOrFail(RedisError.ProtocolError("No response to AUTH"))
+          _        <- response match {
+                        case _: RespValue.SimpleString => ZIO.unit
+                        case err: RespValue.Error      => ZIO.fail(err.asRedisError)
+                        case other                     =>
+                          ZIO.fail(RedisError.ProtocolError(s"Unexpected response to AUTH: $other"))
+                      }
+        } yield ()
+      
+      effect.catchAll(e => ZIO.logError(s"Failed to authenticate subscription connection: $e"))
+    }
 }
 
 private[redis] object SingleNodeSubscriptionExecutor {

--- a/modules/redis/src/main/scala/zio/redis/internal/SubscriptionExecutor.scala
+++ b/modules/redis/src/main/scala/zio/redis/internal/SubscriptionExecutor.scala
@@ -27,16 +27,17 @@ private[redis] trait SubscriptionExecutor {
 
 private[redis] object SubscriptionExecutor {
   lazy val layer: ZLayer[RedisConfig, RedisError.IOError, SubscriptionExecutor] =
-    RedisConnection.layer.fresh >>> pubSublayer
+    (RedisConnection.layer.fresh ++ ZLayer.service[RedisConfig]) >>> pubSublayer
 
   lazy val local: Layer[RedisError.IOError, SubscriptionExecutor] =
     RedisConnection.local.fresh >>> pubSublayer
 
-  private lazy val pubSublayer: ZLayer[RedisConnection, RedisError.IOError, SubscriptionExecutor] =
+  private lazy val pubSublayer: ZLayer[RedisConnection with RedisConfig, RedisError.IOError, SubscriptionExecutor] =
     ZLayer.scoped {
       for {
         conn   <- ZIO.service[RedisConnection]
-        pubSub <- SingleNodeSubscriptionExecutor.create(conn)
+        config <- ZIO.service[RedisConfig]
+        pubSub <- SingleNodeSubscriptionExecutor.create(conn, config)
       } yield pubSub
     }
 }


### PR DESCRIPTION
## Summary
`SingleNodeSubscriptionExecutor` never issued `AUTH` on the subscription
connection. #1205 fixed this for the command executor but not for
subscriptions. Connecting `RedisSubscription.singleNode` to a Redis with
`requirepass`/ACLs fails every subscribe with `NOAUTH Authentication required.`
and the reconnect loop in `SingleNodeRunner` spams warnings forever.

Mirror `SingleNodeExecutor.auth` on the subscription executor: when
`RedisConfig.auth` is set, synchronously write `AUTH` and await the reply
*before* the `run` fiber starts, so the send/receive loop never races on
the reply.

## Out of scope
Reconnect-time re-auth. The existing subscription `onError` already doesn't
call `connection.reconnect`, and adding both here would race with the
concurrent `send` fiber writing to the same socket. Left for a follow-up
once writes can be serialized (e.g. a connection-write mutex, or adding an
AUTH variant to the subscription `Request` ADT).

## Test plan
- [x] New integration tests in `ConnectionSpec`:
  - `subscription auth required error` — asserts NOAUTH propagates when no auth configured
  - `subscription automatic auth` — subscribe + publish roundtrip with AUTH configured
- [x] `sbt fmt`, `sbt lint`, `sbt client/test` (299 unit tests) green locally
- [x] Manually verified end-to-end against `redis:7 --requirepass ...` using the repro from #1249

Fixes #1249.

---
_Disclosure: The diagnosis, reproducer, patch, and tests were produced with
heavy assistance from [Claude Code](https://claude.com/claude-code). I've
reviewed all of it and run it end-to-end, but wanted to flag the assist._